### PR TITLE
Update extractor_wrapper to optionally track `gold_standard`

### DIFF
--- a/panoptes_aggregation/extractors/dropdown_extractor.py
+++ b/panoptes_aggregation/extractors/dropdown_extractor.py
@@ -7,7 +7,7 @@ from .extractor_wrapper import extractor_wrapper
 from .question_extractor import slugify_or_null
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def dropdown_extractor(classification, **kwargs):
     '''Extract annotations from a dropdown task into a Counter object
 

--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -13,28 +13,32 @@ def unpack_annotations(annotations, task):
     return annotations_list
 
 
-def extractor_wrapper(func):
-    @wraps(func)
-    def wrapper(argument, **kwargs):
-        #: check if argument is a flask request
-        if hasattr(argument, 'get_json'):
-            kwargs = argument.args.copy().to_dict()
-            if 'details' in kwargs:
-                kwargs['details'] = ast.literal_eval(kwargs['details'])
-            if 'tools' in kwargs:
-                kwargs['tools'] = ast.literal_eval(kwargs['tools'])
-            data = argument.get_json()
-        else:
-            data = argument
-        task = kwargs.pop('task', 'all')
-        no_version = kwargs.pop('no_version', False)
-        annotations = data['annotations']
-        annotations_list = unpack_annotations(annotations, task)
-        data['annotations'] = annotations_list
-        extraction = func(data, **kwargs)
-        # add package version to the extracted content
-        if not no_version:
-            append_version(extraction)
-        return extraction
-    wrapper._original = func
-    return wrapper
+def extractor_wrapper(gold_standard=False):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(argument, **kwargs):
+            #: check if argument is a flask request
+            if hasattr(argument, 'get_json'):
+                kwargs = argument.args.copy().to_dict()
+                if 'details' in kwargs:
+                    kwargs['details'] = ast.literal_eval(kwargs['details'])
+                if 'tools' in kwargs:
+                    kwargs['tools'] = ast.literal_eval(kwargs['tools'])
+                data = argument.get_json()
+            else:
+                data = argument
+            task = kwargs.pop('task', 'all')
+            no_version = kwargs.pop('no_version', False)
+            annotations = data['annotations']
+            annotations_list = unpack_annotations(annotations, task)
+            data['annotations'] = annotations_list
+            if gold_standard:
+                kwargs['gold_standard'] = data.get('gold_standard', False)
+            extraction = func(data, **kwargs)
+            # add package version to the extracted content
+            if not no_version:
+                append_version(extraction)
+            return extraction
+        wrapper._original = func
+        return wrapper
+    return decorator

--- a/panoptes_aggregation/extractors/i2a_extractor.py
+++ b/panoptes_aggregation/extractors/i2a_extractor.py
@@ -41,7 +41,7 @@ def calc_lambda_central(annotation):
     return lambdacen
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def i2a_extractor(classification, **kwargs):
     '''Extract annotations from intro2astro annotation and returns calculated values
     and values extracted from subject metadata required by students to use Hubble's Law

--- a/panoptes_aggregation/extractors/line_text_extractor.py
+++ b/panoptes_aggregation/extractors/line_text_extractor.py
@@ -12,7 +12,7 @@ from .extractor_wrapper import extractor_wrapper
 from .tool_wrapper import tool_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 @tool_wrapper
 def line_text_extractor(classification, **kwargs):
     '''Extract annotations from a line tool with a text sub-task

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -92,7 +92,7 @@ def earth_day(parser):
         return None
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def nfn_extractor(classification, **kwargs):
     response = {}
     if len(classification['annotations']) > 0:

--- a/panoptes_aggregation/extractors/point_extractor.py
+++ b/panoptes_aggregation/extractors/point_extractor.py
@@ -8,7 +8,7 @@ from .extractor_wrapper import extractor_wrapper
 from .tool_wrapper import tool_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 @tool_wrapper
 def point_extractor(classification, **kwargs):
     '''Extract annotations from a point drawing tool into lists.

--- a/panoptes_aggregation/extractors/point_extractor_by_frame.py
+++ b/panoptes_aggregation/extractors/point_extractor_by_frame.py
@@ -9,7 +9,7 @@ from .subtask_extractor_wrapper import subtask_wrapper
 from .tool_wrapper import tool_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 @tool_wrapper
 @subtask_wrapper
 def point_extractor_by_frame(classification, **kwargs):

--- a/panoptes_aggregation/extractors/poly_line_text_extractor.py
+++ b/panoptes_aggregation/extractors/poly_line_text_extractor.py
@@ -13,9 +13,9 @@ from .tool_wrapper import tool_wrapper
 import warnings
 
 
-@extractor_wrapper
+@extractor_wrapper(gold_standard=True)
 @tool_wrapper
