### PR TITLE
Add dropdown task

### DIFF
--- a/docs/source/extractros.rst
+++ b/docs/source/extractros.rst
@@ -27,3 +27,6 @@ Extractors
 
 .. automodule:: panoptes_aggregation.extractors.sw_graphic_extractor
   :members:
+
+.. automodule:: panoptes_aggregation.extractors.dropdown_extractor
+  :members:

--- a/docs/source/reducers.rst
+++ b/docs/source/reducers.rst
@@ -21,3 +21,6 @@ Reducers
 
 .. automodule:: panoptes_aggregation.reducers.sw_variant_reducer
   :members:
+
+.. automodule:: panoptes_aggregation.reducers.dropdown_reducer
+  :members:

--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -7,6 +7,7 @@ from .line_text_extractor import line_text_extractor
 from .sw_extractor import sw_extractor
 from .sw_variant_extractor import sw_variant_extractor
 from .sw_graphic_extractor import sw_graphic_extractor
+from .dropdown_extractor import dropdown_extractor
 from .workflow_extractor_config import workflow_extractor_config
 from .filter_annotations import filter_annotations
 
@@ -19,5 +20,6 @@ extractors = {
     'line_text_extractor': line_text_extractor,
     'sw_extractor': sw_extractor,
     'sw_variant_extractor': sw_variant_extractor,
-    'sw_graphic_extractor': sw_graphic_extractor
+    'sw_graphic_extractor': sw_graphic_extractor,
+    'dropdown_extractor': dropdown_extractor
 }

--- a/panoptes_aggregation/extractors/dropdown_extractor.py
+++ b/panoptes_aggregation/extractors/dropdown_extractor.py
@@ -1,0 +1,33 @@
+'''
+Dropdown Extractor
+-------------------
+This module provides a function to extract dropdown selections from panoptes annotations.
+'''
+from .extractor_wrapper import extractor_wrapper
+from .question_extractor import slugify_or_null
+
+
+@extractor_wrapper
+def dropdown_extractor(classification):
+    '''Extract annotations from a dropdown task into a Counter object
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing `annotations` as a key that is a list of
+        panoptes annotations
+
+    Returns
+    -------
+    extraction : dict
+        A dictionary containing `value` as a key that is a list of
+        Counter dictionaries, one entry for each dropdown list in the
+        task
+    '''
+    annotation = classification['annotations'][0]
+    answers = {
+        'value': []
+    }
+    for value in annotation['value']:
+        answers['value'].append({slugify_or_null(value['value']): 1})
+    return answers

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -3,6 +3,7 @@ from .rectangle_reducer import rectangle_reducer
 from .question_reducer import question_reducer
 from .survey_reducer import survey_reducer
 from .poly_line_text_reducer import poly_line_text_reducer
+from .dropdown_reducer import dropdown_reducer
 from .process_kwargs import process_kwargs
 from .sw_variant_reducer import sw_variant_reducer
 
@@ -12,5 +13,6 @@ reducers = {
     'question_reducer': question_reducer,
     'survey_reducer': survey_reducer,
     'poly_line_text_reducer': poly_line_text_reducer,
-    'sw_variant_reducer': sw_variant_reducer
+    'sw_variant_reducer': sw_variant_reducer,
+    'dropdown_reducer': dropdown_reducer
 }

