### PR TITLE
Update python from 3.6 to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: bionic  # required for Python >= 3.7
 language: "python"
 python:
-  - "3.6"
+  - "3.7"
 install:
   - pip install -U pip
   - pip install -U .[online,test,doc]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 ENV LANG=C.UTF-8
 

--- a/Dockerfile.bin_cmds
+++ b/Dockerfile.bin_cmds
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
3.6 has entered "security fix only" mode.  It will be supported for another two years, but some packages might start dropping support before that time.

closes #184 