### PR TITLE
Add linter and test configuration file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+  */tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [report]
 omit =
-  */tests/*
+  panoptes_aggregation/tests/*
+  panoptes_aggregation/scripts/gui*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ install:
   - pip install -U pip
   - pip install -U .[online,test,doc]
 script: nosetests
+after_success: coveralls
 notifications:
   email: false

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 ## Code Style
-Use [PEP8](https://www.python.org/dev/peps/pep-0008/) syntax.
+[PEP8](https://www.python.org/dev/peps/pep-0008/) style is used in most cases and Pylama is used for linting by running `pylama` in the source directory.  The `setup.cfg` contains the configuration for the linter and lists the error codes that are being ignored.
 
 ---
 
@@ -99,5 +99,5 @@ The code is auto-documented using [sphinx](http://www.sphinx-doc.org/en/stable/i
 4. Build the docs with the `make_docs.sh` bash script
 
 ### 4. Make sure everything still works
-1. run `nosetests` and ensure all tests still pass
-2. (optional) run `nosetests --with-coverage --cover-erase --cover-html --cover-package=panoptes_aggregation` to check test coverage
+1. run `nosetests` and ensure all tests still pass (coverage is automatically reported)
+2. (optional) `nosetests --cover-html` to compile an html page for checking what parts of the code are not covered

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![DOI](https://zenodo.org/badge/98517215.svg)](https://zenodo.org/badge/latestdoi/98517215)
+[![Coverage Status](https://coveralls.io/repos/github/zooniverse/aggregation-for-caesar/badge.svg?branch=master)](https://coveralls.io/github/zooniverse/aggregation-for-caesar?branch=master)
 
 # Getting started
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[pylama]
+format = pylint
+skip = dist/*,cover/*,build/*,.ropeproject/*,docs/*
+linters = pep8,pyflakes
+ignore = E402,E501,E722
+
+[pylama:*/__init__.py]
+ignore = W0611
+
+[nosetests]
+with-coverage = 1
+cover-package = panoptes_aggregation
+cover-erase = 1

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'test': [
             'nose',
             'coverage',
+            'coveralls',
             'pylama'
         ],
         'gui': [

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ setup(
         ],
         'test': [
             'nose',
-            'coverage'
+            'coverage',
+            'pylama'
         ],
         'gui': [
             'Gooey'


### PR DESCRIPTION
closes #122 

The `setup.cfg` file contains the configuration for pylama and 
nosetests. This ensures that the linter rules being ignored are included 
in the repo and that the coverage is shown when tests are run.