### PR TITLE
Seprate shortcut task to separate extractor and reducer

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -17,6 +17,7 @@ extractors = {
     'point_extractor_by_frame': point_extractor_by_frame,
     'rectangle_extractor': rectangle_extractor,
     'question_extractor': question_extractor,
+    'shortcut_extractor': question_extractor,
     'survey_extractor': survey_extractor,
     'poly_line_text_extractor': poly_line_text_extractor,
     'line_text_extractor': line_text_extractor,

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -20,6 +20,7 @@ reducers = {
     'point_reducer_hdbscan': point_reducer_hdbscan,
     'rectangle_reducer': rectangle_reducer,
     'question_reducer': question_reducer,
+    'shortcut_reducer': question_reducer,
     'survey_reducer': survey_reducer,
     'poly_line_text_reducer': poly_line_text_reducer,
     'sw_variant_reducer': sw_variant_reducer,

--- a/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
+++ b/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
@@ -180,7 +180,9 @@ extractor_config = {
     ],
     'question_extractor': [
         {'task': 'T1'},
-        {'task': 'T2'},
+        {'task': 'T2'}
+    ],
+    'shortcut_extractor': [
         {'task': 'T6'}
     ],
     'survey_extractor': [
@@ -225,6 +227,7 @@ reducer_config = [
     {'shape_reducer_dbscan': {
         'shape': 'rectangle'
     }},
+    {'shortcut_reducer': {}},
     {'slider_reducer': {}},
     {'survey_reducer': {}}
 ]

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 type_to_extractor = {
     'single': 'question_extractor',
     'multiple': 'question_extractor',
-    'shortcut': 'question_extractor',
+    'shortcut': 'shortcut_extractor',
     'dropdown': 'dropdown_extractor',
     'survey': 'survey_extractor',
     'point': 'point_extractor_by_frame',
@@ -23,6 +23,7 @@ type_to_extractor = {
 
 standard_reducers = {
     'question_extractor': 'question_reducer',
+    'shortcut_extractor': 'shortcut_reducer',
     'dropdown_extractor': 'dropdown_reducer',
     'survey_extractor': 'survey_reducer',
     'point_extractor': 'point_reducer',


### PR DESCRIPTION
This PR maps `shortcut_extractor` and `shortcut_reducer` to the 
`question_extractor` and `question_reducer`.  By making a new extractor 
and reducer these types of tasks will be extracted/reduced to their own 
`csv` file.

This should address #113 