### PR TITLE
Fix #64 by mapping `line_text_reducer` to `poly_line_text_reducer`

### DIFF
--- a/bin/reduce_panoptes_csv.py
+++ b/bin/reduce_panoptes_csv.py
@@ -41,7 +41,7 @@ def reduce_csv(extracted_csv, filter='first', keywords={}, output='reductions', 
     workflow_id = extracted.workflow_id.iloc[0]
     extractor_name = extracted.extractor.iloc[0]
     reducer_name = extractor_name.replace('extractor', 'reducer')
-    if reducer_name == 'sw_reducer':
+    if (reducer_name == 'sw_reducer') or (reducer_name == 'line_text_reducer'):
         reducer_name = 'poly_line_text_reducer'
     if reducer_name == 'sw_graphic_reducer':
         reducer_name = 'rectangle_reducer'


### PR DESCRIPTION
Forgot to map this value when I wrote the extractor.  Note this only affected offline reductions when the reducers are auto-detected.  The Caesar configs are fine since the reducers need to be identified by hand.