### PR TITLE
Default TESS skill to 1

### DIFF
--- a/panoptes_aggregation/reducers/tess_reducer_column.py
+++ b/panoptes_aggregation/reducers/tess_reducer_column.py
@@ -86,7 +86,7 @@ def tess_reducer_column(data_by_tool, **kwargs):
     '''
     user_id = np.array(kwargs.pop('user_id'))
     relevant_reduction = kwargs.pop('relevant_reduction')
-    skill = np.array([rr['data']['skill'] for rr in relevant_reduction])
+    skill = np.array([rr['data']['skill'] if rr else 1.0 for rr in relevant_reduction])
     clusters = OrderedDict()
     loc = np.array(data_by_tool['data'])
     index = np.array(data_by_tool['index'])

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
@@ -60,7 +60,7 @@ kwargs_extra_data = {
         {'data': {'skill': 0.8}},
         {'data': {'skill': 0.1}},
         {'data': {'skill': 0.3}},
-        {'data': {'skill': 0.2}}
+        None
     ]
 }
 


### PR DESCRIPTION
Closes #136

When a user makes their first classification there is no `skill` value  yet, so default it to `1.0` (equal to unweighted). 