### PR TITLE
Fix 61

### DIFF
--- a/panoptes_aggregation/extractors/filter_annotations.py
+++ b/panoptes_aggregation/extractors/filter_annotations.py
@@ -8,7 +8,7 @@ def filter_annotations(annotations, config, human=False):
             if isinstance(config[annotation['task']], dict):
                 for extractor_name, tool_config in config[annotation['task']].items():
                     annotations_by_extractor.setdefault(extractor_name, {'annotations': [], 'config': {}})
-                    if len(tool_config['details']) > 0:
+                    if len(tool_config.get('details', [])) > 0:
                         annotations_by_extractor[extractor_name]['config'] = {'details': tool_config['details']}
                     annotations_by_extractor[extractor_name]['annotations'].append({
                         'task': annotation['task'],

--- a/panoptes_aggregation/extractors/line_text_extractor.py
+++ b/panoptes_aggregation/extractors/line_text_extractor.py
@@ -44,7 +44,7 @@ def line_text_extractor(classification):
         text = value['details'][0]['value']
         x = [value['x1'], value['x2']]
         y = [value['y1'], value['y2']]
-        if len(x) > 1:
+        if (len(x) > 1) and (x[0] != x[-1]):
             fit = np.polyfit(x, y, 1)
             y_fit = np.polyval(fit, [x[0], x[-1]])
             dx = x[-1] - x[0]

--- a/panoptes_aggregation/extractors/line_text_extractor.py
+++ b/panoptes_aggregation/extractors/line_text_extractor.py
@@ -44,7 +44,7 @@ def line_text_extractor(classification):
         text = value['details'][0]['value']
         x = [value['x1'], value['x2']]
         y = [value['y1'], value['y2']]
-        if (len(x) > 1) and (x[0] != x[-1]):
+        if (len(x) > 1) and (not np.isclose(x[0], x[-1], atol=0.01)):
             fit = np.polyfit(x, y, 1)
             y_fit = np.polyval(fit, [x[0], x[-1]])
             dx = x[-1] - x[0]

--- a/panoptes_aggregation/extractors/poly_line_text_extractor.py
+++ b/panoptes_aggregation/extractors/poly_line_text_extractor.py
@@ -77,7 +77,7 @@ def poly_line_text_extractor(classification, dot_freq='word'):
         text = value['details'][0]['value']
         x = [point['x'] for point in value['points']]
         y = [point['y'] for point in value['points']]
-        if len(x) > 1:
+        if (len(x) > 1) and (not np.isclose(np.min(x), np.max(x), atol=0.01)):
             fit = np.polyfit(x, y, 1)
             y_fit = np.polyval(fit, [x[0], x[-1]])
             dx = x[-1] - x[0]

--- a/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
@@ -56,6 +56,41 @@ annotation = [
                 'text': 'All the words'
             }
         ]
+    }, {
+        'task': 'T4',
+        'task_label': 'Draw poly and transcribe',
+        'value': [
+            {
+                "tool": 0,
+                "frame": 0,
+                "closed": True,
+                "points": [
+                    {"x": 749.7457275390625, "y": 139.9468231201172},
+                    {"x": 1373.24658203125, "y": 128.85250854492188}
+                ],
+                "details": [
+                    {"value": "John's Island Sept 18th 1856"}
+                ],
+                "tool_label": "Poly"
+            }
+        ]
+    }, {
+        'task': 'T5',
+        'task_label': 'Draw line and transcribe',
+        'value': [
+            {
+                'tool': 0,
+                'frame': 0,
+                'x1': 749.7457275390625,
+                'y1': 139.9468231201172,
+                'x2': 1373.24658203125,
+                'y2': 128.85250854492188,
+                'details': [
+                    {'value': "John's Island Sept 18th 1856"}
+                ],
+                'tool_label': 'Line'
+            }
+        ]
     }
 ]
 
@@ -80,7 +115,13 @@ config = {
     },
     'T1': 'question_extractor',
     'T2': 'question_extractor',
-    'T3': ['sw_extractor', 'sw_graphic_extractor']
+    'T3': ['sw_extractor', 'sw_graphic_extractor'],
+    'T4': {
+        'poly_line_text_extractor': {'tool': [0]}
+    },
+    'T5': {
+        'line_text_extractor': {'tool': [0]}
+    }
 }
 
 
@@ -174,6 +215,45 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }]
+            },
+            'poly_line_text_extractor': {
+                'annotations': [{
+                    'task': 'T4',
+                    'value': [
+                        {
+                            "tool": 0,
+                            "frame": 0,
+                            "closed": True,
+                            "points": [
+                                {"x": 749.7457275390625, "y": 139.9468231201172},
+                                {"x": 1373.24658203125, "y": 128.85250854492188}
+                            ],
+                            "details": [
+                                {"value": "John's Island Sept 18th 1856"}
+                            ]
+                        }
+                    ]
+                }],
+                'config': {}
+            },
+            'line_text_extractor': {
+                'annotations': [{
+                    'task': 'T5',
+                    'value': [
+                        {
+                            'tool': 0,
+                            'frame': 0,
+                            'x1': 749.7457275390625,
+                            'y1': 139.9468231201172,
+                            'x2': 1373.24658203125,
+                            'y2': 128.85250854492188,
+                            'details': [
+                                {'value': "John's Island Sept 18th 1856"}
+                            ]
+                        }
+                    ]
+                }],
+                'config': {}
             }
         }
         result = filter_annotations(self.annotation, config)
@@ -273,6 +353,49 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }]
+            },
+            'poly_line_text_extractor': {
+                'annotations': [{
+                    'task': 'T4',
+                    'task_label': 'Draw poly and transcribe',
+                    'value': [
+                        {
+                            "tool": 0,
+                            "frame": 0,
+                            "closed": True,
+                            "points": [
+                                {"x": 749.7457275390625, "y": 139.9468231201172},
+                                {"x": 1373.24658203125, "y": 128.85250854492188}
+                            ],
+                            "details": [
+                                {"value": "John's Island Sept 18th 1856"}
+                            ],
+                            "tool_label": "Poly"
+                        }
+                    ]
+                }],
+                'config': {}
+            },
+            'line_text_extractor': {
+                'annotations': [{
+                    'task': 'T5',
+                    'task_label': 'Draw line and transcribe',
+                    'value': [
+                        {
+                            'tool': 0,
+                            'frame': 0,
+                            'x1': 749.7457275390625,
+                            'y1': 139.9468231201172,
+                            'x2': 1373.24658203125,
+                            'y2': 128.85250854492188,
+                            'details': [
+                                {'value': "John's Island Sept 18th 1856"}
+                            ],
+                            'tool_label': 'Line'
+                        }
+                    ]
+                }],
+                'config': {}
             }
         }
         result = filter_annotations(self.annotation, config, human=True)


### PR DESCRIPTION
Fix issue #61 by defaulting to and empty `details` array when it is not in the config object.  Tests have been added to reproduce the original error. 

This also fixes a numpy warning when processing DCW data. When finding the slope of a line of transcribed text make sure the endpoints are far apart.  DCW has some endpoints that are on top of each other (not sure how the front end allowed this...).
