### PR TITLE
Intro2Astro extractor

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -11,6 +11,7 @@ from .sw_graphic_extractor import sw_graphic_extractor
 from .dropdown_extractor import dropdown_extractor
 from .shape_extractor import shape_extractor
 from .slider_extractor import slider_extractor
+from .i2a_extractor import i2a_extractor
 from ..copy_function import copy_function
 
 shortcut_extractor = copy_function(question_extractor, 'shortcut_extractor')
@@ -29,5 +30,6 @@ extractors = {
     'sw_graphic_extractor': sw_graphic_extractor,
     'dropdown_extractor': dropdown_extractor,
     'shape_extractor': shape_extractor,
-    'slider_extractor': slider_extractor
+    'slider_extractor': slider_extractor,
+    'i2a_extractor': i2a_extractor
 }

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -4,8 +4,6 @@ Intro2Astro Extractor
 This module provides a function that converts the pixel annotation to wavelength and uses the subject metadata
 to precalculate values required by students to use Hubble's Law to compute galactic velocity.
 '''
-import json
-import sys
 from .extractor_wrapper import extractor_wrapper
 
 def get_annotation(classification):

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -15,6 +15,7 @@ def get_annotation(classification):
     nw = classification['metadata']['subject_dimensions'][0]['naturalWidth']
     return {'xleft': xleft, 'width': width, 'nw': nw}
 
+
 def get_galaxy_metadata(metadata):
     ra = metadata['RA']
     dec = metadata['Dec']
@@ -23,6 +24,7 @@ def get_galaxy_metadata(metadata):
     elliptical = bool(metadata['elliptical'])
     url = metadata['URL']
     return {'ra': ra, 'dec': dec, 'z': z, 'galID': galID, 'elliptical': elliptical, 'url': url}
+
 
 def calc_lambda_central(annotation):
     # Input is a annotation dictionary with x_left, width, and natural window width
@@ -36,6 +38,7 @@ def calc_lambda_central(annotation):
     lamperpix = (lambdamax - lambdamin) / (xmax - xmin)
     lambdacen = (xleft + (width / 2.) - xmin) * lamperpix + lambdamin
     return lambdacen
+
 
 @extractor_wrapper
 def i2a_extractor(classification, **kwargs):

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -1,0 +1,64 @@
+'''
+Intro2Astro Extractor
+------------------
+This module provides a function that converts the pixel annotation to wavelength and uses the subject metadata
+to precalculate values required by students to use Hubble's Law to compute galactic velocity.
+'''
+import json
+import sys
+from .extractor_wrapper import extractor_wrapper
+
+def get_annotation(classification):
+    # Gets the first (only) task's annotation's 'values', pulling the first from lists when required
+    annotation_values = next(iter(classification['annotations'].values()))[0]['value'][0]
+
+    xleft = annotation_values['x']
+    width = annotation_values['width']
+    nw = classification['metadata']['subject_dimensions'][0]['naturalWidth']
+    return {'xleft': xleft, 'width': width, 'nw': nw}
+
+def get_galaxy_metadata(metadata):
+    ra = metadata['RA']
+    dec = metadata['Dec']
+    z = float(metadata['#Published_Redshift'])
+    galID = metadata['SVG_filename'].replace(".svg", "")
+    elliptical = bool(metadata['elliptical'])
+    url = metadata['URL']
+    return {'ra': ra, 'dec': dec, 'z': z, 'galID': galID, 'elliptical': elliptical, 'url': url}
+
+def calc_lambda_central(annotation):
+    # Input is a annotation dictionary with x_left, width, and natural window width
+    xleft = annotation['xleft']
+    width = annotation['width']
+    nw = annotation['nw']
+    xmin = int((108. / 1152.) * nw)  # These hardcoded pixel values represent the default window sizes
+    xmax = int((1081. / 1152.) * nw)  # If the actual window was sized differently, the factor of 'nw' scales the result appropriately
+    lambdamin = 380.
+    lambdamax = 500.
+    lamperpix = (lambdamax - lambdamin) / (xmax - xmin)
+    lambdacen = (xleft + (width / 2.) - xmin) * lamperpix + lambdamin
+    return lambdacen
+
+@extractor_wrapper
+def i2a_extractor(classification, **kwargs):
+    # import pdb; pdb.set_trace()
+    response = {}
+    if len(classification['annotation']) > 0:
+        annotation = get_annotation(classification)
+        galaxy_metadata = get_galaxy_metadata(classification['subject']['metadata'])
+        lambdacen = calc_lambda_central(annotation)
+
+        redshift = (lambdacen - 393.37) / 393.37
+        velocity = 300000 * redshift
+        dist = galaxy_metadata['z'] * 3e5 / 68
+
+        response['galaxy_id'] = galaxy_metadata['galID']
+        response['url'] = galaxy_metadata['url']
+        response['RA'] = galaxy_metadata['ra']
+        response['dec'] = galaxy_metadata['dec']
+        response['dist'] = dist
+        response['redshift'] = redshift
+        response['velocity'] = velocity
+        response['lambdacen'] = lambdacen
+
+    return response

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -10,7 +10,7 @@ from .extractor_wrapper import extractor_wrapper
 
 def get_annotation(classification):
     # Gets the first (only) task's annotation's 'values', pulling the first from lists when required
-    annotation_values = next(iter(classification['annotations'].values()))[0]['value'][0]
+    annotation_values = next(iter(classification['annotations']))['value'][0]
 
     xleft = annotation_values['x']
     width = annotation_values['width']
@@ -41,9 +41,79 @@ def calc_lambda_central(annotation):
 
 @extractor_wrapper
 def i2a_extractor(classification, **kwargs):
-    # import pdb; pdb.set_trace()
+    '''Extract annotations from intro2astro annotation and returns calculated values
+    and values extracted from subject metadata required by students to use Hubble's Law
+    to compute galactic velocity.
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing an `annotations` key that is a list of
+        panoptes annotations. There should only be one, and the first
+        is the only one considered.
+
+    Returns
+    -------
+    extraction : dict
+        A dictionary with a set of keys, including those that were computed by this
+        function and those that were extracted from the subject metadata.
+
+    Examples
+    --------
+    classification = {
+        "annotations": [
+            {
+                "task": "T0",
+                "value": [
+                    {
+                        "width": 80.36077880859375,
+                        "tool": 0,
+                        "0": 0,
+                        "details": [],
+                        "x": 541.7737426757812,
+                        "frame": 0
+                    }
+                ]
+            }
+        ],
+        "metadata": {
+            "subject_dimensions": [
+                {
+                    "clientWidth": 444,
+                    "clientHeight": 333,
+                    "naturalWidth": 1152,
+                    "naturalHeight": 864
+                }
+            ]
+        },
+        "subject": {
+            "metadata": {
+                "RA": "121.62522",
+                "Dec": "17.42804",
+                "URL": "http://skyserver.sdss.org/dr12/en/tools/explore/Summary.aspx?ra=121.62522&dec=17.42804",
+                "spiral": "0",
+                "elliptical": "1",
+                "Distance_Mpc": "481.4064706",
+                "SVG_filename": "1237665128518320259.svg",
+                "#Published_Redshift": "0.1091188"
+            }
+        }
+    }
+
+    >>> point_extractor(classification)
+        {
+            "galaxy_id": "1237665128518320259",
+            "url": "http://skyserver.sdss.org/dr12/en/tools/explore/Summary.aspx?ra=121.62522&dec=17.42804",
+            "RA": "121.62522",
+            "dec": "17.42804",
+            "dist": 481.40647058823527,
+            "redshift": 0.1146063992421806,
+            "velocity": 34381.91977265418,
+            "lambdacen": 438.4527192698966
+        }
+    '''
     response = {}
-    if len(classification['annotation']) > 0:
+    if len(classification['annotations']) > 0:
         annotation = get_annotation(classification)
         galaxy_metadata = get_galaxy_metadata(classification['subject']['metadata'])
         lambdacen = calc_lambda_central(annotation)

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -6,6 +6,7 @@ to precalculate values required by students to use Hubble's Law to compute galac
 '''
 from .extractor_wrapper import extractor_wrapper
 
