### PR TITLE
Text box aggregation

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -13,6 +13,7 @@ from .shape_extractor import shape_extractor
 from .slider_extractor import slider_extractor
 from .nfn_extractor import nfn_extractor
 from .i2a_extractor import i2a_extractor
+from .text_extractor import text_extractor
 from ..copy_function import copy_function
 
 shortcut_extractor = copy_function(question_extractor, 'shortcut_extractor')
@@ -33,5 +34,6 @@ extractors = {
     'shape_extractor': shape_extractor,
     'slider_extractor': slider_extractor,
     'i2a_extractor': i2a_extractor,
-    'nfn_extractor': nfn_extractor
+    'nfn_extractor': nfn_extractor,
+    'text_extractor': text_extractor
 }

--- a/panoptes_aggregation/extractors/text_extractor.py
+++ b/panoptes_aggregation/extractors/text_extractor.py
@@ -1,0 +1,15 @@
+'''
+Text Extractor
+--------------
+This module provides a function to extract text tasks from panoptes annotations
+'''
+from .extractor_wrapper import extractor_wrapper
+
+
+@extractor_wrapper()
+def text_extractor(classifiction, **kwargs):
+    extract = {}
+    if len(classifiction['annotations']) > 0:
+        annotaiton = classifiction['annotations'][0]
+        extract['text'] = annotaiton['value']
+    return extract

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -13,6 +13,7 @@ from .shape_reducer_hdbscan import shape_reducer_hdbscan
 from .slider_reducer import slider_reducer
 from .tess_reducer_column import tess_reducer_column
 from .tess_gold_standard_reducer import tess_gold_standard_reducer
+from .text_reducer import text_reducer
 from ..copy_function import copy_function
 
 shortcut_reducer = copy_function(question_reducer, 'shortcut_reducer')
@@ -32,5 +33,6 @@ reducers = {
     'shape_reducer_hdbscan': shape_reducer_hdbscan,
     'slider_reducer': slider_reducer,
     'tess_reducer_column': tess_reducer_column,
-    'tess_gold_standard_reducer': tess_gold_standard_reducer
+    'tess_gold_standard_reducer': tess_gold_standard_reducer,
+    'text_reducer': text_reducer
 }

--- a/panoptes_aggregation/reducers/text_reducer.py
+++ b/panoptes_aggregation/reducers/text_reducer.py
@@ -1,0 +1,63 @@
+'''
+Text Tool Reducer
+-----------------
+This module provides functions to reducer the panoptes text tool into an
+alignment table.
+'''
+import collatex as col
+from .text_utils import consensus_score, tokenize
+from .reducer_wrapper import reducer_wrapper
+
+# override the built-in tokenize
+col.core_classes.WordPunctuationTokenizer.tokenize = tokenize
+
+
+def process_data(data_list):
+    '''Flatten list of extracts into a list of strings.  Empty strings
+    are not returned'''
+    return [d['text'] for d in data_list if d['text'].strip() != '']
+
+
+@reducer_wrapper(process_data=process_data)
+def text_reducer(data, **kwargs):
+    '''Reduce a list of text into an alignment table
+    Parameters
+    ----------
+    data : list
+        A list of strigs to be aligned
+
+    Returns
+    -------
+    reduction : dict
+        A dictionary with the following keys:
+
+        * `aligned_text` : A list of lists containing the aligned text.
+            There is one list for each identified word, and each of those lists contains
+            one item for each user that entered text. If the user did not transcribe
+            a word an empty string is used.
+        * `number_views` : Number of volunteers who entered non-blank text
+        * `consensus_score` : The average number of users who's text agreed
+            Note, if `consensus_score` is the same a `number_views` every user agreed with each other
+    '''
+    reduction = {}
+    if len(data) > 0:
+        witness_keys = []
+        aligned_text = []
+        collation = col.Collation()
+        for index, text in enumerate(data):
+            key = str(index)
+            witness_keys.append(key)
+            collation.add_plain_witness(key, text)
+        alignment_table = col.collate(collation, near_match=True, segmentation=False)
+        for cols in alignment_table.columns:
+            word_dict = cols.tokens_per_witness
+            word_list = []
+            for key in witness_keys:
+                word_list.append(str(word_dict.get(key, [''])[0]))
+            aligned_text.append(word_list)
+        reduction = {
+            'aligned_text': aligned_text,
+            'number_views': len(data),
+            'consensus_score': consensus_score(aligned_text)
+        }
+    return reduction

