### PR TITLE
Clean sw xml

### DIFF
--- a/panoptes_aggregation/extractors/sw_extractor.py
+++ b/panoptes_aggregation/extractors/sw_extractor.py
@@ -24,8 +24,13 @@ tag_whitelist = [
 def clean_text(s):
     # remove unicode chars
     s_out = s.encode('ascii', 'ignore').decode('ascii')
-    # remove span tags (these should never have been in the text to begin with)
-    if '<' in s_out:
+    if '<xml>' in s_out:
+        # the user copy and pasted in from micorsoft office
+        # these classifications are a mess, just strip all tags
+        soup = bs4.BeautifulSoup(s_out, 'lxml')
+        s_out = soup.get_text().replace('\n', '')
+    elif '<' in s_out:
+        # remove html tags (these should never have been in the text to begin with)
         soup = bs4.BeautifulSoup(s_out, 'html.parser')
         for match in soup.findAll():
             if (match.text.strip() == '') or (match.name not in tag_whitelist):

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -263,7 +263,7 @@ def align_words(word_line, xy_line, text_line, kwargs_cluster, kwargs_dbscan):
         collation = col.Collation()
         witness_key = []
         for tdx, t in enumerate(text_line):
-            if t != '':
+            if t.strip() != '':
                 key = str(tdx)
                 collation.add_plain_witness(key, t)
                 witness_key.append(key)


### PR DESCRIPTION
Identify and strip `xml` tags from classifications.   These are caused by a user that copied and pasted text from MS Office.