### PR TITLE
Default `max_weighted_count` to `None` when there are no clusters

### DIFF
--- a/panoptes_aggregation/reducers/tess_reducer_column.py
+++ b/panoptes_aggregation/reducers/tess_reducer_column.py
@@ -111,5 +111,8 @@ def tess_reducer_column(data_by_tool, **kwargs):
                 # user_ids in the cluster
                 k_users = [user_id[j] for j in index[idx]]
                 clusters.setdefault('user_ids', []).append(k_users)
-    clusters['max_weighted_count'] = max(clusters['weighted_counts'])
+    if 'weighted_counts' in clusters:
+        clusters['max_weighted_count'] = max(clusters['weighted_counts'])
+    else:
+        clusters['max_weighted_count'] = None
     return clusters

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
@@ -153,3 +153,61 @@ TestTESSReducerColumnCenter = ReducerTest(
     },
     network_kwargs=kwargs_extra_data
 )
+
+extracted_data_no_cluster = [
+    {
+        'frame0': {
+            'T0_tool0_x': [
+                0.0,
+                100.0,
+                50.0
+            ],
+            'T0_tool0_width': [
+                1.0,
+                100.0,
+                50.0
+            ]
+        }
+    }
+]
+
+kwargs_extra_data_no_cluster = {
+    'user_id': [
+        1
+    ],
+    'relevant_reduction': [
+        {'data': {'skill': 0.4}}
+    ]
+}
+
+processed_data_no_cluster = {
+    'data': [
+        (0.0, 1.0),
+        (100.0, 100.0),
+        (50.0, 50.0),
+    ],
+    'index': [
+        0,
+        0,
+        0
+    ]
+}
+
+reduced_data_no_cluster = {
+    'max_weighted_count': None
+}
+
+TestTESSReducerColumnCenter = ReducerTest(
+    tess_reducer_column,
+    process_data,
+    extracted_data_no_cluster,
+    processed_data_no_cluster,
+    reduced_data_no_cluster,
+    'Test TESS column reducer no clusters',
+    kwargs={
+        'x': 'left',
+        'eps': 50,
+        'min_samples': 2
+    },
+    network_kwargs=kwargs_extra_data_no_cluster
+)


### PR DESCRIPTION
Closes #138

When no clusters are found the reducer returns and empty object and the 
`weighted_counts` does not exist.  In this case the `max_weighted_count` 
is set to `None` to avoid the reducer crashing.