### PR TITLE
Fixes crash when `None` is passed in as a data value

### DIFF
--- a/panoptes_aggregation/reducers/point_reducer.py
+++ b/panoptes_aggregation/reducers/point_reducer.py
@@ -76,13 +76,15 @@ def point_reducer(data_by_tool, **kwargs):
     '''
     clusters = OrderedDict()
     for tool, loc_list in data_by_tool.items():
-        loc = np.array(loc_list)
+        # clean `None` values for the list
+        loc_list_clean = [xy for xy in loc_list if None not in xy]
+        loc = np.array(loc_list_clean)
         # orignal data points in order used by cluster code
         clusters['{0}_points_x'.format(tool)] = list(loc[:, 0])
         clusters['{0}_points_y'.format(tool)] = list(loc[:, 1])
         # default each point in no cluster
         clusters['{0}_cluster_labels'.format(tool)] = [-1] * loc.shape[0]
-        if loc.shape[0] > kwargs['min_samples']:
+        if loc.shape[0] >= kwargs['min_samples']:
             db = DBSCAN(**kwargs).fit(loc)
             # what cluster each point belongs to
             clusters['{0}_cluster_labels'.format(tool)] = list(db.labels_)

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer.py
@@ -17,8 +17,8 @@ extracted_data = [
     {
         'tool1_x': list(xy[:12, 0]),
         'tool1_y': list(xy[:12, 1]),
-        'tool2_x': [3],
-        'tool2_y': [4]
+        'tool2_x': [3, None, None],
+        'tool2_y': [4, None, None]
     },
     {
         'tool1_x': list(xy[12:, 0]),
@@ -27,7 +27,7 @@ extracted_data = [
 ]
 processed_data = {
     'tool1': [tuple(z) for z in list(xy)],
-    'tool2': [(3, 4)]
+    'tool2': [(3, 4), (None, None), (None, None)]
 }
 reduced_data = {
     'tool1_points_x': list(xy[:, 0]),


### PR DESCRIPTION
All rows of data with `None` in them are removed before clustering.  A
test was added for this case.  Also the `min_sample` check was adjusted
to `>=` instead of `>`, this was a typo in the first place.

The `None` values come from the "shortcut" task.