### PR TITLE
Check for min number of users before trying to reshape data in TESS reducer

### DIFF
--- a/panoptes_aggregation/reducers/tess_reducer_column.py
+++ b/panoptes_aggregation/reducers/tess_reducer_column.py
@@ -106,8 +106,8 @@ def tess_reducer_column(data_by_tool, **kwargs):
     x = kwargs.pop('x')
     if x == 'left':
         loc[:, 0] += 0.5 * loc[:, 1]
-    loc_with_index = np.hstack([loc, index.reshape(-1, 1)])
-    if number_users >= kwargs['min_samples']:
+    if (number_users >= kwargs['min_samples']) and (len(loc) == len(index)):
+        loc_with_index = np.hstack([loc, index.reshape(-1, 1)])
         db = DBSCAN(**kwargs, metric=metric).fit(loc_with_index)
         core_samples_mask = np.zeros_like(db.labels_, dtype=bool)
         core_samples_mask[db.core_sample_indices_] = True

--- a/panoptes_aggregation/reducers/tess_reducer_column.py
+++ b/panoptes_aggregation/reducers/tess_reducer_column.py
@@ -106,7 +106,7 @@ def tess_reducer_column(data_by_tool, **kwargs):
     x = kwargs.pop('x')
     if x == 'left':
         loc[:, 0] += 0.5 * loc[:, 1]
-    if (number_users >= kwargs['min_samples']) and (len(loc) == len(index)):
+    if (number_users >= kwargs['min_samples']) and (len(loc) == len(index)) and (loc.ndim == 2):
         loc_with_index = np.hstack([loc, index.reshape(-1, 1)])
         db = DBSCAN(**kwargs, metric=metric).fit(loc_with_index)
         core_samples_mask = np.zeros_like(db.labels_, dtype=bool)

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
@@ -201,7 +201,7 @@ reduced_data_no_cluster = {
     'max_weighted_count': None
 }
 
-TestTESSReducerColumnCenter = ReducerTest(
+TestTESSReducerNoCluster = ReducerTest(
     tess_reducer_column,
     process_data,
     extracted_data_no_cluster,


### PR DESCRIPTION
Explicitly check that `loc` and `index` have the expected shapes and only try to stack them after the min number of users have seen the subject.