### PR TITLE
Remove explicit cython install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: "python"
 python:
   - "3.6"
 install:
+  - pip install --upgrade pip
   - pip install -U .[online,test,doc]
 script: nosetests
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: "python"
 python:
   - "3.6"
 install:
-  - pip install --upgrade pip
+  - pip install -U pip
   - pip install -U .[online,test,doc]
 script: nosetests
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: "python"
 python:
   - "3.6"
 install:
-  - pip install cython
   - pip install -U .[online,test,doc]
 script: nosetests
 notifications:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ WORKDIR /usr/src/aggregation
 
 RUN pip install --upgrade pip
 
-# this line is still needed until hdbscan pushes to pip next
-RUN pip install cython numpy
-
 # install dependencies
 COPY setup.py .
 RUN pip install .[online,test,doc]

--- a/Dockerfile.bin_cmds
+++ b/Dockerfile.bin_cmds
@@ -6,9 +6,6 @@ WORKDIR /usr/src/aggregation
 
 RUN pip install --upgrade pip
 
-# this line is still needed until hdbscan pushes to pip next
-RUN pip install cython numpy
-
 # install dependencies
 COPY setup.py .
 RUN pip install .[test]

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Upgrade and existing installation:
 pip install -U panoptes_aggregation
 ```
 
-If you see an error about `Cython` not being installed run `pip install cython` and try `pip install .` again.
-
 ### With Docker
 [https://docs.docker.com/get-started/](https://docs.docker.com/get-started/)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'collatex==2.1.2',
         'hdbscan',
         'lxml',
-        'numpy',
+        'numpy>=1.14.5',
         'nose',
         'pandas',
         'progressbar2',


### PR DESCRIPTION
HDBSCAN has been updated on pip so cython dependency is handled correctly.

This closes #85