### PR TITLE
Make sure missing task key does not crash extractor

### DIFF
--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -10,7 +10,7 @@ def unpack_annotations(annotations, task):
             else:
                 annotations_list.append(value)
     else:
-        annotations_list = annotations[task]
+        annotations_list = annotations.get(task, [])
     return annotations_list
 
 


### PR DESCRIPTION
Just default to an empty list if a task key is not in the extractor
list.