### PR TITLE
Update sphinx config

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -49,7 +49,7 @@ The routes are automatically constructed using the `extractors` dictionary in th
 ### 4. Add to documentation
 The code is auto-documented using [sphinx](http://www.sphinx-doc.org/en/stable/index.html).
 
-1. Add a doc string to every function written and a "heading" doc string at the top of any new files created (follow the [numpy doc string convention](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt))
+1. Add a doc string to every function written and a "heading" doc string at the top of any new files created (follow the [numpy doc string convention](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
 2. Add a reference to the new file to `docs/source/extractors.rst`
 3. Add to the extractor/reducer lookup table `docs/source/Task_lookup_table.rst`
 4. Build the docs with the `make_docs.sh` bash script
@@ -93,7 +93,7 @@ The routes are automatically constructed using the `reducers` dictionary in the 
 ### 3. Add to documentation
 The code is auto-documented using [sphinx](http://www.sphinx-doc.org/en/stable/index.html).
 
-1. Add a doc string to every function written and a "heading" doc string at the top of any new files created (follow the [numpy doc string convention](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt))
+1. Add a doc string to every function written and a "heading" doc string at the top of any new files created (follow the [numpy doc string convention](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
 2. Add a reference to the new file to `docs/source/reducers.rst`
 3. Add to the extractor/reducer lookup table `docs/source/Task_lookup_table.rst`
 4. Build the docs with the `make_docs.sh` bash script

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,6 @@ compat.make_admonition = BaseAdmonition
 sys.path.insert(0, os.path.abspath('../../panoptes_aggregation'))
 sys.path.insert(0, os.path.abspath('../..'))
 from panoptes_aggregation import __version__
-from recommonmark.parser import CommonMarkParser
 import datetime
 
 # -- General configuration ------------------------------------------------
@@ -41,7 +40,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'recommonmark'
 ]
 napoleon_google_docstring = False
 napoleon_use_param = False
@@ -50,13 +50,13 @@ napoleon_use_ivar = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-source_parsers = {
-   '.md': CommonMarkParser,
-}
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown'
+}
 # source_suffix = '.rst'
 
 # The master toctree document.

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         ],
         'doc': [
             'recommonmark',
-            'sphinx',
+            'sphinx==2.1.2',
             'sphinxcontrib-httpdomain',
             'sphinx_rtd_theme'
         ],


### PR DESCRIPTION
closes #180

This updates the sphinx config file to remove the 
`RemovedInSphinx30Warning` messages.  One warning still remains that has 
to do with the theme being used, once `sphinx_rtd_theme` pushes their 
next release to pip this will be fixed as well.

The sphinx version has been locked down so dependabot can take over 
updating this when needed.