### PR TITLE
Ability to extract drawing tasks by tool

### DIFF
--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -23,6 +23,8 @@ def extractor_wrapper(func):
             kwargs = argument.args.copy().to_dict()
             if 'details' in kwargs:
                 kwargs['details'] = ast.literal_eval(kwargs['details'])
+            if 'tools' in kwargs:
+                kwargs['tools'] = ast.literal_eval(kwargs['tools'])
             task = kwargs.pop('task', 'all')
             data = argument.get_json()
             annotations = data['annotations']

--- a/panoptes_aggregation/extractors/line_text_extractor.py
+++ b/panoptes_aggregation/extractors/line_text_extractor.py
@@ -9,9 +9,11 @@ from collections import OrderedDict
 import copy
 import numpy as np
 from .extractor_wrapper import extractor_wrapper
+from .tool_wrapper import tool_wrapper
 
 
 @extractor_wrapper
+@tool_wrapper
 def line_text_extractor(classification):
     '''Extract annotations from a line tool with a text sub-task
 

--- a/panoptes_aggregation/extractors/point_extractor.py
+++ b/panoptes_aggregation/extractors/point_extractor.py
@@ -6,9 +6,11 @@ This module provides a function to extract drawn points from panoptes annotation
 from collections import OrderedDict
 from slugify import slugify
 from .extractor_wrapper import extractor_wrapper
+from .tool_wrapper import tool_wrapper
 
 
 @extractor_wrapper
+@tool_wrapper
 def point_extractor(classification):
     '''Extract annotations from a point drawing tool into lists.
     This extractor does *not* support extraction from multi-frame subjects or

--- a/panoptes_aggregation/extractors/point_extractor_by_frame.py
+++ b/panoptes_aggregation/extractors/point_extractor_by_frame.py
@@ -7,9 +7,11 @@ from collections import OrderedDict
 from slugify import slugify
 from .extractor_wrapper import extractor_wrapper
 from .subtask_extractor_wrapper import subtask_wrapper
+from .tool_wrapper import tool_wrapper
 
 
 @extractor_wrapper
+@tool_wrapper
 @subtask_wrapper
 def point_extractor_by_frame(classification):
     '''Extract annotations from a point drawing tool into lists

--- a/panoptes_aggregation/extractors/poly_line_text_extractor.py
+++ b/panoptes_aggregation/extractors/poly_line_text_extractor.py
@@ -9,9 +9,11 @@ from collections import OrderedDict
 import copy
 import numpy as np
 from .extractor_wrapper import extractor_wrapper
+from .tool_wrapper import tool_wrapper
 
 
 @extractor_wrapper
+@tool_wrapper
 def poly_line_text_extractor(classification, dot_freq='word'):
     '''Extract annotations from a polygon tool with a text sub-task
 

--- a/panoptes_aggregation/extractors/rectangle_extractor.py
+++ b/panoptes_aggregation/extractors/rectangle_extractor.py
@@ -6,9 +6,11 @@ This module provides a function to extract drawn rectangles from panoptes annota
 from collections import OrderedDict
 from .extractor_wrapper import extractor_wrapper
 from .subtask_extractor_wrapper import subtask_wrapper
+from .tool_wrapper import tool_wrapper
 
 
 @extractor_wrapper
