### PR TITLE
Let keywords be passed to extractors in offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a collection of external reducers written for [caesar](https://github.com/zooniverse/caesar) and offline use.
 
 # Documentation
-https://zooniverse.github.io/aggregation-for-caesar/
+https://aggregation-caesar.zooniverse.org/docs
 
 # Offline use
 To install (python 3 only):
@@ -22,8 +22,10 @@ You will need two files for offline use:
 Note: this only works for question tasks and the drawing tool's point data at the moment
 
 Use the command line tool to extract your data into one flat `csv` file for each extractor used:
+
 ```bash
-usage: extract_panoptes_csv.py [-h] [-v VERSION] [-H] [-o OUTPUT]
+usage: extract_panoptes_csv.py [-h] [-v VERSION] [-k KEYWORDS] [-H] [-O]
+                               [-o OUTPUT]
                                classification_csv workflow_csv workflow_id
 
 extract data from panoptes classifications based on the workflow
@@ -38,8 +40,15 @@ optional arguments:
   -h, --help            show this help message and exit
   -v VERSION, --version VERSION
                         the workflow version to extract
+  -k KEYWORDS, --keywords KEYWORDS
+                        keywords to be passed into the extractor for a task in
+                        the form of a json string, e.g. '{"T0": {"dot_freq":
+                        "line"} }' (note: double quotes must be used inside
+                        the brackets)
   -H, --human           switch to make the data column labels use the task and
                         question labels instead of generic labels
+  -O, --order           arrange the data columns in alphabetical order before
+                        saving
   -o OUTPUT, --output OUTPUT
                         the base name for output csv file to store the
                         annotation extractions (one file will be created for

--- a/panoptes_aggregation/extractors/filter_annotations.py
+++ b/panoptes_aggregation/extractors/filter_annotations.py
@@ -6,8 +6,11 @@ def filter_annotations(annotations, config, human=False):
     for annotation in annotations:
         if annotation['task'] in config:
             if isinstance(config[annotation['task']], dict):
+                keywords = config[annotation['task']].pop('keywords', None)
                 for extractor_name, tool_config in config[annotation['task']].items():
                     annotations_by_extractor.setdefault(extractor_name, {'annotations': [], 'config': {}})
+                    if keywords is not None:
+                        annotations_by_extractor[extractor_name]['keywords'] = keywords
                     if len(tool_config.get('details', [])) > 0:
                         annotations_by_extractor[extractor_name]['config'] = {'details': tool_config['details']}
                     annotations_by_extractor[extractor_name]['annotations'].append({

--- a/panoptes_aggregation/extractors/workflow_extractor_config.py
+++ b/panoptes_aggregation/extractors/workflow_extractor_config.py
@@ -8,7 +8,7 @@ type_to_extractor = {
 }
 
 
-def workflow_extractor_config(tasks):
+def workflow_extractor_config(tasks, keywords={}):
     extractor_config = {}
     if tasks == {'init': {'question': 'init.question', 'type': 'single', 'answers': []}}:
         # this is Shakespeares World, return the correct config
@@ -50,6 +50,8 @@ def workflow_extractor_config(tasks):
                                     details_functions.append(None)
                             tools_config[tool_key]['details'][detail_key] = details_functions
             extractor_config[task_key] = tools_config
+            if task_key in keywords:
+                extractor_config[task_key]['keywords'] = keywords[task_key]
         elif task['type'] in type_to_extractor:
             extractor_config[task_key] = type_to_extractor[task['type']]
     return extractor_config

--- a/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_filter_annotations.py
@@ -117,10 +117,12 @@ config = {
     'T2': 'question_extractor',
     'T3': ['sw_extractor', 'sw_graphic_extractor'],
     'T4': {
-        'poly_line_text_extractor': {'tool': [0]}
+        'poly_line_text_extractor': {'tool': [0]},
+        'keywords': {'dot_freq': 'line'}
     },
     'T5': {
-        'line_text_extractor': {'tool': [0]}
+        'line_text_extractor': {'tool': [0]},
+        'keywords': {'dot_freq': 'word'}
     }
 }
 
@@ -128,6 +130,7 @@ config = {
 class TestFilterAnnotations(unittest.TestCase):
     def setUp(self):
         self.annotation = copy.deepcopy(annotation)
+        self.config = copy.deepcopy(config)
         self.maxDiff = None
 
     def test_filter(self):
@@ -234,7 +237,8 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }],
-                'config': {}
+                'config': {},
+                'keywords': {'dot_freq': 'line'}
             },
             'line_text_extractor': {
                 'annotations': [{
@@ -253,10 +257,11 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }],
-                'config': {}
+                'config': {},
+                'keywords': {'dot_freq': 'word'}
             }
         }
-        result = filter_annotations(self.annotation, config)
+        result = filter_annotations(self.annotation, self.config)
         self.assertDictEqual(result, expected_result)
 
     def test_filter_human(self):
@@ -374,7 +379,8 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }],
-                'config': {}
+                'config': {},
+                'keywords': {'dot_freq': 'line'}
             },
             'line_text_extractor': {
                 'annotations': [{
@@ -395,10 +401,11 @@ class TestFilterAnnotations(unittest.TestCase):
                         }
                     ]
                 }],
-                'config': {}
+                'config': {},
+                'keywords': {'dot_freq': 'word'}
             }
         }
-        result = filter_annotations(self.annotation, config, human=True)
+        result = filter_annotations(self.annotation, self.config, human=True)
         self.assertDictEqual(result, expected_result)
 
 

--- a/panoptes_aggregation/tests/extractor_tests/test_workflow_extractor_config.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_workflow_extractor_config.py
@@ -127,6 +127,11 @@ tasks = {
     }
 }
 
+keywords = {
+    'T4': {'dot_freq': 'line'},
+    'T5': {'dot_freq': 'word'}
+}
+
 expected = {
     'T0': {
         'point_extractor': {
@@ -150,10 +155,12 @@ expected = {
     'T2': 'question_extractor',
     'T3': 'survey_extractor',
     'T4': {
-        'poly_line_text_extractor': {'tool': [0]}
+        'poly_line_text_extractor': {'tool': [0]},
+        'keywords': {'dot_freq': 'line'}
     },
     'T5': {
-        'line_text_extractor': {'tool': [0]}
+        'line_text_extractor': {'tool': [0]},
+        'keywords': {'dot_freq': 'word'}
     }
 }
 
@@ -161,7 +168,7 @@ expected = {
 class TestWorkflowExtractorConfig(unittest.TestCase):
     def test_config(self):
         '''Test workflow auto config works'''
-        result = workflow_extractor_config(tasks)
+        result = workflow_extractor_config(tasks, keywords=keywords)
         self.assertDictEqual(result, expected)
 
 

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -249,6 +249,13 @@ extracted_data = [
                 -38.990998547208093
             ]
         }
+    },
+    {
+        'frame2': {
+            'points': {'x': [[1, 180, 250]], 'y': [[1, 1, 1]]},
+            'text': [['some', 'words']],
+            'slope': [0]
+        }
     }
 ]
 
@@ -448,6 +455,16 @@ processed_data = {
             0,
             0
         ]
+    },
+    'frame2': {
+        'x': [
+            [1, 180, 250]
+        ],
+        'y': [
+            [1, 1, 1]
+        ],
+        'text': [['some', 'words']],
+        'slope': [0]
     }
 }
 
@@ -683,6 +700,30 @@ reduced_data = {
             'line_slope': 0.0,
             'slope_label': 0
         }
+    ],
+    'frame2': [
+        {
+            'clusters_x': [
+                1,
+                180,
+                250
+            ],
+            'clusters_y': [
+                1.0,
+                1.0,
+                1.0
+            ],
+            'clusters_text': [
+                ['some'],
+                ['words'],
+                ['']
+            ],
+            'number_views': 1,
+            'consensus_score': 1.0,
+            'gutter_label': 0,
+            'line_slope': 0.0,
+            'slope_label': 0
+        }
     ]
 }
 
@@ -903,6 +944,20 @@ processed_data_by_line = {
             0,
             0
         ]
+    },
+    'frame2': {
+        'x': [
+            [1, 250]
+        ],
+        'y': [
+            [1, 1]
+        ],
+        'text': [
+            ['some words']
+        ],
+        'slope': [
+            0
+        ]
     }
 }
 
@@ -1087,6 +1142,21 @@ reduced_data_by_line = {
             ],
             'number_views': 2,
             'consensus_score': 2.0,
+            'gutter_label': 0,
+            'line_slope': 0.0,
+            'slope_label': 0
+        }
+    ],
+    'frame2': [
+        {
+            'clusters_x': [1, 250],
+            'clusters_y': [1, 1],
+            'clusters_text': [
+                ['some'],
+                ['words']
+            ],
+            'number_views': 1,
+            'consensus_score': 1.0,
             'gutter_label': 0,
             'line_slope': 0.0,
             'slope_label': 0


### PR DESCRIPTION
The `-k` switch can be used for the extractor with optional keywords
that can be passed by task id.  This is needed for offline extraction of
text workflows like ASM.