### PR TITLE
new tess endpoints for MAST

### DIFF
--- a/endpoints.yml.template
+++ b/endpoints.yml.template
@@ -3,3 +3,11 @@ endpoints:
         url: https://masttest.stsci.edu/planethunterstess/api/v0.1/load/transit
         auth-header: X-ASB-AUTH
         auth-token: MAST_AUTH_TOKEN
+    mast_test:
+        url: https://masttest.stsci.edu/planethunterstess/api/v0.1/load/transit
+        auth-header: X-ASB-AUTH
+        auth-token: MAST_AUTH_TOKEN
+    mast_production:
+        url: https://mast.stsci.edu/phad/api/v0.1/load/transit
+        auth-header: X-ASB-AUTH
+        auth-token: MAST_PROD_TOKEN


### PR DESCRIPTION
again: none of this will actually change the behavior of the forwarder; this simply adds more valid destinations that can be specified in the URL. we will only start posting to the new endpoint once the URL in the caesar effect is changed.