### PR TITLE
Make AnnoTate work

### DIFF
--- a/panoptes_aggregation/extractors/sw_extractor.py
+++ b/panoptes_aggregation/extractors/sw_extractor.py
@@ -53,17 +53,18 @@ def sw_extractor(classification):
     extract[frame] = copy.deepcopy(blank_frame)
     if len(classification['annotations']) > 0:
         annotation = classification['annotations'][0]
-        for value in annotation['value']:
-            if ('startPoint' in value) and ('endPoint' in value) and ('text' in value):
-                x = [value['startPoint']['x'], value['endPoint']['x']]
-                y = [value['startPoint']['y'], value['endPoint']['y']]
-                if (None not in x) and (None not in y):
-                    text = [clean_text(value['text'])]
-                    dx = x[-1] - x[0]
-                    dy = y[-1] - y[0]
-                    slope = np.rad2deg(np.arctan2(dy, dx))
-                    extract[frame]['text'].append(text)
-                    extract[frame]['points']['x'].append(x)
-                    extract[frame]['points']['y'].append(y)
-                    extract[frame]['slope'].append(slope)
+        if isinstance(annotation['value'], list):
+            for value in annotation['value']:
+                if ('startPoint' in value) and ('endPoint' in value) and ('text' in value):
+                    x = [value['startPoint']['x'], value['endPoint']['x']]
+                    y = [value['startPoint']['y'], value['endPoint']['y']]
+                    if (None not in x) and (None not in y):
+                        text = [clean_text(value['text'])]
+                        dx = x[-1] - x[0]
+                        dy = y[-1] - y[0]
+                        slope = np.rad2deg(np.arctan2(dy, dx))
+                        extract[frame]['text'].append(text)
+                        extract[frame]['points']['x'].append(x)
+                        extract[frame]['points']['y'].append(y)
+                        extract[frame]['slope'].append(slope)
     return extract

--- a/panoptes_aggregation/extractors/sw_graphic_extractor.py
+++ b/panoptes_aggregation/extractors/sw_graphic_extractor.py
@@ -12,18 +12,19 @@ def sw_graphic_extractor(classification):
     frame = 'frame0'
     if len(classification['annotations']) > 0:
         annotation = classification['annotations'][0]
-        for value in annotation['value']:
-            if ('type' in value) and ((value['type'] == 'graphic') or (value['type'] == 'image')):
-                exist = exist_and_finite(value, 'x') and exist_and_finite(value, 'y') and exist_and_finite(value, 'width') and exist_and_finite(value, 'height')
-                if (value['type'] == 'graphic'):
-                    exist = exist and exist_and_finite(value, 'tag')
+        if isinstance(annotation['value'], list):
+            for value in annotation['value']:
+                if ('type' in value) and ((value['type'] == 'graphic') or (value['type'] == 'image')):
+                    exist = exist_and_finite(value, 'x') and exist_and_finite(value, 'y') and exist_and_finite(value, 'width') and exist_and_finite(value, 'height')
+                    if (value['type'] == 'graphic'):
+                        exist = exist and exist_and_finite(value, 'tag')
+                        if exist:
+                            extract.setdefault(frame, OrderedDict())
+                            extract[frame].setdefault('tool0_tag', []).append(value['tag'])
                     if exist:
                         extract.setdefault(frame, OrderedDict())
-                        extract[frame].setdefault('tool0_tag', []).append(value['tag'])
-                if exist:
-                    extract.setdefault(frame, OrderedDict())
-                    extract[frame].setdefault('tool0_x', []).append(float(value['x']))
-                    extract[frame].setdefault('tool0_y', []).append(float(value['y']))
-                    extract[frame].setdefault('tool0_width', []).append(float(value['width']))
-                    extract[frame].setdefault('tool0_height', []).append(float(value['height']))
+                        extract[frame].setdefault('tool0_x', []).append(float(value['x']))
+                        extract[frame].setdefault('tool0_y', []).append(float(value['y']))
+                        extract[frame].setdefault('tool0_width', []).append(float(value['width']))
+                        extract[frame].setdefault('tool0_height', []).append(float(value['height']))
     return extract

--- a/panoptes_aggregation/extractors/workflow_extractor_config.py
+++ b/panoptes_aggregation/extractors/workflow_extractor_config.py
@@ -7,6 +7,11 @@ def workflow_extractor_config(tasks):
         extractor_config['T2'] = ['sw_extractor', 'sw_variant_extractor', 'sw_graphic_extractor']
         extractor_config['T3'] = 'question_extractor'
         return extractor_config
+    if ('T0' in tasks) and ('annotate-' in tasks['T0']['type']):
+        # this is annotate, return the correct config
+        extractor_config['T0'] = 'question_extractor'
+        extractor_config['T2'] = ['sw_extractor', 'sw_graphic_extractor']
+        extractor_config['T3'] = 'question_extractor'
     for task_key, task in tasks.items():
         if task['type'] == 'drawing':
             tools_config = {}

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
@@ -152,6 +152,15 @@ expected_blank = {
     }
 }
 
+classification_wrong = {
+    'annotations': [
+        {
+            'value': 1,
+            'task': 'T2'
+        }
+    ]
+}
+
 
 class TestSWExtractor(unittest.TestCase):
     def setUp(self):
@@ -196,6 +205,20 @@ class TestSWExtractor(unittest.TestCase):
     def test_request_blank(self):
         request_kwargs = {
             'data': json.dumps(annotation_by_task(classification_blank)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context(**request_kwargs):
+            result = extractors.sw_extractor(flask.request)
+            self.assertDictEqual(result, expected_blank)
+
+    def test_extract_wrong(self):
+        result = extractors.sw_extractor(classification_wrong)
+        self.assertDictEqual(result, expected_blank)
+
+    def test_request_wrong(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification_wrong)),
             'content_type': 'application/json'
         }
         app = flask.Flask(__name__)

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
@@ -99,6 +99,15 @@ classification_blank = {
 
 expected_blank = {}
 
+classification_wrong = {
+    'annotations': [
+        {
+            'value': 1,
+            'task': 'T2'
+        }
+    ]
+}
+
 
 class TextSWGraphicExtractor(unittest.TestCase):
     def test_extract_sw(self):
@@ -136,6 +145,20 @@ class TextSWGraphicExtractor(unittest.TestCase):
     def test_request_blank(self):
         request_kwargs = {
             'data': json.dumps(annotation_by_task(classification_blank)),
+            'content_type': 'application/json'
+        }
+        app = flask.Flask(__name__)
+        with app.test_request_context(**request_kwargs):
+            result = extractors.sw_graphic_extractor(flask.request)
+            self.assertDictEqual(result, expected_blank)
+
+    def test_extract_wrong(self):
+        result = extractors.sw_graphic_extractor(classification_wrong)
+        self.assertDictEqual(result, expected_blank)
+
+    def test_request_wrong(self):
+        request_kwargs = {
+            'data': json.dumps(annotation_by_task(classification_wrong)),
             'content_type': 'application/json'
         }
         app = flask.Flask(__name__)


### PR DESCRIPTION
This introduces the AnnoTate workflow to the auto-detect config tool for offline processing and allows the sw_*_extractors to properly ignore incorrect data.  It turns out at least one AnnoTate classification has the wrong task label assigned to a classification.  Tests have been added to reproduce this situation.