-def poly_line_text_extractor(classification, dot_freq='word', **kwargs):
+def poly_line_text_extractor(classification, dot_freq='word', gold_standard=False, **kwargs):
     '''Extract annotations from a polygon tool with a text sub-task
 
     Parameters
@@ -111,6 +111,7 @@ def poly_line_text_extractor(classification, dot_freq='word', **kwargs):
                         extract[frame]['points']['x'].append(x)
                         extract[frame]['points']['y'].append(y)
                         extract[frame]['slope'].append(slope)
+                        extract[frame]['gold_standard'] = gold_standard
                 elif (dot_freq == 'line'):
                     # NOTE: if there are not two `points` the extract is not used
                     if len(x) == 2:
@@ -118,4 +119,5 @@ def poly_line_text_extractor(classification, dot_freq='word', **kwargs):
                         extract[frame]['points']['x'].append(x)
                         extract[frame]['points']['y'].append(y)
                         extract[frame]['slope'].append(slope)
+                        extract[frame]['gold_standard'] = gold_standard
     return extract

--- a/panoptes_aggregation/extractors/question_extractor.py
+++ b/panoptes_aggregation/extractors/question_extractor.py
@@ -17,7 +17,7 @@ def slugify_or_null(s):
         return slugify(s, separator='-')
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def question_extractor(classification, **kwargs):
     '''Extract annotations from a question task into a Counter object
 

--- a/panoptes_aggregation/extractors/rectangle_extractor.py
+++ b/panoptes_aggregation/extractors/rectangle_extractor.py
@@ -9,7 +9,7 @@ from .subtask_extractor_wrapper import subtask_wrapper
 from .tool_wrapper import tool_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 @tool_wrapper
 @subtask_wrapper
 def rectangle_extractor(classification, **kwargs):

--- a/panoptes_aggregation/extractors/shape_extractor.py
+++ b/panoptes_aggregation/extractors/shape_extractor.py
@@ -10,7 +10,7 @@ from .tool_wrapper import tool_wrapper
 from ..shape_tools import SHAPE_LUT
 
 
-@extractor_wrapper
+@extractor_wrapper()
 @tool_wrapper
 @subtask_wrapper
 def shape_extractor(classification, **kwargs):

--- a/panoptes_aggregation/extractors/slider_extractor.py
+++ b/panoptes_aggregation/extractors/slider_extractor.py
@@ -6,7 +6,7 @@ This module provides a function to extract slider tasks from panoptes annotation
 from .extractor_wrapper import extractor_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def slider_extractor(classification, **kwargs):
     '''Extract annotations from a slider task
 

--- a/panoptes_aggregation/extractors/survey_extractor.py
+++ b/panoptes_aggregation/extractors/survey_extractor.py
@@ -10,7 +10,7 @@ from .question_extractor import question_extractor
 from .extractor_wrapper import extractor_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def survey_extractor(classification, **kwargs):
     '''Extract annotations from a survye task into a list
 

--- a/panoptes_aggregation/extractors/sw_extractor.py
+++ b/panoptes_aggregation/extractors/sw_extractor.py
@@ -60,7 +60,7 @@ def clean_text(s):
     return s_out
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def sw_extractor(classification, **kwargs):
     '''Extract text annotations from Shakespeares World and AnnoTate.
 

--- a/panoptes_aggregation/extractors/sw_graphic_extractor.py
+++ b/panoptes_aggregation/extractors/sw_graphic_extractor.py
@@ -12,7 +12,7 @@ def exist_and_finite(d, key):
     return (key in d) and (d[key] != 'NaN')
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def sw_graphic_extractor(classification, **kwargs):
     '''Extract all graphics data from a classification
 

--- a/panoptes_aggregation/extractors/sw_variant_extractor.py
+++ b/panoptes_aggregation/extractors/sw_variant_extractor.py
@@ -7,7 +7,7 @@ annotations made on Shakespeares World.
 from .extractor_wrapper import extractor_wrapper
 
 
-@extractor_wrapper
+@extractor_wrapper()
 def sw_variant_extractor(classification, **kwargs):
     '''Extract all variants in a classification into one list
 

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
@@ -2,6 +2,7 @@ from panoptes_aggregation import extractors
 from .base_test_class import TextExtractorTest, TextExtractorBadKeywordTest
 
 classification = {
+    "gold_standard": True,
     "annotations": [
         {
             "task": "T1",
@@ -120,7 +121,8 @@ expected = {
             -1.01939,
             -1.091213,
             -0.261027
-        ]
+        ],
+        'gold_standard': True
     },
     'frame1': {
         'points': {
@@ -154,7 +156,8 @@ expected = {
         'slope': [
             1.157333,
             90
-        ]
+        ],
+        'gold_standard': True
     }
 }
 


### PR DESCRIPTION
When the wrapper is used with `gold_standard=True` the `gold_standard` 
key from an annotation object will be passed into the extraction function 
with the `gold_standard` keyword.  The extractor decides how this should 
be structured inside the extract.

Since the extractor_wrapper takes a keyword all the 
`@extractor_wrapper`s had to be changed to `@extractor_wrapper()`.

The `poly_line_text_extractor` is updated to use this new functionality.