### PR TITLE
Update docs for Polygon As Line Tool for Text

### DIFF
--- a/panoptes_aggregation/extractors/poly_line_text_extractor.py
+++ b/panoptes_aggregation/extractors/poly_line_text_extractor.py
@@ -1,8 +1,8 @@
 '''
 Polygon As Line Tool for Text Extractor
 ---------------------------------------
-This module provides a fuction to eaxtract panoptes annotations
-from porjects using a polygon tool to mark word in a transcribed
+This module provides a function to extract panoptes annotations
+from projects using a polygon tool to mark words in a transcribed
 document and provide the transcribed text as a sub-task.
 '''
 from collections import OrderedDict


### PR DESCRIPTION
This commit fixes some typos in the documentation for Polygon As Line Tool for Text.