### PR TITLE
NfN Extractor: Handle various annotation varietals

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -43,14 +43,16 @@ class ClassificationParser(object):
         return f
 
     def get_basic(self, label):
-        # import pdb; pdb.set_trace()
         if label in self.subject_metadata:
             return self.subject_metadata[label]
         elif label in self.params:
             task = self.params[label]
-            if self.params[label] in self.tasks:
+            if task in self.tasks:
                 value = self.tasks[task]
-                return value[0]['value']
+                try:
+                    return value[0]['value']
+                except TypeError:
+                    return value
             else:
                 return None
         else:

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -91,3 +91,33 @@ TestNfNTwo = ExtractorTest(
     'Test NfN on Earth Day with year as nested task and country from metadata. At lunchtime, local time.',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'}
 )
+
+classification_1 = {
+    "annotations": [
+        {
+            "task": "T10",
+            "value": 1976
+        }
+    ],
+    "metadata": {
+        "utc_offset": "21600",
+    },
+    "subject": {
+        "metadata": {}
+    },
+    "created_at": "2019-05-22T06:28:13.667Z",
+}
+
+expected_1 = {
+    "workflow": "herbarium",
+    "decade": "70s",
+    "time": "lunchbreak"
+}
+
+TestNfNThree = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_1,
+    expected_1,
+    'Test NfN bare integer year annotation at lunchtime.',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+)


### PR DESCRIPTION
The discrepancy between Panoptes and Caesar-style annotations when digging for nested tasks is causing a bit of an issue.