+@tool_wrapper
 @subtask_wrapper
 def rectangle_extractor(classification):
     '''Extact rectangle dtata from annotation

--- a/panoptes_aggregation/extractors/tool_wrapper.py
+++ b/panoptes_aggregation/extractors/tool_wrapper.py
@@ -1,0 +1,16 @@
+from functools import wraps
+
+
+def tool_wrapper(func):
+    @wraps(func)
+    def wrapper(data, **kwargs):
+        if 'tools' in kwargs:
+            tools = kwargs.pop('tools')
+            for annotation in data['annotations']:
+                new_value = []
+                for v in annotation['value']:
+                    if v['tool'] in tools:
+                        new_value.append(v)
+                annotation['value'] = new_value
+        return func(data, **kwargs)
+    return wrapper

--- a/panoptes_aggregation/tests/extractor_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/extractor_tests/base_test_class.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 import json
 import flask
@@ -18,7 +19,7 @@ def ExtractorTest(function, classification, expected, name, rkwargs={}, fkwargs=
 
         def test_extract(self):
             '''Test the offline extract function'''
-            result = function(classification, **fkwargs)
+            result = function(copy.deepcopy(classification), **fkwargs)
             if test_type == 'assertDictEqual':
                 self.assertDictEqual(dict(result), expected)
             else:
@@ -27,7 +28,7 @@ def ExtractorTest(function, classification, expected, name, rkwargs={}, fkwargs=
         def test_request(self):
             '''Test the online extract function'''
             request_kwargs = {
-                'data': json.dumps(annotation_by_task(classification)),
+                'data': json.dumps(annotation_by_task(copy.deepcopy(classification))),
                 'content_type': 'application/json'
             }
             app = flask.Flask(__name__)
@@ -56,7 +57,7 @@ def TextExtractorTest(function, classification, expected, name, kwargs={}):
 
         def test_extract(self):
             '''Test the offline extract function'''
-            result = function(classification, **kwargs)
+            result = function(copy.deepcopy(classification), **kwargs)
             for i in expected.keys():
                 with self.subTest(i=i):
                     self.assertIn(i, result)
@@ -71,7 +72,7 @@ def TextExtractorTest(function, classification, expected, name, kwargs={}):
         def test_request(self):
             '''Test the online extract function'''
             request_kwargs = {
-                'data': json.dumps(annotation_by_task(classification)),
+                'data': json.dumps(annotation_by_task(copy.deepcopy(classification))),
                 'content_type': 'application/json'
             }
             app = flask.Flask(__name__)

--- a/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
@@ -140,3 +140,11 @@ TestLineText = TextExtractorTest(
     expected,
     'Test line-text extractor'
 )
+
+TestLineTextTool = TextExtractorTest(
+    extractors.line_text_extractor,
+    classification,
+    expected,
+    'Test line-text extractor with tool specified',
+    kwargs={'tools': [0]}
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
@@ -115,3 +115,26 @@ TestPointTask = ExtractorTest(
     'Test point with task specified',
     rkwargs={'task': 'T0'}
 )
+
+TestPointAllTools = ExtractorTest(
+    extractors.point_extractor,
+    classification,
+    expected,
+    'Test point with all tools specified',
+    rkwargs={'task': 'T0'},
+    fkwargs={'tools': [0, 1]}
+)
+
+expected_0 = {
+    'T0_tool0_x': expected['T0_tool0_x'],
+    'T0_tool0_y': expected['T0_tool0_y']
+}
+
+TestPointOneTool = ExtractorTest(
+    extractors.point_extractor,
+    classification,
+    expected_0,
+    'Test point with one tool specified',
+    rkwargs={'task': 'T0'},
+    fkwargs={'tools': [0]}
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_point_extractor_by_frame.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_point_extractor_by_frame.py
@@ -103,17 +103,42 @@ expected = {
     }
 }
 
-TestPoint = ExtractorTest(
+TestPointByFrame = ExtractorTest(
     extractors.point_extractor_by_frame,
     classification,
     expected,
-    'Test point'
+    'Test point by frame'
 )
 
-TestPointTask = ExtractorTest(
+TestPointByFrameTask = ExtractorTest(
     extractors.point_extractor_by_frame,
     classification,
     expected,
-    'Test point with task specified',
+    'Test point by frame with task specified',
     rkwargs={'task': 'T0'}
+)
+
+TestPointByFrameAllTools = ExtractorTest(
+    extractors.point_extractor_by_frame,
+    classification,
+    expected,
+    'Test point by frame with all tools specified',
+    rkwargs={'task': 'T0'},
+    fkwargs={'tools': [0, 1]}
+)
+
+expected_0 = {
+    'frame0': {
+        'T0_tool0_x': expected['frame0']['T0_tool0_x'],
+        'T0_tool0_y': expected['frame0']['T0_tool0_y']
+    }
+}
+
+TestPointByFrameOneTool = ExtractorTest(
+    extractors.point_extractor_by_frame,
+    classification,
+    expected_0,
+    'Test point by frame with one tool specified',
+    rkwargs={'task': 'T0'},
+    fkwargs={'tools': [0]}
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor.py
@@ -179,3 +179,11 @@ TestPolyLineText = TextExtractorTest(
     expected,
     'Test poly-line-text extractor by word'
 )
+
+TestPolyLineTextTool = TextExtractorTest(
+    extractors.poly_line_text_extractor,
+    classification,
+    expected,
+    'Test poly-line-text extractor by word with tool specified',
+    kwargs={'tools': [0]}
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
@@ -135,10 +135,18 @@ expected = {
     }
 }
 
-TestPolyLineText = TextExtractorTest(
+TestPolyLineTextByLine = TextExtractorTest(
     extractors.poly_line_text_extractor,
     classification,
     expected,
     'Test poly-line-text extractor by line',
     kwargs={'dot_freq': 'line'}
+)
+
+TestPolyLineTextByLineTool = TextExtractorTest(
+    extractors.poly_line_text_extractor,
+    classification,
+    expected,
+    'Test poly-line-text extractor by line with tool specified',
+    kwargs={'dot_freq': 'line', 'tools': [0]}
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_rectangle_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_rectangle_extractor.py
@@ -68,3 +68,39 @@ TestRectangle = ExtractorTest(
     expected,
     'Test rectangle'
 )
+
+TestRectangleTask = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected,
+    'Test rectangle with task specified',
+    rkwargs={'task': 'T2'}
+)
+
+TestRectangleAllTools = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected,
+    'Test rectangle with all tools specified',
+    rkwargs={'task': 'T2'},
+    fkwargs={'tools': [0, 1]}
+)
+
+expected_0 = {
+    'frame0': {
+        'T2_tool0_x': expected['frame0']['T2_tool0_x'],
+        'T2_tool0_y': expected['frame0']['T2_tool0_y'],
+        'T2_tool0_width': expected['frame0']['T2_tool0_width'],
+        'T2_tool0_height': expected['frame0']['T2_tool0_height']
+    },
+    'frame1': expected['frame1']
+}
+
+TestRectangleOneTool = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected_0,
+    'Test rectangle one tool specified',
+    rkwargs={'task': 'T2'},
+    fkwargs={'tools': [0]}
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor.py
@@ -120,3 +120,83 @@ TestSubtask = ExtractorTest(
         }
     }
 )
+
+TestSubtaskTask = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected,
+    'Test subtask extraction with task specified',
+    rkwargs={'task': 'T0'},
+    fkwargs={
+        'details': {
+            'T0_tool0': [
+                'question_extractor',
+                'question_extractor',
+                'dropdown_extractor'
+            ]
+        }
+    }
+)
+
+TestSubtaskAllTools = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected,
+    'Test subtask extraction with all tools specified',
+    fkwargs={
+        'tools': [0, 1],
+        'details': {
+            'T0_tool0': [
+                'question_extractor',
+                'question_extractor',
+                'dropdown_extractor'
+            ]
+        }
+    }
+)
+
+expected_0 = {
+    'frame0': {
+        'T0_tool0_x': [0, 100],
+        'T0_tool0_y': [0, 105],
+        'T0_tool0_width': [5, 50],
+        'T0_tool0_height': [10, 100],
+        'T0_tool0_details': [
+            [
+                {'0': 1},
+                {'1': 1, '0': 1},
+                {'value': [
+                    {'option-1': 1},
+                    {'option-2': 1},
+                    {'None': 1}
+                ]}
+            ],
+            [
+                {'1': 1},
+                {'0': 1},
+                {'value': [
+                    {'option-3': 1},
+                    {'option-4': 1},
+                    {'option-5': 1}
+                ]}
+            ]
+        ]
+    }
+}
+
+TestSubtaskOneTool = ExtractorTest(
+    extractors.rectangle_extractor,
+    classification,
+    expected_0,
+    'Test subtask extraction with one tool specified',
+    fkwargs={
+        'tools': [0],
+        'details': {
+            'T0_tool0': [
+                'question_extractor',
+                'question_extractor',
+                'dropdown_extractor'
+            ]
+        }
+    }
+)


### PR DESCRIPTION
This PR adds the ability to pass in the `tools` keyword to any drawing tool extractor.  This should be a list of tool ID numbers to be included in the extract.  Example `tools=[0, 1, 3]`.

Tests have also been added to all drawing tools using this keyword.  Some conflicting test names were also fixed so all test now run as expected.