### PR TITLE
Fixed error if not iterable. Updated specs to include int anno type.

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -6,6 +6,7 @@ annotation for use in their Field Book.
 '''
 from .extractor_wrapper import extractor_wrapper
 
+import collections
 from dateutil.parser import parse as dateparse
 from datetime import timedelta
 
@@ -25,13 +26,20 @@ class ClassificationParser(object):
         }
         self.tasks = self.flatten(classification['annotations'])
 
+    def iterable(self, arg):
+        return (
+            isinstance(arg, collections.Iterable)
+            and not isinstance(arg, str)
+        )
+
     def flatten(self, anno):
         f = {}
         for a in anno:
             f[a['task']] = a['value']
-            for subanno in a['value']:
-                if 'task' in subanno:
-                    f[subanno['task']] = subanno['value']
+            if (self.iterable(a['value'])):
+                for subanno in a['value']:
+                    if 'task' in subanno:
+                        f[subanno['task']] = subanno['value']
         return f
 
     def get_basic(self, label):

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -20,8 +20,15 @@ classification = {
                     "option": True
                 }
             ]
+        },
+        {
+            "task": "T3",
+            "value": 5
         }
     ],
+    "subject": {
+        "metadata": {}
+    },
     "metadata": {
         "utc_offset": "21600",
     },
@@ -43,15 +50,15 @@ TestNfN = ExtractorTest(
     kwargs={'year': 'T10', 'workflow': 'herbarium', 'country': "T1"}
 )
 
-classification = {
+classification_0 = {
     "annotations": [{
-        "task": "T31",
+        "task": "T99",
         "value": [
             {
-                "task": "T10",
+                "task": "T11",
                 "value": [
                     {
-                        "value": 1999,
+                        "value": 2001,
                         "option": True
                     }
                 ]
@@ -69,18 +76,18 @@ classification = {
     "created_at": "2019-04-22T06:28:13.667Z",
 }
 
-expected = {
+expected_0 = {
     "workflow": "herbarium",
-    "decade": "90s",
+    "decade": "00s",
     "time": "lunchbreak",
     "earth_day": True,
     "country": "United States"
 }
 
-TestNfN = ExtractorTest(
+TestNfNTwo = ExtractorTest(
     extractors.nfn_extractor,
-    classification,
-    expected,
+    classification_0,
+    expected_0,
     'Test NfN on Earth Day with year as nested task and country from metadata. At lunchtime, local time.',
-    kwargs={'year': 'T10', 'workflow': 'herbarium', 'country': 'metadata'}
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'}
 )


### PR DESCRIPTION
Strings are iterable and my tests only otherwise included dicts and lists. So when I was checking to see if there was a subtask and the answer was an int, it blew up. Also renamed the second test and associated vars to ensure that it was running against the correct data.