### PR TITLE
Fix dependency error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'python-levenshtein',
         'python-slugify',
         'pyyaml',
-        'scikit-learn',
+        'scikit-learn==0.20.3',
         'scipy>=1.1.0',
         'werkzeug'
     ]


### PR DESCRIPTION
scikit-learn was updated and while there's a new deprecation _warning_ at the top of the Travis build, there's also a full blown ModuleNotFoundError down below. This PR is a test to see if locking the version to the previous will help. If so, it could be a stopgap to get deployments out while a real fix is implemented. Full error follows.

`/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.`