### PR TITLE
run extract / reduce scripts in local docker image

### DIFF
--- a/Dockerfile.bin_cmds
+++ b/Dockerfile.bin_cmds
@@ -1,0 +1,17 @@
+FROM python:3
+
+ENV LANG=C.UTF-8
+
+WORKDIR /usr/src/aggregation
+
+# install requirements
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+RUN pip install .
+
+# make documentation
+RUN /bin/bash -lc ./make_docs.sh
+
+CMD python routes.py

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ cd aggregation-for-caesar
 pip install .
 ```
 
+Or use the docker image provided
+```
+`docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar`
+
+From the root directory of this repository, run cmds using the docker image
+docker run -it --rm --name extract_panoptes_csv -v "$PWD":/usr/src/aggregation aggregation_for_caesar python bin/extract_panoptes_csv.py --help
+```
+
 ## Download your data from the project builder
 You will need two files for offline use:
  - The classification dump: The `Request new classification export` or `Request new workflow classification export` button from the lab's `Data Export` tab

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker-compose -f docker-compose.local_scripts.yml run --rm local_scripts python
 ```
 **Or directly via docker**
 ```
-docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar`
+docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar
 ```
 From the root directory of this repository, run the desirect python scripts using the docker image, e.g. `extract_panoptes_csv.py --help`
 ```

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ pip install .
 
 Or use the docker image provided
 ```
-`docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar`
-
-From the root directory of this repository, run cmds using the docker image
+docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar`
+```
+From the root directory of this repository, run the desirect python scripts using the docker image, e.g. `extract_panoptes_csv.py --help`
+```
 docker run -it --rm --name extract_panoptes_csv -v "$PWD":/usr/src/aggregation aggregation_for_caesar python bin/extract_panoptes_csv.py --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a collection of external reducers written for [caesar](https://github.co
 https://aggregation-caesar.zooniverse.org/docs
 
 # Offline use
+### With your own python install
 To install (python 3 only):
 ```bash
 git clone https://github.com/zooniverse/aggregation-for-caesar.git
@@ -13,7 +14,19 @@ cd aggregation-for-caesar
 pip install .
 ```
 
-Or use the docker image provided
+### With Docker
+https://docs.docker.com/get-started/
+
+**Using docker-compose** https://docs.docker.com/compose/
+```
+docker-compose -f docker-compose.local_scripts.yml build local_scripts
+```
+From the root directory of this repository, run the desirect python scripts using the docker image, e.g. `extract_panoptes_csv.py --help`
+```
+docker-compose -f docker-compose.local_scripts.yml run --rm local_scripts python bin/extract_panoptes_csv.py --help
+
+```
+**Or directly via docker**
 ```
 docker build . -f Dockerfile.bin_cmds -t aggregation_for_caesar`
 ```

--- a/docker-compose.local_scripts.yml
+++ b/docker-compose.local_scripts.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  local_scripts:
+    build:
+      context: ./
+      dockerfile: Dockerfile.bin_cmds
+    volumes:
+      - ./:/usr/src/aggregation


### PR DESCRIPTION
added instructions to run extract / reduce scripts via a custom locally built docker image. The docker image needed the extra PIP install to run the local code vs as a web server. 

I wasn't sure what CMD to leave in there maybe we could default to one that prints instructions if needed? Happy to rework this as needed.