### PR TITLE
Swap slope gutter

### DIFF
--- a/panoptes_aggregation/extractors/filter_annotations.py
+++ b/panoptes_aggregation/extractors/filter_annotations.py
@@ -15,10 +15,11 @@ def filter_annotations(annotations, config, human=False):
                     if human:
                         annotations_by_extractor[extractor_name][-1]['task_label'] = annotation['task_label']
                     for value in annotation['value']:
-                        if value['tool'] in tool_idx:
-                            if not human:
-                                value.pop('tool_label')
-                            annotations_by_extractor[extractor_name][-1]['value'].append(value)
+                        if 'tool' in value:
+                            if value['tool'] in tool_idx:
+                                if not human:
+                                    value.pop('tool_label')
+                                annotations_by_extractor[extractor_name][-1]['value'].append(value)
             else:
                 extractor_name = config[annotation['task']]
                 annotations_by_extractor.setdefault(extractor_name, [])

--- a/panoptes_aggregation/reducers/poly_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/poly_line_text_reducer.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     'eps_slope': {'default': 25.0, 'type': float},
     'eps_line': {'default': 40.0, 'type': float},
     'eps_word': {'default': 40.0, 'type': float},
+    'gutter_tol': {'default': 0.0, 'type': float},
     'dot_freq': {'default': 'word', 'type': str},
     'min_samples': {'default': 1, 'type': int},
     'metric': {'default': 'euclidean', 'type': str},
@@ -92,6 +93,7 @@ def poly_line_text_reducer(data_by_frame, **kwargs_dbscan):
     kwargs_cluster['eps_slope'] = kwargs_dbscan.pop('eps_slope')
     kwargs_cluster['eps_line'] = kwargs_dbscan.pop('eps_line')
     kwargs_cluster['eps_word'] = kwargs_dbscan.pop('eps_word')
+    kwargs_cluster['gutter_tol'] = kwargs_dbscan.pop('gutter_tol')
     kwargs_cluster['dot_freq'] = kwargs_dbscan.pop('dot_freq')
     kwargs_cluster['metric'] = kwargs_dbscan.pop('metric')
     return cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan)

--- a/panoptes_aggregation/reducers/poly_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/poly_line_text_reducer.py
@@ -15,6 +15,7 @@ DEFAULTS = {
     'eps_line': {'default': 40.0, 'type': float},
     'eps_word': {'default': 40.0, 'type': float},
     'gutter_tol': {'default': 0.0, 'type': float},
+    'min_word_count': {'default': 1, 'type': int},
     'dot_freq': {'default': 'word', 'type': str},
     'min_samples': {'default': 1, 'type': int},
     'metric': {'default': 'euclidean', 'type': str},
@@ -96,4 +97,5 @@ def poly_line_text_reducer(data_by_frame, **kwargs_dbscan):
     kwargs_cluster['gutter_tol'] = kwargs_dbscan.pop('gutter_tol')
     kwargs_cluster['dot_freq'] = kwargs_dbscan.pop('dot_freq')
     kwargs_cluster['metric'] = kwargs_dbscan.pop('metric')
+    kwargs_cluster['min_word_count'] = kwargs_dbscan.pop('min_word_count')
     return cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan)

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -14,7 +14,7 @@ def tokenize(self, contents):
 col.core_classes.WordPunctuationTokenizer.tokenize = tokenize
 
 
-def overlap(x, y):
+def overlap(x, y, tol=0):
     '''Check if two line segments overlap
 
     Parameters
@@ -23,16 +23,26 @@ def overlap(x, y):
         A list with the start and end point of the first line segment
     y : lits
         A list with the start and end point of the second line segment
-
+    tol : float
+        The tolerance to consider lines overlapping. Default 0, positive
+        value indicate small overlaps are not considered, negitive values
+        idicate small gaps are not considered.
     Returns
     -------
     overlap : bool
         True if the two line segments overlap, False otherwise
     '''
