### PR TITLE
Package updates

### DIFF
--- a/panoptes_aggregation/reducers/point_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/point_reducer_hdbscan.py
@@ -5,10 +5,14 @@ This module provides functions to cluster points extracted with
 :mod:`panoptes_aggregation.extractors.point_extractor`.
 '''
 import numpy as np
-from hdbscan import HDBSCAN
 from collections import OrderedDict
 from .reducer_wrapper import reducer_wrapper
 from .subtask_reducer_wrapper import subtask_wrapper
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+    from hdbscan import HDBSCAN
 
 
 DEFAULTS = {

--- a/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
@@ -5,14 +5,17 @@ This module provides functions to cluster shapes extracted with
 :mod:`panoptes_aggregation.extractors.shape_extractor`.
 '''
 import numpy as np
-from hdbscan import HDBSCAN
 from collections import OrderedDict
 from .reducer_wrapper import reducer_wrapper
 from .subtask_reducer_wrapper import subtask_wrapper
 from ..shape_tools import SHAPE_LUT
 from .shape_process_data import process_data, DEFAULTS_PROCESS
 from .shape_metric import get_shape_metric_and_avg
+import warnings
 
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+    from hdbscan import HDBSCAN
 
 DEFAULTS = {
     'min_cluster_size': {'default': 5, 'type': int},

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -279,8 +279,7 @@ def align_words(word_line, xy_line, text_line, kwargs_cluster, kwargs_dbscan):
                 collation.add_plain_witness(key, t)
                 witness_key.append(key)
         if len(collation.witnesses) > 0:
-            scheduler = col.near_matching.Scheduler()
-            alignment_table = col.collate(collation, near_match=True, segmentation=False, scheduler=scheduler)
+            alignment_table = col.collate(collation, near_match=True, segmentation=False)
             for cols in alignment_table.columns:
                 word_dict = cols.tokens_per_witness
                 word_list = []
@@ -290,8 +289,7 @@ def align_words(word_line, xy_line, text_line, kwargs_cluster, kwargs_dbscan):
                     else:
                         word_list.append('')
                 clusters_text.append(word_list)
-            # fix memory leak by deleting these
-            del scheduler
+            # fix memory leak by deleting this
             del alignment_table
     return clusters_x, clusters_y, clusters_text
 

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -749,9 +749,9 @@ reduced_data = {
         },
         {
             'clusters_text': [
-                ['are', '', 'are', 'are', '', 'are'],
+                ['are', '', 'are', 'are', '&', 'are'],
                 ['', 'going', 'going', '', '', 'going'],
-                ['', 'to', 'to', '', '&', 'to'],
+                ['', 'to', 'to', '', '', 'to'],
                 ['', '', 'fall', '', '', 'fall']
             ],
             'clusters_x': [819.36, 1344.815],

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'python-levenshtein',
         'python-slugify',
         'pyyaml',
-        'scikit-learn==0.20.3',
+        'scikit-learn==0.21.1',
         'scipy>=1.1.0',
         'werkzeug'
     ]

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     },
     install_requires=[
         'beautifulsoup4',
-        'collatex==2.1.2',
+        'collatex==2.2',
         'hdbscan',
         'lxml',
         'numpy==1.16.2',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'lxml',
         'numpy==1.16.2',
         'nose',
-        'pandas',
+        'pandas==0.24.2',
         'progressbar2',
         'python-levenshtein',
         'python-slugify',


### PR DESCRIPTION
This PR updates the scikit-learn and collatex python packages in perpetration for the updated text reducers being used by the new text-editor.

The update to collatex (the text alignment package the text reducer uses) has allowed a code work-around to be removed for the `text_utils.py` file.

HDBSCAN now works with the latest scikit-learn but it still has one `DepreciationWarning` for its `joblib` import.  I have added a local warning filter to catch this and locked down the new scikit-learn version making it safe to ignore this warning.
