### PR TITLE
Fix SW empty annotation extract

### DIFF
--- a/panoptes_aggregation/extractors/sw_extractor.py
+++ b/panoptes_aggregation/extractors/sw_extractor.py
@@ -43,26 +43,27 @@ def clean_text(s):
 
 @extractor_wrapper
 def sw_extractor(classification):
+    extract = OrderedDict()
     blank_frame = OrderedDict([
         ('points', OrderedDict([('x', []), ('y', [])])),
         ('text', []),
         ('slope', [])
     ])
-    extract = OrderedDict()
     frame = 'frame0'
     extract[frame] = copy.deepcopy(blank_frame)
-    annotation = classification['annotations'][0]
-    for value in annotation['value']:
-        if ('startPoint' in value) and ('endPoint' in value) and ('text' in value):
-            x = [value['startPoint']['x'], value['endPoint']['x']]
-            y = [value['startPoint']['y'], value['endPoint']['y']]
-            if (None not in x) and (None not in y):
-                text = [clean_text(value['text'])]
-                dx = x[-1] - x[0]
-                dy = y[-1] - y[0]
-                slope = np.rad2deg(np.arctan2(dy, dx))
-                extract[frame]['text'].append(text)
-                extract[frame]['points']['x'].append(x)
-                extract[frame]['points']['y'].append(y)
-                extract[frame]['slope'].append(slope)
+    if len(classification['annotations']) > 0:
+        annotation = classification['annotations'][0]
+        for value in annotation['value']:
+            if ('startPoint' in value) and ('endPoint' in value) and ('text' in value):
+                x = [value['startPoint']['x'], value['endPoint']['x']]
+                y = [value['startPoint']['y'], value['endPoint']['y']]
+                if (None not in x) and (None not in y):
+                    text = [clean_text(value['text'])]
+                    dx = x[-1] - x[0]
+                    dy = y[-1] - y[0]
+                    slope = np.rad2deg(np.arctan2(dy, dx))
+                    extract[frame]['text'].append(text)
+                    extract[frame]['points']['x'].append(x)
+                    extract[frame]['points']['y'].append(y)
+                    extract[frame]['slope'].append(slope)
     return extract

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -6,7 +6,7 @@ from sklearn.cluster import DBSCAN
 
 
 def tokenize(self, contents):
-    '''tokenize only on space so angle bracket tags are not split'''
+    '''Tokenize only on space so angle bracket tags are not split'''
     return contents.split()
 
 
@@ -27,6 +27,7 @@ def overlap(x, y, tol=0):
         The tolerance to consider lines overlapping. Default 0, positive
         value indicate small overlaps are not considered, negitive values
         idicate small gaps are not considered.
+
     Returns
     -------
     overlap : bool

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
@@ -137,6 +137,21 @@ expected = {
     }
 }
 
+classification_blank = {
+    'annotations': []
+}
+
+expected_blank = {
+    'frame0': {
+        'points': {
+            'x': [],
+            'y': []
+        },
+        'text': [],
+        'slope': []
+    }
+}
+
 
 class TestSWExtractor(unittest.TestCase):
     def setUp(self):
@@ -173,6 +188,20 @@ class TestSWExtractor(unittest.TestCase):
                                 np.testing.assert_allclose(result[i][j], expected[i][j], atol=1e-5)
                             else:
                                 self.assertEqual(result[i][j], expected[i][j])
+
+    def test_extract_blank(self):
+        result = extractors.sw_extractor(classification_blank)
+        self.assertDictEqual(result, expected_blank)
+
+    def test_request_blank(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification_blank)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context(**request_kwargs):
+            result = extractors.sw_extractor(flask.request)
+            self.assertDictEqual(result, expected_blank)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Empty annotations was causing the SW extractor to crash.  These changes prevent this from happening and make sure the empty annotation is extracted into the correctly shaped empty object for the reducer.