--- a/panoptes_aggregation/tests/extractor_tests/test_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_text_extractor.py
@@ -1,0 +1,20 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    'annotations': [{
+        'task': 'T0',
+        'value': 'test text'
+    }]
+}
+
+expected = {
+    'text': 'test text'
+}
+
+TestTextExtractor = ExtractorTest(
+    extractors.text_extractor,
+    classification,
+    expected,
+    'Test text extractor'
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_reducer.py
@@ -1,0 +1,57 @@
+from panoptes_aggregation.reducers.text_reducer import process_data, text_reducer
+from .base_test_class import ReducerTest
+
+extracted_data = [
+    {'text': 'this is some test text'},
+    {'text': 'this is some text text'},
+    {'text': 'this is some test text'},
+    {'text': ''},
+    {'text': '     '}
+]
+
+processed_data = [
+    'this is some test text',
+    'this is some text text',
+    'this is some test text'
+]
+
+reduced_data = {
+    'aligned_text': [
+        ['this', 'this', 'this'],
+        ['is', 'is', 'is'],
+        ['some', 'some', 'some'],
+        ['test', 'text', 'test'],
+        ['text', 'text', 'text']
+    ],
+    'number_views': 3,
+    'consensus_score': 2.8
+}
+
+TestTextReducer = ReducerTest(
+    text_reducer,
+    process_data,
+    extracted_data,
+    processed_data,
+    reduced_data,
+    'Test text reducer',
+    processed_type='list'
+)
+
+extracted_data_blank = [
+    {'text': ''},
+    {'text': ' '},
+    {'text': '   '},
+]
+
+processed_data_blank = []
+reduced_data_blank = {}
+
+TextBalnkTextReducer = ReducerTest(
+    text_reducer,
+    process_data,
+    extracted_data_blank,
+    processed_data_blank,
+    reduced_data_blank,
+    'Test text reducer all extracts balnk',
+    processed_type='list'
+)

--- a/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
+++ b/panoptes_aggregation/tests/utility_tests/test_workflow_config.py
@@ -142,6 +142,10 @@ tasks = {
         'max': '3',
         'min': '1.5',
         'step': '0.01'
+    },
+    'T8': {
+        'type': 'text',
+        'instruction': 'T8.instruction'
     }
 }
 keywords = {
@@ -202,6 +206,9 @@ extractor_config = {
     ],
     'slider_extractor': [
         {'task': 'T7'}
+    ],
+    'text_extractor': [
+        {'task': 'T8'}
     ]
 }
 reducer_config = [
@@ -229,7 +236,8 @@ reducer_config = [
     }},
     {'shortcut_reducer': {}},
     {'slider_reducer': {}},
-    {'survey_reducer': {}}
+    {'survey_reducer': {}},
+    {'text_reducer': {}}
 ]
 
 

--- a/panoptes_aggregation/workflow_config.py
+++ b/panoptes_aggregation/workflow_config.py
@@ -18,7 +18,8 @@ type_to_extractor = {
     'rotateRectangle': 'shape_extractor',
     'triangle': 'shape_extractor',
     'fan': 'shape_extractor',
-    'slider': 'slider_extractor'
+    'slider': 'slider_extractor',
+    'text': 'text_extractor'
 }
 
 standard_reducers = {
@@ -35,7 +36,8 @@ standard_reducers = {
     'sw_extractor': 'poly_line_text_reducer',
     'sw_variant_extractor': 'sw_variant_reducer',
     'shape_extractor': 'shape_reducer_dbscan',
-    'slider_extractor': 'slider_reducer'
+    'slider_extractor': 'slider_reducer',
+    'text_extractor': 'text_reducer'
 }
 
 


### PR DESCRIPTION
Add new extractor and reducer for the Panoptes text task (a free form text box).  The extracts are of the from:

```python
{
    'text': 'this is some test text'
}
```

The reductions are an alignment table of all the responses:

```python
{
    'aligned_text': [
        ['this', 'this', 'this'],
        ['is', 'is', 'is'],
        ['some', 'some', 'some'],
        ['test', 'text', 'test'],
        ['text', 'text', 'text']
    ],
    'number_views': 3,
    'consensus_score': 2.8
}
```

The table has one word per row and one transcription per column.  Alignment is done with the [collatex](http://interedition.github.io/collatex/pythonport.html) python package.