--- a/panoptes_aggregation/reducers/dropdown_reducer.py
+++ b/panoptes_aggregation/reducers/dropdown_reducer.py
@@ -1,0 +1,57 @@
+'''
+Dropdown Reducer
+----------------
+This module porvides functions to reduce the dropdown task extracts from
+:mod:`panoptes_aggregation.extractors.dropdown_extractor`.
+'''
+from collections import Counter
+import numpy as np
+from .reducer_wrapper import reducer_wrapper
+
+
+def process_data(data):
+    '''Process a list of extracted dropdown answers into `Counter` objects
+
+    Parameters
+    ----------
+    data : list
+        A list of extractions created by
+        :meth:`panoptes_aggregation.extractors.dropdown_extractor.dropdown_extractor`
+
+    Returns
+    -------
+    process_data : list
+        A list-of-lists of `Counter` objects. The is one element of the outer list
+        for each classification made, and one element of the inner list for each
+        dropdown list in the task.
+    '''
+    data_out = []
+    for extract in data:
+        values = []
+        for value in extract['value']:
+            values.append(Counter(value))
+        data_out.append(values)
+    return data_out
+
+
+@reducer_wrapper(process_data=process_data)
+def dropdown_reducer(votes_list):
+    '''Reducer a list-of-lists of `Counter` objects into one list of dicts
+
+    Parameters
+    ----------
+    votes_list : list
+        A list-of-lists of `Counter` objects from :meth:`process_data`
+
+    Returns
+    -------
+    reduction : dict
+        A dictionary with one key `value` the contains a list of dictionaries
+        (one for each dropdown in the task) giving the vote count for each `key`
+    '''
+    value = np.array(votes_list).sum(axis=0).tolist()
+    value = list(map(dict, value))
+    output = {
+        'value': value
+    }
+    return output

--- a/panoptes_aggregation/tests/extractor_tests/test_dropdown_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_dropdown_extractor.py
@@ -1,0 +1,39 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    'annotations': [
+        {
+            'task': 'T0',
+            'value': [
+                {
+                    'value': 'Option 1',
+                    'option': True
+                },
+                {
+                    'value': 'Option 2',
+                    'option': True
+                },
+                {
+                    'value': None,
+                    'option': False
+                }
+            ]
+        }
+    ]
+}
+
+expected = {
+    'value': [
+        {'option-1': 1},
+        {'option-2': 1},
+        {'None': 1}
+    ]
+}
+
+TestDropdown = ExtractorTest(
+    extractors.dropdown_extractor,
+    classification,
+    expected,
+    'Test dropdown list'
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
@@ -134,7 +134,7 @@ expected = {
     }
 }
 
-TestPolyLineText = TextExtractorTest(
+TestLineText = TextExtractorTest(
     extractors.line_text_extractor,
     classification,
     expected,

--- a/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
@@ -1,0 +1,63 @@
+from collections import Counter
+from panoptes_aggregation.reducers.dropdown_reducer import process_data, dropdown_reducer
+from .base_test_class import ReducerTest
+
+extracted_data = [
+    {
+        'value': [
+            {'option-1': 1},
+            {'option-2': 1},
+            {'None': 1}
+        ]
+    },
+    {
+        'value': [
+            {'option-4': 1},
+            {'option-2': 1},
+            {'None': 1}
+        ]
+    },
+    {
+        'value': [
+            {'option-1': 1},
+            {'option-3': 1},
+            {'option-5': 1}
+        ]
+    }
+]
+
+processed_data = [
+    [
+        Counter({'option-1': 1}),
+        Counter({'option-2': 1}),
+        Counter({'None': 1})
+    ],
+    [
+        Counter({'option-4': 1}),
+        Counter({'option-2': 1}),
+        Counter({'None': 1})
+    ],
+    [
+        Counter({'option-1': 1}),
+        Counter({'option-3': 1}),
+        Counter({'option-5': 1})
+    ]
+]
+
+reduced_data = {
+    'value': [
+        {'option-1': 2, 'option-4': 1},
+        {'option-2': 2, 'option-3': 1},
+        {'None': 2, 'option-5': 1}
+    ]
+}
+
+TestDropdownReducer = ReducerTest(
+    dropdown_reducer,
+    process_data,
+    extracted_data,
+    processed_data,
+    reduced_data,
+    'Test dropdown reducer',
+    processed_type='list'
+)


### PR DESCRIPTION
This PR adds a reducer and extractor for the dropdown task.  Since the task is formatted as a potential collection of dropdown lists, the extractor and reducer both return lists inside a dictionary of the form:
```python
{
    'value': [
        {...},
        {...}
    ]
}
```