### PR TITLE
Add running reducer for TESS gold standard reducer

### DIFF
--- a/panoptes_aggregation/running_reducers/__init__.py
+++ b/panoptes_aggregation/running_reducers/__init__.py
@@ -1,6 +1,8 @@
 from .tess_user_reducer import tess_user_reducer
+from .tess_gold_standard_reducer import tess_gold_standard_reducer_rr
 
 
 running_reducers = {
-    'tess_user_reducer': tess_user_reducer
+    'tess_user_reducer': tess_user_reducer,
+    'tess_gold_standard_reducer': tess_gold_standard_reducer_rr
 }

--- a/panoptes_aggregation/running_reducers/tess_gold_standard_reducer.py
+++ b/panoptes_aggregation/running_reducers/tess_gold_standard_reducer.py
@@ -1,0 +1,32 @@
+from ..reducers.tess_gold_standard_reducer import process_data as tgsr_process_data
+from .running_reducer_wrapper import running_reducer_wrapper
+import numpy as np
+
+
+@running_reducer_wrapper()
+def tess_gold_standard_reducer_rr(data, **kwargs):
+    store = kwargs.pop('store')
+    output = {
+        '_store': store
+    }
+    count = store.get('count', 0)
+    processed_data = tgsr_process_data(data)
+    if len(processed_data) > 0:
+        current_successes = np.array(processed_data[0], dtype=int)
+        past_successes = np.array(
+            store.get(
+                'number_of_successes',
+                np.zeros(len(current_successes), dtype=int)
+            )
+        )
+        count += 1
+        number_of_successes = past_successes + current_successes
+        output['difficulty'] = (number_of_successes / count).tolist()
+        output['_store'] = {
+            'number_of_successes': number_of_successes.tolist(),
+            'count': count
+        }
+    elif count > 0:
+        past_successes = np.array(store['number_of_successes'])
+        output['difficulty'] = (past_successes / count).tolist()
+    return output

--- a/panoptes_aggregation/tests/running_reducer_tests/test_tess_gold_standard_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_tess_gold_standard_reducer.py
@@ -1,0 +1,91 @@
+from panoptes_aggregation.running_reducers.tess_gold_standard_reducer import tess_gold_standard_reducer_rr
+from .base_test_class import RunningReducerTestNoProcessing
+
+
+extracted_data = [{
+    'feedback':
+        [
+            {'success': True},
+            {'success': True},
+            {'success': False},
+            {'success': True}
+        ]
+}]
+
+kwargs_extra_data = {
+    'store': {
+        'number_of_successes': [2, 2, 1, 3],
+        'count': 3
+    }
+}
+
+reduced_data = {
+    'difficulty': [
+        0.75,
+        0.75,
+        0.25,
+        1.0
+    ],
+    '_store': {
+        'number_of_successes': [3, 3, 1, 4],
+        'count': 4
+    }
+}
+
+TestTESSGoldStandardRunningReducer = RunningReducerTestNoProcessing(
+    tess_gold_standard_reducer_rr,
+    extracted_data,
+    reduced_data,
+    'Test TESS gold standard reducer in running mode',
+    network_kwargs=kwargs_extra_data
+)
+
+kwargs_extra_data_no_store = {
+    'store': {}
+}
+
+reduced_data_no_store = {
+    'difficulty': [1, 1, 0, 1],
+    '_store': {
+        'number_of_successes': [1, 1, 0, 1],
+        'count': 1
+    }
+}
+
+TestTESSGoldStandardRunningReducerNoStore = RunningReducerTestNoProcessing(
+    tess_gold_standard_reducer_rr,
+    extracted_data,
+    reduced_data_no_store,
+    'Test TESS gold standard reducer in running mode with no store',
+    network_kwargs=kwargs_extra_data_no_store
+)
+
+extracted_data_empty = []
+
+reduced_data_empty = {
+    'difficulty': [0.6666666666666666, 0.6666666666666666, 0.3333333333333333, 1.0],
+    '_store': {
+        'number_of_successes': [2, 2, 1, 3],
+        'count': 3
+    }
+}
+
+TestTESSGoldStandardRunningReducerEmptyExtract = RunningReducerTestNoProcessing(
+    tess_gold_standard_reducer_rr,
+    extracted_data_empty,
+    reduced_data_empty,
+    'Test TESS gold standard reducer in running mode with empty extract',
+    network_kwargs=kwargs_extra_data
+)
+
+reduced_data_empty_no_store = {
+    '_store': {}
+}
+
+TestTESSGoldStandardRunningReducerEmptyExtractNoStore = RunningReducerTestNoProcessing(
+    tess_gold_standard_reducer_rr,
+    extracted_data_empty,
+    reduced_data_empty_no_store,
+    'Test TESS gold standard reducer in running mode with empty extract and no store',
+    network_kwargs=kwargs_extra_data_no_store
+)


### PR DESCRIPTION
This will help Caesar process the TESS backlog faster by switching all reducers over to running mode.

In an effort to re-use code the `process_data` function is imported from the existing non-running reducer of the same name.

To avoid errors in Flask the underlying function for this reducer needs a *unique* name, this is why `_rr` has been added at the end of the function name.  The `__init__.py` file in the `running_reducer` folder removes this `_rr` when defining the route name, so the API endpoint will be `/running_reducers/tess_gold_standard_reducer`.