-    return x[1] >= y[0] and y[1] >= x[0]
+    return (x[1] - tol) >= (y[0] + tol) and (y[1] - tol) >= (x[0] + tol)
 
 
-def gutter(lines_in):
+def false_in_middle(a):
+    a = np.array(a)
+    first = np.nonzero(np.cumsum(a) == 1)[0][0]
+    last = np.nonzero(np.cumsum(a[::-1])[::-1] == 1)[0][0]
+    return not a[first:last + 1].all()
+
+
+def gutter(lines_in, tol=0):
     '''Cluster list of input line segments by what side of
     the page gutter they are on.
 
@@ -49,13 +59,17 @@ def gutter(lines_in):
         idicates what side of the gutter(s) the input line segment is on.
     '''
     if len(lines_in) > 0:
-        lines = [[min(l), max(l)] for l in lines_in]
+        lines = np.array([[min(l), max(l)] for l in lines_in])
+        # x_line = np.arange(lines.min(), lines.max() + 0.1, 0.1).round(1)
+        # num_overlap = np.array([sum([overlap(l, [x, x]) for l in lines]) for x in x_line])
+        # min_overlap = num_overlap >= min_samples
+        # mask_out = np.array([false_in_middle(min_overlap[np.array([overlap(l, [x, x]) for x in x_line])]) for l in lines])
         overlap_lines = []
         for ldx, l in enumerate(lines):
             if ldx == 0:
                 overlap_lines = np.array([l])
             else:
-                o_lines = np.array([overlap(o, l) for o in overlap_lines])
+                o_lines = np.array([overlap(o, l, tol=tol) for o in overlap_lines])
                 if o_lines.any():
                     comp = np.vstack([overlap_lines[o_lines], l])
                     overlap_lines[o_lines] = [comp.min(), comp.max()]
@@ -65,8 +79,9 @@ def gutter(lines_in):
         overlap_lines.sort(axis=0)
         gutter_label = -np.ones(len(lines), dtype=int)
         for odx, o in enumerate(overlap_lines):
-            gdx = np.array([overlap(o, l) for l in lines])
+            gdx = np.array([overlap(o, l, tol=tol) for l in lines])
             gutter_label[gdx] = odx
+        # gutter_label[mask_out] = -1
         return gutter_label
     else:
         return np.array([])
@@ -282,15 +297,18 @@ def align_words(word_line, xy_line, text_line, kwargs_cluster, kwargs_dbscan):
     return clusters_x, clusters_y, clusters_text
 
 
-def cluster_by_line(xy_slope, text_slope, annotation_labels, kwargs_cluster, kwargs_dbscan):
+def cluster_by_line(xy_rotate, xy_gutter, text_gutter, annotation_labels, kwargs_cluster, kwargs_dbscan):
     '''A function to take the annotations for one `slope_label` and cluster them
     based on perpendicular distance (e.g. lines of text).
 
     Parameters
     ----------
-    xy_slope : np.array
+    xy_rotate : np.array
+        An array of shape nx2 containing the (x, y) positions of *each* dot drawn in the
+        rotate coordiate frame.
+    xy_gutter : np.array
         An array of shape nx2 containing the (x, y) positions for *each* dot drawn.
-    text_slope : np.array
+    text_gutter : np.array
         An array of shape nx1 containing the text for *each* dot drawn. Note: each
         annotation has an empty string added to the end so this array has the same
         shape as `xy_slope`.
@@ -309,10 +327,6 @@ def cluster_by_line(xy_slope, text_slope, annotation_labels, kwargs_cluster, kwa
         A list of reductions, one for each line. Each reduction is a dictionary
         containing the information for the line.
     '''
-    c = np.cos(np.deg2rad(-kwargs_cluster['avg_slope']))
-    s = np.sin(np.deg2rad(-kwargs_cluster['avg_slope']))
-    R = np.array([[c, -s], [s, c]])
-    xy_rotate = np.dot(xy_slope, R.T)
     lines = xy_rotate[:, 1].reshape(-1, 1)
     words = xy_rotate[:, 0].reshape(-1, 1)
     a_lables = np.unique(annotation_labels)
