### PR TITLE
Let extractors have `task` passed in

### DIFF
--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -1,13 +1,16 @@
 from functools import wraps
 
 
-def unpack_annotations(annotations):
-    annotations_list = []
-    for value in annotations.values():
-        if isinstance(value, list):
-            annotations_list += value
-        else:
-            annotations_list.append(value)
+def unpack_annotations(annotations, task):
+    if task == 'all':
+        annotations_list = []
+        for value in annotations.values():
+            if isinstance(value, list):
+                annotations_list += value
+            else:
+                annotations_list.append(value)
+    else:
+        annotations_list = annotations[task]
     return annotations_list
 
 
@@ -16,9 +19,11 @@ def extractor_wrapper(func):
     def wrapper(argument):
         #: check if argument is a flask request
         if hasattr(argument, 'get_json'):
+            kwargs = argument.args
+            task = kwargs.get('task', 'all')
             data = argument.get_json()
             annotations = data['annotations']
-            annotations_list = unpack_annotations(annotations)
+            annotations_list = unpack_annotations(annotations, task)
             data['annotations'] = annotations_list
             return func(data)
         else:

--- a/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
@@ -120,6 +120,16 @@ class TestPointExtractor(unittest.TestCase):
             result = extractors.point_extractor(flask.request)
             self.assertDictEqual(result, expected)
 
+    def test_extract_request_with_task(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context('?task=T0', **request_kwargs):
+            result = extractors.point_extractor(flask.request)
+            self.assertDictEqual(result, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will filter the incoming classification by task key if provided.
When there is no task key passed in all classifications/tasks will go to
the extractor.