### PR TITLE
Fix shortcut route

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -2,6 +2,7 @@ from .point_extractor import point_extractor
 from .point_extractor_by_frame import point_extractor_by_frame
 from .rectangle_extractor import rectangle_extractor
 from .question_extractor import question_extractor
+from .shortcut_extractor import shortcut_extractor
 from .survey_extractor import survey_extractor
 from .poly_line_text_extractor import poly_line_text_extractor
 from .line_text_extractor import line_text_extractor
@@ -17,7 +18,7 @@ extractors = {
     'point_extractor_by_frame': point_extractor_by_frame,
     'rectangle_extractor': rectangle_extractor,
     'question_extractor': question_extractor,
-    'shortcut_extractor': question_extractor,
+    'shortcut_extractor': shortcut_extractor,
     'survey_extractor': survey_extractor,
     'poly_line_text_extractor': poly_line_text_extractor,
     'line_text_extractor': line_text_extractor,

--- a/panoptes_aggregation/extractors/shortcut_extractor.py
+++ b/panoptes_aggregation/extractors/shortcut_extractor.py
@@ -1,0 +1,61 @@
+'''
+Question Extractor
+------------------
+This module provides a function to extract question tasks (single and multiple)
+from panoptes annotations.
+'''
+from collections import Counter
+from slugify import slugify
+from .extractor_wrapper import extractor_wrapper
+
+
+def slugify_or_null(s):
+    '''Slugify value while casting `null` as a string fisrt'''
+    if (s is None) or (isinstance(s, bool)) or (isinstance(s, int)):
+        return str(s)
+    else:
+        return slugify(s, separator='-')
+
+
+@extractor_wrapper
+def shortcut_extractor(classification, **kwargs):
+    '''Extract annotations from a question task into a Counter object
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing an `annotations` key that is a list of
+        panoptes annotations
+
+    Returns
+    -------
+    extraction : dict
+        A dictionary (formated like a counter) indicating what annotations were
+        made
+
+    Examples
+    --------
+    >>> classification_multiple = {'annotations': [
+        {
+            'vlaue': ['Blue', 'Green']
+        }
+    ]}
+    >>> question_extractor(classification_multiple)
+    {'blue': 1, 'green': 1}
+
+    >>> classification_single = {'annotations': [
+        {'vlaue': 'Yes'}
+    ]}
+    >>> question_extractor(classification_single)
+    {'yes': 1}
+    '''
+    #: assumes only one task is filtered into the extractor
+    answers = Counter()
+    if len(classification['annotations']) > 0:
+        annotation = classification['annotations'][0]
+        if isinstance(annotation['value'], list):
+            for answer in annotation['value']:
+                answers[slugify_or_null(answer)] += 1
+        else:
+            answers[slugify_or_null(annotation['value'])] += 1
+    return dict(answers)

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -3,6 +3,7 @@ from .point_reducer_dbscan import point_reducer_dbscan
 from .point_reducer_hdbscan import point_reducer_hdbscan
 from .rectangle_reducer import rectangle_reducer
 from .question_reducer import question_reducer
+from .shortcut_reducer import shortcut_reducer
 from .survey_reducer import survey_reducer
 from .poly_line_text_reducer import poly_line_text_reducer
 from .dropdown_reducer import dropdown_reducer
@@ -20,7 +21,7 @@ reducers = {
     'point_reducer_hdbscan': point_reducer_hdbscan,
     'rectangle_reducer': rectangle_reducer,
     'question_reducer': question_reducer,
-    'shortcut_reducer': question_reducer,
+    'shortcut_reducer': shortcut_reducer,
     'survey_reducer': survey_reducer,
     'poly_line_text_reducer': poly_line_text_reducer,
     'sw_variant_reducer': sw_variant_reducer,

--- a/panoptes_aggregation/reducers/shortcut_reducer.py
+++ b/panoptes_aggregation/reducers/shortcut_reducer.py
@@ -1,0 +1,58 @@
+'''
+Question Reducer
+----------------
+This module porvides functions to reduce the question task extracts from
+:mod:`panoptes_aggregation.extractors.question_extractor`.
+'''
+from collections import Counter
+from .reducer_wrapper import reducer_wrapper
+
+DEFAULTS = {
+    'pairs': {'default': False, 'type': bool}
+}
+
+
+def process_data(data, pairs=False):
+    '''Process a list of extracted questions into `Counter` objects
+
+    Parameters
+    ----------
+    data : list
+        A list of extractions created by
+        :meth:`panoptes_aggregation.extractors.question_extractor.question_extractor`
+    pairs : bool, optional
+        Default `False`. How multiple choice questions are treated.
+        When `True` the set of all choices is treated as a single answer
+
+    Returns
+    -------
+    processed_data : list
+        A list of `Counter` objects, one for each extraction
+    '''
+    data_out = []
+    for d in data:
+        if pairs:
+            new_key = '+'.join(sorted(d))
+            data_out.append(Counter({new_key: 1}))
+        else:
+            data_out.append(Counter(d))
+    return data_out
+
+
+@reducer_wrapper(process_data=process_data, defaults_process=DEFAULTS)
+def shortcut_reducer(votes_list):
+    '''Reduce a list of `Counter` objects into a single dict
+
+    Parameters
+    ----------
+    votes_list : list
+        A list of `Counter` objects from :meth:`process_data`
+
+    Returns
+    -------
+    reduction : dict
+        A dictionary (formated as a `Counter`) giving the vote count for each
+        `key`
+    '''
+    counter_total = sum(votes_list, Counter())
+    return dict(counter_total)

--- a/panoptes_aggregation/tests/extractor_tests/test_shortcut_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shortcut_extractor.py
@@ -1,0 +1,84 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+single_classification = {
+    'annotations': [{
+        "task": "T0",
+        "task_label": "A single question",
+        "value": "Yes"
+    }]
+}
+
+single_expected = {'yes': 1}
+
+TestSingle = ExtractorTest(
+    extractors.shortcut_extractor,
+    single_classification,
+    single_expected,
+    'Test single question'
+)
+
+multiple_classification = {
+    'annotations': [{
+        "task": "T1",
+        "task_label": "A multi question",
+        "value": ["Blue", "Green"]
+    }]
+}
+
+multiple_expected = {'blue': 1, 'green': 1}
+
+TestMultiple = ExtractorTest(
+    extractors.shortcut_extractor,
+    multiple_classification,
+    multiple_expected,
+    'Test multiple question'
+)
+
+null_classification = {
+    'annotations': [{
+        "task": "T0",
+        "task_label": "A single question",
+        "value": None
+    }]
+}
+
+null_expected = {'None': 1}
+
+TestNull = ExtractorTest(
+    extractors.shortcut_extractor,
+    null_classification,
+    null_expected,
+    'Test null question'
+)
+
+single_classification_two_tasks = {
+    'annotations': [{
+        "task": "T0",
+        "task_label": "A single question 1",
+        "value": "Yes"
+    }, {
+        "task": "T1",
+        "task_label": "A single question 2",
+        "value": "No"
+    }]
+}
+
+single_expected_1 = {'yes': 1}
+single_expected_2 = {'no': 1}
+
+TestSingleTwoTasks = ExtractorTest(
+    extractors.shortcut_extractor,
+    single_classification_two_tasks,
+    single_expected_1,
+    'Test multiple single questions passed in without task keyword'
+)
+
+
+TestSingleTwoTasks = ExtractorTest(
+    extractors.shortcut_extractor,
+    single_classification_two_tasks,
+    single_expected_2,
+    'Test multiple single questions passed in with task keyword',
+    kwargs={'task': 'T1'}
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_shortcut_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shortcut_reducer.py
@@ -1,0 +1,57 @@
+from collections import Counter
+from panoptes_aggregation.reducers.shortcut_reducer import process_data, shortcut_reducer
+from .base_test_class import ReducerTest
+
+extracted_data = [
+    {'a': 1, 'b': 1},
+    {'a': 1},
+    {'b': 1, 'c': 1},
+    {'b': 1, 'a': 1}
+]
+
+processed_data = [
+    Counter({'a': 1, 'b': 1}),
+    Counter({'a': 1}),
+    Counter({'b': 1, 'c': 1}),
+    Counter({'b': 1, 'a': 1})
+]
+
+reduced_data = {
+    'a': 3,
+    'b': 3,
+    'c': 1
+}
+
+TestQuestionReducer = ReducerTest(
+    shortcut_reducer,
+    process_data,
+    extracted_data,
+    processed_data,
+    reduced_data,
+    'Test question reducer',
+    processed_type='list'
+)
+
+processed_data_pairs = [
+    Counter({'a+b': 1}),
+    Counter({'a': 1}),
+    Counter({'b+c': 1}),
+    Counter({'a+b': 1})
+]
+
+reduced_data_pairs = {
+    'a+b': 2,
+    'a': 1,
+    'b+c': 1
+}
+
+TestQuestionReducerPairs = ReducerTest(
+    shortcut_reducer,
+    process_data,
+    extracted_data,
+    processed_data_pairs,
+    reduced_data_pairs,
+    'Test question reducer as pairs',
+    pkwargs={'pairs': True},
+    processed_type='list'
+)


### PR DESCRIPTION
Close #128 

Two flask routes can't point to the same function.  This sets the shortcut task's extractors and reducers as their own functions with new names.