### PR TITLE
Add shortcut task extractor and reducer

### DIFF
--- a/docs/source/Task_lookup_table.rst
+++ b/docs/source/Task_lookup_table.rst
@@ -12,6 +12,8 @@ Basic task types
 | Single Question   | :mod:`panoptes_aggregation.extractors.question_extractor`            | :mod:`panoptes_aggregation.reducers.question_reducer`              |
 +-------------------+                                                                      |                                                                    |
 | Multiple Question |                                                                      |                                                                    |
++-------------------+                                                                      |                                                                    |
+| Shortcut          |                                                                      |                                                                    |
 +-------------------+----------------------------------------------------------------------+--------------------------------------------------------------------+
 | Dropdown          | :mod:`panoptes_aggregation.extractors.dropdown_extractor`            | :mod:`panoptes_aggregation.reducers.dropdown_reducer`              |
 +-------------------+----------------------------------------------------------------------+--------------------------------------------------------------------+

--- a/panoptes_aggregation/scripts/config_workflow_panoptes.py
+++ b/panoptes_aggregation/scripts/config_workflow_panoptes.py
@@ -28,10 +28,8 @@ def config_workflow(workflow_csv, workflow_id, version=None, keywords={}, workfl
         warnings.warn('No major workflow version was specified, defaulting to version {0}'.format(version))
 
     wdx = (workflows.workflow_id == workflow_id) & (workflows.version == version)
-    if wdx.sum() == 0:
-        raise IndexError('workflow ID and workflow major version combination does not exist')
-    if wdx.sum() > 1:
-        raise IndexError('workflow ID and workflow major version combination is not unique')
+    assert (wdx.sum() > 0), 'workflow ID and workflow major version combination does not exist'
+    assert (wdx.sum() == 1), 'workflow ID and workflow major version combination is not unique'
     workflow = workflows[wdx].iloc[0]
     workflow_tasks = json.loads(workflow.tasks)
     extractor_config = workflow_extractor_config(workflow_tasks, keywords=keywords)

--- a/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
+++ b/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
@@ -124,6 +124,14 @@ tasks = {
             }
         ],
         'instruction': 'T5.instruction'
+    },
+    'T6': {
+        'type': 'shortcut',
+        'question': 'T6.question',
+        'answers': [
+            {'label': 'T6.answers.0.label'},
+            {'label': 'T6.answers.1.label'}
+        ]
     }
 }
 
@@ -154,7 +162,8 @@ extractor_config = {
     ],
     'question_extractor': [
         {'task': 'T1'},
-        {'task': 'T2'}
+        {'task': 'T2'},
+        {'task': 'T6'}
     ],
     'survey_extractor': [
         {'task': 'T3'}

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 type_to_extractor = {
     'single': 'question_extractor',
     'multiple': 'question_extractor',
+    'shortcut': 'question_extractor',
     'dropdown': 'dropdown_extractor',
     'survey': 'survey_extractor',
     'point': 'point_extractor_by_frame',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except FileNotFoundError:
 
 setup(
     name='panoptes_aggregation',
-    version='1.0.0',
+    version='1.1.0',
     description='Aggregation code for Zooniverse panoptes projects.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Set up the shortcut task to use the question extractor and reducer.  This task has the same annotation format as a multi-question task.

There is also a small bug fix to make sure workflow version numbers are processed correctly in the offline extraction code.