### PR TITLE
Add doc stirngs to more tests

### DIFF
--- a/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
@@ -73,6 +73,7 @@ class TestFilterAnnotations(unittest.TestCase):
         self.maxDiff = None
 
     def test_filter(self):
+        '''Test annotation filter: Test with no task labels'''
         expected_result = {
             'line_extractor': [{
                 'task': 'T0',
@@ -140,6 +141,7 @@ class TestFilterAnnotations(unittest.TestCase):
         self.assertDictEqual(result, expected_result)
 
     def test_filter_human(self):
+        '''Test annotation filter: Test with task labels'''
         expected_result = {
             'line_extractor': [{
                 'task': 'T0',

--- a/panoptes_aggregation/tests/extractor_tests/test_workflow_extractor_config.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_workflow_extractor_config.py
@@ -103,6 +103,7 @@ expected = {
 
 class TestWorkflowExtractorConfig(unittest.TestCase):
     def test_config(self):
+        '''Test workflow auto config works'''
         result = workflow_extractor_config(tasks)
         self.assertDictEqual(result, expected)
 

--- a/panoptes_aggregation/tests/reducer_tests/test_process_kwargs.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_process_kwargs.py
@@ -16,12 +16,13 @@ expected_default = {
 
 class TestProcessKwargs(unittest.TestCase):
     def test_defaults(self):
+        '''Test process kwargs: Test that defualts are used when nothing is passed in'''
         kwargs = {}
         result = process_kwargs(kwargs, DEFAULTS)
         self.assertDictEqual(result, expected_default)
 
     def test_setting_value(self):
-        # make sure value sets as correct type
+        '''Test process kwargs: Test data type casting works'''
         kwargs = {'a': '10'}
         expected = {
             'a': 10.0,
@@ -32,13 +33,13 @@ class TestProcessKwargs(unittest.TestCase):
         self.assertDictEqual(result, expected)
 
     def test_wrong_type(self):
-        # make sure default is used with bad keywords are passed in
+        '''Test process kwargs: Test that defualts are used when a bad keyword is passed in'''
         kwargs = {'b': '10.5'}
         result = process_kwargs(kwargs, DEFAULTS)
         self.assertDictEqual(result, expected_default)
 
     def test_wrong_key(self):
-        # make sure invalid keywords are not passed in
+        '''Test process kwargs: Test that invaild keywords are not passed in'''
         kwargs = {'random': 'set'}
         result = process_kwargs(kwargs, DEFAULTS)
         self.assertDictEqual(result, expected_default)


### PR DESCRIPTION
Now all tests have a doc string that is visible when the `-v` swtich is
passed to `nosetests`.