### PR TITLE
fix polyline extractor

### DIFF
--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 def unpack_annotations(annotations):
     annotations_list = []
-    for value in annotations.values():
+    for value in annotations:
         if isinstance(value, list):
             annotations_list += value
         else:

--- a/panoptes_aggregation/extractors/test_utils.py
+++ b/panoptes_aggregation/extractors/test_utils.py
@@ -8,5 +8,5 @@ def annotation_by_task(classification_in):
     ann_by_task = {}
     for annotation in annotations:
         ann_by_task.setdefault(annotation['task'], []).append(annotation)
-    classification['annotations'] = ann_by_task
+    classification['annotations'] = list(ann_by_task.values())
     return classification


### PR DESCRIPTION
The extractor was failing to extract classifications produced by the poly line text tool because it was expecting them to be a hash instead of an array.