### PR TITLE
Fix SW empty annotaiton crashing variant and graphic extractors

### DIFF
--- a/panoptes_aggregation/extractors/sw_graphic_extractor.py
+++ b/panoptes_aggregation/extractors/sw_graphic_extractor.py
@@ -10,19 +10,20 @@ def exist_and_finite(d, key):
 def sw_graphic_extractor(classification):
     extract = OrderedDict()
     frame = 'frame0'
-    annotation = classification['annotations'][0]
-    for value in annotation['value']:
-        if ('type' in value) and ((value['type'] == 'graphic') or (value['type'] == 'image')):
-            exist = exist_and_finite(value, 'x') and exist_and_finite(value, 'y') and exist_and_finite(value, 'width') and exist_and_finite(value, 'height')
-            if (value['type'] == 'graphic'):
-                exist = exist and exist_and_finite(value, 'tag')
+    if len(classification['annotations']) > 0:
+        annotation = classification['annotations'][0]
+        for value in annotation['value']:
+            if ('type' in value) and ((value['type'] == 'graphic') or (value['type'] == 'image')):
+                exist = exist_and_finite(value, 'x') and exist_and_finite(value, 'y') and exist_and_finite(value, 'width') and exist_and_finite(value, 'height')
+                if (value['type'] == 'graphic'):
+                    exist = exist and exist_and_finite(value, 'tag')
+                    if exist:
+                        extract.setdefault(frame, OrderedDict())
+                        extract[frame].setdefault('tool0_tag', []).append(value['tag'])
                 if exist:
                     extract.setdefault(frame, OrderedDict())
-                    extract[frame].setdefault('tool0_tag', []).append(value['tag'])
-            if exist:
-                extract.setdefault(frame, OrderedDict())
-                extract[frame].setdefault('tool0_x', []).append(float(value['x']))
-                extract[frame].setdefault('tool0_y', []).append(float(value['y']))
-                extract[frame].setdefault('tool0_width', []).append(float(value['width']))
-                extract[frame].setdefault('tool0_height', []).append(float(value['height']))
+                    extract[frame].setdefault('tool0_x', []).append(float(value['x']))
+                    extract[frame].setdefault('tool0_y', []).append(float(value['y']))
+                    extract[frame].setdefault('tool0_width', []).append(float(value['width']))
+                    extract[frame].setdefault('tool0_height', []).append(float(value['height']))
     return extract

--- a/panoptes_aggregation/extractors/sw_variant_extractor.py
+++ b/panoptes_aggregation/extractors/sw_variant_extractor.py
@@ -25,10 +25,11 @@ def sw_variant_extractor(classification):
     '''
     extract = {}
     variants = []
-    annotation = classification['annotations'][0]
-    for value in annotation['value']:
-        if 'variants' in value:
-            variants += list(filter(None, value['variants']))
-    if len(variants) > 0:
-        extract['variants'] = variants
+    if len(classification['annotations']) > 0:
+        annotation = classification['annotations'][0]
+        for value in annotation['value']:
+            if 'variants' in value:
+                variants += list(filter(None, value['variants']))
+        if len(variants) > 0:
+            extract['variants'] = variants
     return extract

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
@@ -93,6 +93,13 @@ expected_at = {
 }
 
 
+classification_blank = {
+    'annotations': []
+}
+
+expected_blank = {}
+
+
 class TextSWGraphicExtractor(unittest.TestCase):
     def test_extract_sw(self):
         result = extractors.sw_graphic_extractor(classification_sw)
@@ -121,3 +128,17 @@ class TextSWGraphicExtractor(unittest.TestCase):
         with app.test_request_context(**request_kwargs):
             result = extractors.sw_graphic_extractor(flask.request)
             self.assertDictEqual(result, expected_at)
+
+    def test_extract_blank(self):
+        result = extractors.sw_graphic_extractor(classification_blank)
+        self.assertDictEqual(result, expected_blank)
+
+    def test_request_blank(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification_blank)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context(**request_kwargs):
+            result = extractors.sw_graphic_extractor(flask.request)
+            self.assertDictEqual(result, expected_blank)

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_variant_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_variant_extractor.py
@@ -90,6 +90,12 @@ expected = {
     ]
 }
 
+classification_blank = {
+    'annotations': []
+}
+
+expected_blank = {}
+
 
 class TextSWVariantExtractor(unittest.TestCase):
     def test_extract(self):
@@ -105,3 +111,17 @@ class TextSWVariantExtractor(unittest.TestCase):
         with app.test_request_context(**request_kwargs):
             result = extractors.sw_variant_extractor(flask.request)
             self.assertDictEqual(result, expected)
+
+    def test_extract_blank(self):
+        result = extractors.sw_variant_extractor(classification_blank)
+        self.assertDictEqual(result, expected_blank)
+
+    def test_request_blank(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification_blank)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context(**request_kwargs):
+            result = extractors.sw_variant_extractor(flask.request)
+            self.assertDictEqual(result, expected_blank)

--- a/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
@@ -53,7 +53,8 @@ extracted_data = [
             'T0_tool0_width': [20.0],
             'T0_tool0_height': [20.0]
         }
-    }
+    },
+    {}
 ]
 
 processed_data = {


### PR DESCRIPTION
This prevents an empty classification on SW from crashing the variant and graphic extractors.