### PR TITLE
Linter and test cleanup

### DIFF
--- a/panoptes_aggregation/tests/router_tests/test_routes.py
+++ b/panoptes_aggregation/tests/router_tests/test_routes.py
@@ -25,9 +25,9 @@ class RouterTest(unittest.TestCase):
     def route_exists(self, route, expected):
         with self.application.test_client() as client:
             response = client.get(route)
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             result = eval(response.data)
-            self.assertEquals(result, expected)
+            self.assertEqual(result, expected)
 
     def test_home_route(self):
         '''Test home page returns version'''
@@ -68,14 +68,14 @@ class RouterTest(unittest.TestCase):
         '''Test docs route works'''
         with self.application.test_client() as client:
             response = client.get('/docs')
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
 
     def test_post_to_route(self):
         '''Test POST to route works'''
         with patch.dict('panoptes_aggregation.routes.extractors.extractors', mock_extractors_dict):
             with routes.make_application().test_client() as client:
                 response = client.post('/extractors/question_extractor')
-                self.assertEquals(response.status_code, 200)
+                self.assertEqual(response.status_code, 200)
 
     def test_MyEncoder_int(self):
         '''Test MyEncoder converts numpy ints'''

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -83,8 +83,8 @@ def workflow_extractor_config(tasks, keywords={}):
                     task_config.setdefault(extractor_key, default_config)
                     del task_config[extractor_key]['tools']
                 elif ((tool['type'] == 'line')
-                    and (len(tool['details']) == 1)
-                    and (tool['details'][0]['type'] == 'text')):
+                     and (len(tool['details']) == 1)
+                     and (tool['details'][0]['type'] == 'text')):
                     # this is very ugly but I can't think of a better way to auto detect this
                     extractor_key = 'line_text_extractor'
                     task_config.setdefault(extractor_key, default_config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 format = pylint
 exclude = dist/*,cover/*,build/*,.ropeproject/*,docs/*,__init__.py
-ignore = E402,E501,E722
+ignore = E402,E501,E722,W503,E128
 
 [nosetests]
 with-coverage = 1


### PR DESCRIPTION
This PR cleans up some linter issues (turns out two pep8 rules are mutually exclusive causing hound to complain 100% of the time).

Also update tests to use `assertEqual` instead of `assertEquals`.  `assertEquals` will be depreciated soon.