+
 def get_annotation(classification):
     # Gets the first (only) task's annotation's 'values', pulling the first from lists when required
     annotation_values = next(iter(classification['annotations']))['value'][0]

--- a/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
@@ -1,0 +1,60 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    "annotations": [
+        {
+            "task": "T0",
+            "value": [
+                {
+                    "width": 80.36077880859375,
+                    "tool": 0,
+                    "0": 0,
+                    "details": [],
+                    "x": 541.7737426757812,
+                    "frame": 0
+                }
+            ]
+        }
+    ],
+    "metadata": {
+        "subject_dimensions": [
+            {
+                "clientWidth": 444,
+                "clientHeight": 333,
+                "naturalWidth": 1152,
+                "naturalHeight": 864
+            }
+        ]
+    },
+    "subject": {
+        "metadata": {
+            "RA": "121.62522",
+            "Dec": "17.42804",
+            "URL": "http://skyserver.sdss.org/dr12/en/tools/explore/Summary.aspx?ra=121.62522&dec=17.42804",
+            "spiral": "0",
+            "elliptical": "1",
+            "Distance_Mpc": "481.4064706",
+            "SVG_filename": "1237665128518320259.svg",
+            "#Published_Redshift": "0.1091188"
+        }
+    }
+}
+
+expected = {
+    "galaxy_id": "1237665128518320259",
+    "url": "http://skyserver.sdss.org/dr12/en/tools/explore/Summary.aspx?ra=121.62522&dec=17.42804",
+    "RA": "121.62522",
+    "dec": "17.42804",
+    "dist": 481.40647058823527,
+    "redshift": 0.1146063992421806,
+    "velocity": 34381.91977265418,
+    "lambdacen": 438.4527192698966
+}
+
+TestI2A= ExtractorTest(
+    extractors.i2a_extractor,
+    classification,
+    expected,
+    'Test i2a'
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
@@ -52,7 +52,7 @@ expected = {
     "lambdacen": 438.4527192698966
 }
 
-TestI2A= ExtractorTest(
+TestI2A = ExtractorTest(
     extractors.i2a_extractor,
     classification,
     expected,

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -18,7 +18,8 @@ type_to_extractor = {
     'rotateRectangle': 'shape_extractor',
     'triangle': 'shape_extractor',
     'fan': 'shape_extractor',
-    'slider': 'slider_extractor'
+    'slider': 'slider_extractor',
+    'i2a': 'i2a_extractor'
 }
 
 standard_reducers = {

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -18,8 +18,7 @@ type_to_extractor = {
     'rotateRectangle': 'shape_extractor',
     'triangle': 'shape_extractor',
     'fan': 'shape_extractor',
-    'slider': 'slider_extractor',
-    'i2a': 'i2a_extractor'
+    'slider': 'slider_extractor'
 }
 
 standard_reducers = {

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -76,16 +76,16 @@ def workflow_extractor_config(tasks, keywords={}):
                 **task_keywords
             }
             for tdx, tool in enumerate(task['tools']):
-                if ((tool['type'] == 'polygon') and
-                   (len(tool['details']) == 1) and
-                   (tool['details'][0]['type'] == 'text')):
+                if ((tool['type'] == 'polygon')
+                   and (len(tool['details']) == 1)
+                   and (tool['details'][0]['type'] == 'text')):
                     # this is very ugly but I can't think of a better way to auto detect this
                     extractor_key = 'poly_line_text_extractor'
                     task_config.setdefault(extractor_key, default_config)
                     del task_config[extractor_key]['tools']
-                elif ((tool['type'] == 'line') and
-                      (len(tool['details']) == 1) and
-                      (tool['details'][0]['type'] == 'text')):
+                elif ((tool['type'] == 'line')
+                    and (len(tool['details']) == 1)
+                    and (tool['details'][0]['type'] == 'text')):
                     # this is very ugly but I can't think of a better way to auto detect this
                     extractor_key = 'line_text_extractor'
                     task_config.setdefault(extractor_key, default_config)


### PR DESCRIPTION
External extractor for Intro2Astro and their Hubble's Law classroom activity. This currently exists as an openfaas function in the swarm. We're trying to shut all that down, and after evaluating (openfaas in k8s|kubeless|insert faas framework here) I'm really wondering if it's not better to just expand the scope of this repo a little bit more.

This is tested and works as far as the tests are concerned, but getting the web version running locally is a project in itself. Consider this a proof of concept and a continuation of the above discussion.