@@ -327,9 +341,9 @@ def cluster_by_line(xy_slope, text_slope, annotation_labels, kwargs_cluster, kwa
         for a_label in a_lables[ldx]:
             adx |= annotation_labels == a_label
         if kwargs_cluster['dot_freq'] == 'word':
-            clusters_x, clusters_y, clusters_text = cluster_by_word(words[adx], xy_slope[adx], text_slope[adx], annotation_labels[adx], kwargs_cluster, kwargs_dbscan)
+            clusters_x, clusters_y, clusters_text = cluster_by_word(words[adx], xy_gutter[adx], text_gutter[adx], annotation_labels[adx], kwargs_cluster, kwargs_dbscan)
         elif kwargs_cluster['dot_freq'] == 'line':
-            clusters_x, clusters_y, clusters_text = align_words(words[adx], xy_slope[adx], text_slope[adx], kwargs_cluster, kwargs_dbscan)
+            clusters_x, clusters_y, clusters_text = align_words(words[adx], xy_gutter[adx], text_gutter[adx], kwargs_cluster, kwargs_dbscan)
         else:
             raise Exception('Not a valid `dot_freq` keyword')
         line_dict = {
@@ -347,16 +361,60 @@ def cluster_by_line(xy_slope, text_slope, annotation_labels, kwargs_cluster, kwa
     return frame_lines
 
 
-def cluster_by_slope(x, y, text, slope, kwargs_cluster, kwargs_dbscan):
+def cluster_by_gutter(x_slope, y_slope, text_slope, kwargs_cluster, kwargs_dbscan):
+    '''A function to take the annotations for each frame of a subject and group them
+    based on what side of the page gutter they are on.
+
+    Parameters
+    ----------
+    x_slope : list
+        A list-of-lists of the x values for each drawn dot. There is one item in the
+        list for annotation made by the user.
+    y_slope : list
+        A list-of-lists of the y values for each drawn dot. There is one item in the
+        list for annotation made by the user.
+    text_slope : list
+        A list-of-lists of the text for each drawn dot. There is one item in the
+        list for annotation made by the user.
+    kwargs_cluster : dict
+        A dictionary containing the `eps_*`, `metric`, and `dot_freq` keywords
+    kwargs_dbscan : dict
+        A dictionary containing all the other DBSCAN keywords
+
+    Returns
+    -------
+    frame_gutter : list
+        A list of the resulting extractions, one item per line of text found.
+    '''
+    c = np.cos(np.deg2rad(-kwargs_cluster['avg_slope']))
+    s = np.sin(np.deg2rad(-kwargs_cluster['avg_slope']))
+    x_rotate = np.array([np.array(x) * c - np.array(y) * s for x, y in zip(x_slope, y_slope)])
+    y_rotate = np.array([np.array(y) * c + np.array(x) * s for x, y in zip(x_slope, y_slope)])
+    gutter_labels = gutter(x_rotate, tol=kwargs_cluster['gutter_tol'])
+    gutter_labels_sorted = sort_labels(np.array(gutter_labels), np.array([np.mean(x) for x in x_rotate]))
+    frame_gutter = []
+    for gutter_label in gutter_labels_sorted:
+        gdx = gutter_labels == gutter_label
+        annotation_label = np.hstack([np.zeros(len(i)) + idx for idx, i in enumerate(x_slope[gdx])])
+        xy_rotate = np.array(list(zip(np.hstack(x_rotate[gdx]), np.hstack(y_rotate[gdx]))))
+        xy_gutter = np.array(list(zip(np.hstack(x_slope[gdx]), np.hstack(y_slope[gdx]))))
+        text_gutter = np.hstack(text_slope[gdx])
+        kwargs_cluster['gutter_label'] = gutter_label
+        frame_slope = cluster_by_line(xy_rotate, xy_gutter, text_gutter, annotation_label, kwargs_cluster, kwargs_dbscan)
+        frame_gutter += frame_slope
+    return frame_gutter
+
+
+def cluster_by_slope(x_frame, y_frame, text_frame, slope_frame, kwargs_cluster, kwargs_dbscan):
     '''A function to take the annotations for one `gutter_label` and cluster them
     based on what slope the transcription is.
 
     Parameters
     ----------
-    x : list
+    x_frame : list
         A list-of-lists of the x values for each drawn dot. There is one item in the
         list for annotation made by the user.
-    y : list
+    y_frame : list
         A list-of-lists of the y values for each drawn dot. There is one item in the
         list for annotation made by the user.
     text_frame : list
@@ -376,62 +434,17 @@ def cluster_by_slope(x, y, text, slope, kwargs_cluster, kwargs_dbscan):
     frame_slope : list
         A list of the resulting extractions, one item per line of text found.
     '''
-    db_slope = DBSCAN(eps=kwargs_cluster['eps_slope'], metric=angle_metric, **kwargs_dbscan).fit(slope)
-    slope_labels = sort_labels(db_slope.labels_, slope, reducer=avg_angle, descending=True)
+    db_slope = DBSCAN(eps=kwargs_cluster['eps_slope'], metric=angle_metric, **kwargs_dbscan).fit(slope_frame)
+    slope_labels = sort_labels(db_slope.labels_, slope_frame, reducer=avg_angle, descending=True)
     frame_slope = []
     for slope_label in slope_labels:
         sdx = db_slope.labels_ == slope_label
-        annotation_label = np.hstack([np.zeros(len(i)) + idx for idx, i in enumerate(x[sdx])])
-        xy_slope = np.array(list(zip(np.hstack(x[sdx]), np.hstack(y[sdx]))))
-        text_slope = np.hstack(text[sdx])
-        avg_slope = avg_angle(slope[sdx])
+        avg_slope = avg_angle(slope_frame[sdx])
         kwargs_cluster['avg_slope'] = avg_slope
         kwargs_cluster['slope_label'] = slope_label
-        frame_lines = cluster_by_line(xy_slope, text_slope, annotation_label, kwargs_cluster, kwargs_dbscan)
+        frame_lines = cluster_by_gutter(x_frame[sdx], y_frame[sdx], text_frame[sdx], kwargs_cluster, kwargs_dbscan)
         frame_slope += frame_lines
     return frame_slope
-
-
-def cluster_by_gutter(x_frame, y_frame, text_frame, slope_frame, kwargs_cluster, kwargs_dbscan):
-    '''A function to take the annotations for each frame of a subject and group them
-    based on what side of the page gutter they are on.
-
-    Parameters
-    ----------
-    x_frame : list
-        A list-of-lists of the x values for each drawn dot. There is one item in the
-        list for annotation made by the user.
-    y_frame : list
-        A list-of-lists of the y values for each drawn dot. There is one item in the
-        list for annotation made by the user.
-    text_frame : list
-        A list-of-lists of the text for each drawn dot. There is one item in the
-        list for annotation made by the user.
-    slope_frame : list
-        A list of the slopes (in deg) for each annotation
-    kwargs_cluster : dict
-        A dictionary containing the `eps_*`, `metric`, and `dot_freq` keywords
-    kwargs_dbscan : dict
-        A dictionary containing all the other DBSCAN keywords
-
-    Returns
-    -------
-    frame_gutter : list
-        A list of the resulting extractions, one item per line of text found.
-    '''
-    gutter_labels = gutter(x_frame)
-    gutter_labels_sorted = sort_labels(np.array(gutter_labels), np.array([np.mean(x) for x in x_frame]))
-    frame_gutter = []
-    for gutter_label in gutter_labels_sorted:
-        gdx = gutter_labels == gutter_label
-        x = x_frame[gdx]
-        y = y_frame[gdx]
-        text = text_frame[gdx]
-        slope = slope_frame[gdx]
-        kwargs_cluster['gutter_label'] = gutter_label
-        frame_slope = cluster_by_slope(x, y, text, slope, kwargs_cluster, kwargs_dbscan)
-        frame_gutter += frame_slope
-    return frame_gutter
 
 
 def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan):
@@ -446,6 +459,6 @@ def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan):
         for t in text_frame:
             t.append('')
         text_frame = np.array(text_frame)
-        frame_gutter = cluster_by_gutter(x_frame, y_frame, text_frame, slope_frame, kwargs_cluster, kwargs_dbscan)
+        frame_gutter = cluster_by_slope(x_frame, y_frame, text_frame, slope_frame, kwargs_cluster, kwargs_dbscan)
         reduced_data[frame] += frame_gutter
     return reduced_data

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -706,7 +706,7 @@ class TestClusterLines(unittest.TestCase):
         self.assertDictEqual(dict(result), processed_data)
 
     def test_cluster_lines(self):
-        result = poly_line_text_reducer._original(processed_data, metric='euclidean', dot_freq='word', gutter_tol=0, **self.kwargs)
+        result = poly_line_text_reducer._original(processed_data, metric='euclidean', dot_freq='word', gutter_tol=0, min_word_count=1, **self.kwargs)
         self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer(self):

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -482,7 +482,7 @@ reduced_data = {
             'number_views': 7,
             'consensus_score': 4.0,
             'gutter_label': 0,
-            'line_slope': -2.0348953116170234,
+            'line_slope': -1.5696676279703352,
             'slope_label': 0
         },
         {
@@ -510,58 +510,8 @@ reduced_data = {
             'number_views': 5,
             'consensus_score': 3.5,
             'gutter_label': 0,
-            'line_slope': -2.0348953116170234,
+            'line_slope': -1.5696676279703352,
             'slope_label': 0
-        },
-        {
-            'clusters_x': [
-                107.52334594726562,
-                312.98029785156251,
-                435.48880004882812,
-                578.09634399414062
-            ],
-            'clusters_y': [
-                538.7662353515625,
-                357.3962463378906,
-                254.98679809570314,
-                133.79429626464844
-            ],
-            'clusters_text': [
-                ['There', 'There', '', 'There', ''],
-                ['is', 'is', 'is', 'is', 'is'],
-                ['this', 'this', 'this', 'this', ''],
-                ['', '', '', '', '']
-            ],
-            'number_views': 5,
-            'consensus_score': 4.0,
-            'gutter_label': 0,
-            'line_slope': -40.150929458965543,
-            'slope_label': 1
-        },
-        {
-            'clusters_x': [
-                245.50492350260416,
-                408.80970001220703,
-                541.00881958007812,
-                741.60054524739587
-            ],
-            'clusters_y': [
-                544.34928385416663,
-                417.33450317382812,
-                304.87551879882812,
-                126.4166971842448
-            ],
-            'clusters_text': [
-                ['text', 'test', 'text', ''],
-                ['as', 'as', 'as', 'as'],
-                ['well', 'well', 'well', ''],
-                ['', '', '', '']
-            ],
-            'number_views': 4,
-            'consensus_score': 3.0,
-            'gutter_label': 0,
-            'line_slope': -40.150929458965543,
-            'slope_label': 1
         },
         {
             'clusters_x': [
@@ -588,7 +538,7 @@ reduced_data = {
             'number_views': 6,
             'consensus_score': 4.25,
             'gutter_label': 1,
-            'line_slope': -1.0113944075943084,
+            'line_slope': -1.5696676279703352,
             'slope_label': 0
         },
         {
@@ -610,8 +560,58 @@ reduced_data = {
             'number_views': 4,
             'consensus_score': 3.5,
             'gutter_label': 1,
-            'line_slope': -1.0113944075943084,
+            'line_slope': -1.5696676279703352,
             'slope_label': 0
+        },
+        {
+            'clusters_x': [
+                107.52334594726562,
+                312.9802978515625,
+                435.4888000488281,
+                578.0963439941406
+            ],
+            'clusters_y': [
+                538.7662353515625,
+                357.3962463378906,
+                254.98679809570314,
+                133.79429626464844
+            ],
+            'clusters_text': [
+                ['There', 'There', '', 'There', ''],
+                ['is', 'is', 'is', 'is', 'is'],
+                ['this', 'this', 'this', 'this', ''],
+                ['', '', '', '', '']
+            ],
+            'number_views': 5,
+            'consensus_score': 4.0,
+            'gutter_label': 0,
+            'line_slope': -40.020044794251575,
+            'slope_label': 1
+        },
+        {
+            'clusters_x': [
+                245.50492350260416,
+                408.80970001220703,
+                541.0088195800781,
+                741.6005452473959
+            ],
+            'clusters_y': [
+                544.3492838541666,
+                417.3345031738281,
+                304.8755187988281,
+                126.4166971842448
+            ],
+            'clusters_text': [
+                ['text', 'test', 'text', ''],
+                ['as', 'as', 'as', 'as'],
+                ['well', 'well', 'well', ''],
+                ['', '', '', '']
+            ],
+            'number_views': 4,
+            'consensus_score': 3.0,
+            'gutter_label': 0,
+            'line_slope': -40.020044794251575,
+            'slope_label': 1
         },
         {
             'clusters_x': [
@@ -635,7 +635,7 @@ reduced_data = {
             'number_views': 5,
             'consensus_score': 4.0,
             'gutter_label': 1,
-            'line_slope': -39.912957341303802,
+            'line_slope': -40.020044794251575,
             'slope_label': 1
         },
         {
@@ -660,7 +660,7 @@ reduced_data = {
             'number_views': 6,
             'consensus_score': 4.333333333333333,
             'gutter_label': 1,
-            'line_slope': -39.912957341303802,
+            'line_slope': -40.020044794251575,
             'slope_label': 1
         }
     ],
@@ -703,15 +703,15 @@ class TestClusterLines(unittest.TestCase):
 
     def test_process_data(self):
         result = process_data(extracted_data)
-        self.assertDictEqual(result, processed_data)
+        self.assertDictEqual(dict(result), processed_data)
 
     def test_cluster_lines(self):
-        result = poly_line_text_reducer._original(processed_data, metric='euclidean', dot_freq='word', **self.kwargs)
-        self.assertDictEqual(result, reduced_data)
+        result = poly_line_text_reducer._original(processed_data, metric='euclidean', dot_freq='word', gutter_tol=0, **self.kwargs)
+        self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer(self):
         result = poly_line_text_reducer(extracted_data, **self.kwargs)
-        self.assertDictEqual(result, reduced_data)
+        self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer_request(self):
         app = flask.Flask(__name__)
@@ -722,7 +722,7 @@ class TestClusterLines(unittest.TestCase):
         url_params = '?{0}'.format(urllib.parse.urlencode(self.kwargs))
         with app.test_request_context(url_params, **request_kwargs):
             result = poly_line_text_reducer(flask.request)
-            self.assertDictEqual(result, reduced_data)
+            self.assertDictEqual(dict(result), reduced_data)
 
 
 if __name__ == '__main__':

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -948,7 +948,7 @@ class TestSWClusterLines(unittest.TestCase):
         self.assertDictEqual(dict(result), processed_data)
 
     def test_cluster_lines(self):
-        result = poly_line_text_reducer._original(processed_data, metric='euclidean', gutter_tol=0, **self.kwargs)
+        result = poly_line_text_reducer._original(processed_data, metric='euclidean', gutter_tol=0, min_word_count=1, **self.kwargs)
         self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer(self):

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -702,7 +702,7 @@ reduced_data = {
             'clusters_y': [127.12, 139.355],
             'consensus_score': 4.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         },
@@ -717,7 +717,7 @@ reduced_data = {
             'clusters_y': [273.3075, 274.9225],
             'consensus_score': 4.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         },
@@ -732,7 +732,7 @@ reduced_data = {
             'clusters_y': [340.52799999999996, 338.09],
             'consensus_score': 4.75,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 5,
             'slope_label': 0
         },
@@ -747,7 +747,7 @@ reduced_data = {
             'clusters_y': [395.975, 384.53999999999996],
             'consensus_score': 3.75,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         },
@@ -762,7 +762,7 @@ reduced_data = {
             'clusters_y': [461.305, 448.28499999999997],
             'consensus_score': 3.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 6,
             'slope_label': 0
         },
@@ -778,7 +778,7 @@ reduced_data = {
             'clusters_y': [508.83666666666664, 500.505],
             'consensus_score': 2.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 3,
             'slope_label': 0
         },
@@ -794,7 +794,7 @@ reduced_data = {
             'clusters_y': [566.2200000000001, 552.72],
             'consensus_score': 2.8,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         },
@@ -809,7 +809,7 @@ reduced_data = {
             'clusters_y': [630.3525, 611.5733333333334],
             'consensus_score': 3.25,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         },
@@ -824,7 +824,7 @@ reduced_data = {
             'clusters_y': [683.7599999999999, 680.4133333333334],
             'consensus_score': 2.75,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 5,
             'slope_label': 0
         },
@@ -838,7 +838,7 @@ reduced_data = {
             'clusters_y': [739.5300000000001, 747.7033333333334],
             'consensus_score': 3.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 3,
             'slope_label': 0
         },
@@ -854,7 +854,7 @@ reduced_data = {
             'clusters_y': [800.1466666666666, 826.4449999999999],
             'consensus_score': 2.8,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 3,
             'slope_label': 0
         },
@@ -869,7 +869,7 @@ reduced_data = {
             'clusters_y': [850.88, 850.7],
             'consensus_score': 1.75,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 3,
             'slope_label': 0},
         {
@@ -883,7 +883,7 @@ reduced_data = {
             'clusters_y': [909.73, 934.2650000000001],
             'consensus_score': 2.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 3,
             'slope_label': 0},
         {
@@ -895,7 +895,7 @@ reduced_data = {
             'clusters_y': [963.015, 956.645],
             'consensus_score': 2.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 2,
             'slope_label': 0},
         {
@@ -909,7 +909,7 @@ reduced_data = {
             'clusters_y': [1015.4, 1020.78],
             'consensus_score': 1.5,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 2,
             'slope_label': 0},
         {
@@ -924,7 +924,7 @@ reduced_data = {
             'clusters_y': [1088.7925, 1088.0325],
             'consensus_score': 4.0,
             'gutter_label': 1,
-            'line_slope': 0.05346843624842927,
+            'line_slope': 0.09112619119034585,
             'number_views': 4,
             'slope_label': 0
         }
@@ -945,15 +945,15 @@ class TestSWClusterLines(unittest.TestCase):
 
     def test_process_data(self):
         result = process_data(extracted_data)
-        self.assertDictEqual(result, processed_data)
+        self.assertDictEqual(dict(result), processed_data)
 
     def test_cluster_lines(self):
-        result = poly_line_text_reducer._original(processed_data, metric='euclidean', **self.kwargs)
-        self.assertDictEqual(result, reduced_data)
+        result = poly_line_text_reducer._original(processed_data, metric='euclidean', gutter_tol=0, **self.kwargs)
+        self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer(self):
         result = poly_line_text_reducer(extracted_data, **self.kwargs)
-        self.assertDictEqual(result, reduced_data)
+        self.assertDictEqual(dict(result), reduced_data)
 
     def test_poly_line_text_reducer_request(self):
         app = flask.Flask(__name__)
@@ -964,7 +964,7 @@ class TestSWClusterLines(unittest.TestCase):
         url_params = '?{0}'.format(urllib.parse.urlencode(self.kwargs))
         with app.test_request_context(url_params, **request_kwargs):
             result = poly_line_text_reducer(flask.request)
-            self.assertDictEqual(result, reduced_data)
+            self.assertDictEqual(dict(result), reduced_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This swaps the order of angle and gutter detection.  This switch produces cleaner results for SW aggregation since classifications that typically bridge page gutters are at strange angles and don't pass the `min_samples` threshold.