### PR TITLE
Text editor add extractor index

### DIFF
--- a/panoptes_aggregation/reducers/optics_text_utils.py
+++ b/panoptes_aggregation/reducers/optics_text_utils.py
@@ -152,7 +152,7 @@ def remove_nans(input):
     return [i if np.isfinite(i) else None for i in input]
 
 
-def cluster_of_one(X, data, user_ids):
+def cluster_of_one(X, data, user_ids, extract_index):
     '''Create "clusters of one" out of the data passed in. Lines of text
     identified as noise are kept around as clusters of one so they can be
     displayed in the front-end to the next user.
@@ -164,6 +164,10 @@ def cluster_of_one(X, data, user_ids):
     data: list
         A list containing dictionaries with the original data that X maps to, of the form
         `{'x': [start_x, end_x], 'y': [start_y, end_y], 'text': ['text for line'], 'gold_standard': bool}`.
+    user_ids: list
+        A list of user_ids (The second column of X maps to this list)
+    extract_index: list
+        A list of n values with the extract index for each of rows in X
 
     Returns
     -------
@@ -171,7 +175,7 @@ def cluster_of_one(X, data, user_ids):
         A list with n clusters each containing only one calssification
     '''
     clusters = []
-    for row in X:
+    for rdx, row in enumerate(X):
         index = int(row[0])
         user_index = int(row[1])
         line = data[index]
@@ -186,6 +190,7 @@ def cluster_of_one(X, data, user_ids):
             'line_slope': slope,
             'consensus_score': 1.0,
             'user_ids': remove_nans([user_ids[user_index]]),
+            'extract_index': [extract_index[rdx]],
             'gold_standard': [line['gold_standard']]
         }
         clusters.append(value)

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -334,6 +334,7 @@ def cluster_by_line(
     annotation_labels,
     gs_gutter,
     data_index_gutter,
+    ext_index_gutter,
     kwargs_cluster,
     kwargs_dbscan
 ):
@@ -359,6 +360,8 @@ def cluster_by_line(
         An array of bools indicating if the annotation was made in gold standard mode
     data_index_gutter : np.array
         An array of indicies indicating what calssification each classification came from
+    ext_index_gutter : np.array
+        A list of extractor indicies used to map the reduction to the extract
     kwargs_cluster : dict
         A dictionary containing the `eps_*`, `metric`, and `dot_freq` keywords
     kwargs_dbscan : dict
@@ -412,7 +415,8 @@ def cluster_by_line(
             'slope_label': int(kwargs_cluster['slope_label']),
             'gutter_label': int(kwargs_cluster['gutter_label']),
             'gold_standard': gs_gutter[ldx].tolist(),
-            'data_index': data_index_gutter[ldx].tolist()
+            'data_index': data_index_gutter[ldx].tolist(),
+            'extract_index': ext_index_gutter[ldx].tolist()
         }
         if len(line_dict['clusters_x']) > 0:
             frame_lines.append(line_dict)
@@ -425,6 +429,7 @@ def cluster_by_gutter(
     text_slope,
     gs_slope,
     data_index_slope,
+    ext_index_slope,
     kwargs_cluster,
     kwargs_dbscan
 ):
@@ -446,6 +451,8 @@ def cluster_by_gutter(
         A list of bools indicating if the annotation was made in gold standard mode
     data_index_slope : np.array
         A list of indicies indicating what calssification each classification came from
+    ext_index_slope : np.array
+        A list of extractor indicies used to map the reduction to the extract
     kwargs_cluster : dict
         A dictionary containing the `eps_*`, `metric`, and `dot_freq` keywords
     kwargs_dbscan : dict
@@ -477,6 +484,7 @@ def cluster_by_gutter(
             annotation_label,
             gs_slope[gdx],
             data_index_slope[gdx],
+            ext_index_slope[gdx],
             kwargs_cluster,
             kwargs_dbscan
         )
@@ -491,6 +499,7 @@ def cluster_by_slope(
     slope_frame,
     gs_frame,
     data_index_frame,
+    ext_index_frame,
     kwargs_cluster,
     kwargs_dbscan
 ):
@@ -516,6 +525,8 @@ def cluster_by_slope(
         A list of bools indicating if the annotation was made in gold standard mode
     data_index_frame : np.array
         A list of indicies indicating what calssification each classification came from
+    ext_index_frame : np.array
+        A list of extractor indicies used to map the reduction to the extract
     kwargs_cluster : dict
         A dictionary containing the `eps_*`, `metric`, and `dot_freq` keywords
     kwargs_dbscan : dict
@@ -541,6 +552,7 @@ def cluster_by_slope(
                 text_frame[sdx],
                 gs_frame[sdx],
                 data_index_frame[sdx],
+                ext_index_frame[sdx],
                 kwargs_cluster,
                 kwargs_dbscan
             )
@@ -558,6 +570,7 @@ def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan, user_ids_inpu
         x_frame = np.array(copy.deepcopy(value['x']))
         y_frame = np.array(copy.deepcopy(value['y']))
         text_frame = copy.deepcopy(value['text'])
+        ext_index_frame = np.array(extractor_index(value['data_index']))
         # pad with empty strings to keep array sizes the same
         for t in text_frame:
             t.append('')
@@ -569,6 +582,7 @@ def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan, user_ids_inpu
             slope_frame,
             gs_frame,
             data_index_frame,
+            ext_index_frame,
             kwargs_cluster,
             kwargs_dbscan
         )

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -22,6 +22,22 @@ def tokenize(self, contents):
 col.core_classes.WordPunctuationTokenizer.tokenize = tokenize
 
 
+def extractor_index(x):
+    edx = []
+    i_prev = None
+    e_prev = -1
+    for i in x:
+        if i_prev is None:
+            i_prev = i
+        else:
+            if i != i_prev:
+                i_prev = i
+                e_prev = -1
+        e_prev += 1
+        edx.append(e_prev)
+    return edx
+
+
 def overlap(x, y, tol=0):
     '''Check if two line segments overlap
 

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -274,6 +274,7 @@ reduced_data = {
             'line_slope': 358.894,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [2, 0, 3],
             'gold_standard': [False, True, False],
             'slope_label': 0,
             'gutter_label': 0
@@ -292,6 +293,7 @@ reduced_data = {
             'line_slope': 358.894,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [0, 1, 2],
             'gold_standard': [False, True, False],
             'slope_label': 0,
             'gutter_label': 0
@@ -309,6 +311,7 @@ reduced_data = {
             'line_slope': 358.894,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [4, 4, 7],
             'gold_standard': [False, True, False],
             'slope_label': 0,
             'gutter_label': 1
@@ -325,6 +328,7 @@ reduced_data = {
             'line_slope': 358.894,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [5, 5, 5],
             'gold_standard': [False, True, False],
             'slope_label': 0,
             'gutter_label': 1
@@ -341,6 +345,7 @@ reduced_data = {
             'line_slope': 320.143,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [1, 6, 4],
             'gold_standard': [False, True, False],
             'slope_label': 1,
             'gutter_label': 0
@@ -357,6 +362,7 @@ reduced_data = {
             'line_slope': 320.143,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [3, 7, 6],
             'gold_standard': [False, True, False],
             'slope_label': 1,
             'gutter_label': 0
@@ -372,6 +378,7 @@ reduced_data = {
             'line_slope': 320.143,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [6, 2, 0],
             'gold_standard': [False, True, False],
             'slope_label': 1,
             'gutter_label': 1
@@ -388,6 +395,7 @@ reduced_data = {
             'line_slope': 320.143,
             'number_views': 3,
             'user_ids': [1, 2, 3],
+            'extract_index': [7, 3, 1],
             'gold_standard': [False, True, False],
             'slope_label': 1,
             'gutter_label': 1
@@ -405,6 +413,7 @@ reduced_data = {
             'line_slope': 214.875,
             'number_views': 1,
             'user_ids': [4],
+            'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 2,
             'gutter_label': 0
@@ -422,6 +431,7 @@ reduced_data = {
             'line_slope': 0.0,
             'number_views': 2,
             'user_ids': [2, 3],
+            'extract_index': [0, 0],
             'gold_standard': [True, False],
             'slope_label': 0,
             'gutter_label': 0
@@ -439,6 +449,7 @@ reduced_data = {
             'line_slope': 0.0,
             'number_views': 1,
             'user_ids': [4],
+            'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 0,
             'gutter_label': 0
@@ -609,6 +620,7 @@ reduced_data_with_dolar_sign = {
         'line_slope': 0.0,
         'number_views': 7,
         'user_ids': [1, 2, 3, 4, 5, 6, 7],
+        'extract_index': [0, 0, 0, 0, 0, 0, 0],
         'gold_standard': [False, False, False, False, False, False, False],
         'slope_label': 0,
         'gutter_label': 0

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -625,7 +625,8 @@ reduced_data = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 3, 4, 5, 5],
+            'extract_index': [2, 0, 0, 1, 3, 2, 8]
         },
         {
             'clusters_x': [
@@ -655,7 +656,8 @@ reduced_data = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [0, 1, 6, 2, 3]
         },
         {
             'clusters_x': [
@@ -685,7 +687,8 @@ reduced_data = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [4, 4, 2, 7, 0, 1]
         },
         {
             'clusters_x': [
@@ -709,7 +712,8 @@ reduced_data = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
-            'user_ids': [1, 2, 3, 4]
+            'user_ids': [1, 2, 3, 4],
+            'extract_index': [5, 5, 7, 5]
         },
         {
             'clusters_x': [
@@ -736,7 +740,8 @@ reduced_data = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [1, 6, 5, 4, 7]
         },
         {
             'clusters_x': [
@@ -763,7 +768,8 @@ reduced_data = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
-            'user_ids': [1, 2, 4, 5]
+            'user_ids': [1, 2, 4, 5],
+            'extract_index': [3, 7, 6, 4]
         },
         {
             'clusters_x': [
@@ -790,7 +796,8 @@ reduced_data = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [6, 2, 4, 0, 6]
         },
         {
             'clusters_x': [
@@ -817,7 +824,8 @@ reduced_data = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [7, 3, 3, 1, 5, 9]
         }
     ],
     'frame1': [
@@ -843,7 +851,8 @@ reduced_data = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False, True],
-            'user_ids': [2, 4]
+            'user_ids': [2, 4],
+            'extract_index': [0, 0]
         }
     ],
     'frame2': [
@@ -869,7 +878,8 @@ reduced_data = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False],
-            'user_ids': [6]
+            'user_ids': [6],
+            'extract_index': [0]
         }
     ]
 }
@@ -1234,7 +1244,8 @@ reduced_data_by_line = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 3, 4, 5, 5],
+            'extract_index': [2, 0, 0, 1, 3, 2, 8]
         },
         {
             'clusters_x': [
@@ -1258,7 +1269,8 @@ reduced_data_by_line = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [0, 1, 6, 2, 3]
         },
         {
             'clusters_x': [
@@ -1281,7 +1293,8 @@ reduced_data_by_line = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [4, 4, 2, 7, 0, 1]
         },
         {
             'clusters_x': [
@@ -1303,7 +1316,8 @@ reduced_data_by_line = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
-            'user_ids': [1, 2, 3, 4]
+            'user_ids': [1, 2, 3, 4],
+            'extract_index': [5, 5, 7, 5]
         },
         {
             'clusters_x': [
@@ -1325,7 +1339,8 @@ reduced_data_by_line = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [1, 6, 5, 4, 7]
         },
         {
             'clusters_x': [
@@ -1347,7 +1362,8 @@ reduced_data_by_line = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
-            'user_ids': [1, 2, 4, 5]
+            'user_ids': [1, 2, 4, 5],
+            'extract_index': [3, 7, 6, 4]
         },
         {
             'clusters_x': [
@@ -1369,7 +1385,8 @@ reduced_data_by_line = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [6, 2, 4, 0, 6]
         },
         {
             'clusters_x': [
@@ -1391,7 +1408,8 @@ reduced_data_by_line = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [7, 3, 3, 1, 5, 9]
         }
     ],
     'frame1': [
@@ -1414,7 +1432,8 @@ reduced_data_by_line = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False, True],
-            'user_ids': [2, 4]
+            'user_ids': [2, 4],
+            'extract_index': [0, 0]
         }
     ],
     'frame2': [
@@ -1431,7 +1450,8 @@ reduced_data_by_line = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False],
-            'user_ids': [6]
+            'user_ids': [6],
+            'extract_index': [0]
         }
     ]
 }
@@ -1484,7 +1504,8 @@ reduced_data_min_word = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 3, 4, 5, 5],
+            'extract_index': [2, 0, 0, 1, 3, 2, 8]
         },
         {
             'clusters_x': [
@@ -1508,7 +1529,8 @@ reduced_data_min_word = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [0, 1, 6, 2, 3]
         },
         {
             'clusters_x': [
@@ -1531,7 +1553,8 @@ reduced_data_min_word = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [4, 4, 2, 7, 0, 1]
         },
         {
             'clusters_x': [
@@ -1553,7 +1576,8 @@ reduced_data_min_word = {
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
-            'user_ids': [1, 2, 3, 4]
+            'user_ids': [1, 2, 3, 4],
+            'extract_index': [5, 5, 7, 5]
         },
         {
             'clusters_x': [
@@ -1575,7 +1599,8 @@ reduced_data_min_word = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [1, 6, 5, 4, 7]
         },
         {
             'clusters_x': [
@@ -1597,7 +1622,8 @@ reduced_data_min_word = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
-            'user_ids': [1, 2, 4, 5]
+            'user_ids': [1, 2, 4, 5],
+            'extract_index': [3, 7, 6, 4]
         },
         {
             'clusters_x': [
@@ -1619,7 +1645,8 @@ reduced_data_min_word = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
-            'user_ids': [1, 2, 3, 4, 5]
+            'user_ids': [1, 2, 3, 4, 5],
+            'extract_index': [6, 2, 4, 0, 6]
         },
         {
             'clusters_x': [
@@ -1641,7 +1668,8 @@ reduced_data_min_word = {
             'line_slope': -40.020044794251575,
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
-            'user_ids': [1, 2, 3, 4, 5, 5]
+            'user_ids': [1, 2, 3, 4, 5, 5],
+            'extract_index': [7, 3, 3, 1, 5, 9]
         }
     ],
     'frame1': [
@@ -1664,7 +1692,8 @@ reduced_data_min_word = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False, True],
-            'user_ids': [2, 4]
+            'user_ids': [2, 4],
+            'extract_index': [0, 0]
         }
     ],
     'frame2': [
@@ -1681,7 +1710,8 @@ reduced_data_min_word = {
             'line_slope': 0.0,
             'slope_label': 0,
             'gold_standard': [False],
-            'user_ids': [6]
+            'user_ids': [6],
+            'extract_index': [0]
         }
     ]
 }

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -868,7 +868,8 @@ reduced_data = {
             'number_views': 4,
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
-            'user_ids': [1, 4, 5, 6]
+            'user_ids': [1, 4, 5, 6],
+            'extract_index': [0, 0, 0, 0]
         },
         {
             'clusters_text': [
@@ -885,7 +886,8 @@ reduced_data = {
             'number_views': 4,
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
-            'user_ids': [2, 4, 5, 6]
+            'user_ids': [2, 4, 5, 6],
+            'extract_index': [0, 1, 1, 1]
         },
         {
             'clusters_text': [
@@ -902,7 +904,8 @@ reduced_data = {
             'number_views': 5,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False],
-            'user_ids': [2, 3, 4, 5, 6]
+            'user_ids': [2, 3, 4, 5, 6],
+            'extract_index': [1, 0, 2, 2, 2]
         },
         {
             'clusters_text': [
@@ -919,7 +922,8 @@ reduced_data = {
             'number_views': 4,
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
-            'user_ids': [3, 4, 5, 6]
+            'user_ids': [3, 4, 5, 6],
+            'extract_index': [1, 3, 3, 3]
         },
         {
             'clusters_text': [
@@ -936,7 +940,8 @@ reduced_data = {
             'number_views': 6,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False, False],
-            'user_ids': [3, 3, 4, 5, 5, 6]
+            'user_ids': [3, 3, 4, 5, 5, 6],
+            'extract_index': [3, 4, 4, 4, 5, 4]
         },
         {
             'clusters_text': [
@@ -954,7 +959,8 @@ reduced_data = {
             'number_views': 3,
             'slope_label': 0,
             'gold_standard': [False, False, False],
-            'user_ids': [1, 4, 6]
+            'user_ids': [1, 4, 6],
+            'extract_index': [2, 5, 5]
         },
         {
             'clusters_text': [
@@ -973,6 +979,7 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [3, 4, 5, 6],
+            'extract_index': [5, 6, 6, 6]
         },
         {
             'clusters_text': [
@@ -989,7 +996,8 @@ reduced_data = {
             'number_views': 4,
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
-            'user_ids': [3, 4, 5, 6]
+            'user_ids': [3, 4, 5, 6],
+            'extract_index': [2, 7, 8, 7]
         },
         {
             'clusters_text': [
@@ -1006,7 +1014,8 @@ reduced_data = {
             'number_views': 5,
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False],
-            'user_ids': [1, 4, 5, 5, 6]
+            'user_ids': [1, 4, 5, 5, 6],
+            'extract_index': [4, 8, 9, 10, 8]
         },
         {
             'clusters_text': [
@@ -1022,7 +1031,8 @@ reduced_data = {
             'number_views': 3,
             'slope_label': 0,
             'gold_standard': [False, False, False],
-            'user_ids': [4, 5, 6]
+            'user_ids': [4, 5, 6],
+            'extract_index': [9, 11, 9]
         },
         {
             'clusters_text': [
@@ -1040,7 +1050,8 @@ reduced_data = {
             'number_views': 3,
             'slope_label': 0,
             'gold_standard': [False, False, False],
-            'user_ids': [4, 5, 6]
+            'user_ids': [4, 5, 6],
+            'extract_index': [10, 12, 10]
         },
         {
             'clusters_text': [
@@ -1057,7 +1068,8 @@ reduced_data = {
             'number_views': 3,
             'slope_label': 0,
             'gold_standard': [False, False, False],
-            'user_ids': [5, 5, 6]
+            'user_ids': [5, 5, 6],
+            'extract_index': [13, 23, 16]
         },
         {
             'clusters_text': [
@@ -1074,7 +1086,8 @@ reduced_data = {
             'number_views': 3,
             'slope_label': 0,
             'gold_standard': [False, False, False],
-            'user_ids': [4, 5, 6]
+            'user_ids': [4, 5, 6],
+            'extract_index': [11, 24, 11]
         },
         {
             'clusters_text': [
@@ -1089,7 +1102,8 @@ reduced_data = {
             'number_views': 2,
             'slope_label': 0,
             'gold_standard': [False, False],
-            'user_ids': [5, 6]
+            'user_ids': [5, 6],
+            'extract_index': [15, 12]
         },
         {
             'clusters_text': [
@@ -1106,7 +1120,8 @@ reduced_data = {
             'number_views': 2,
             'slope_label': 0,
             'gold_standard': [False, False],
-            'user_ids': [5, 6]
+            'user_ids': [5, 6],
+            'extract_index': [16, 14]
         },
         {
             'clusters_text': [
@@ -1124,7 +1139,8 @@ reduced_data = {
             'number_views': 4,
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
-            'user_ids': [1, 4, 5, 6]
+            'user_ids': [1, 4, 5, 6],
+            'extract_index': [7, 12, 17, 15]
         }
     ]
 }

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
@@ -69,7 +69,8 @@ reduced_data = {
             'number_views': 1,
             'slope_label': 0,
             'gold_standard': [False],
-            'user_ids': [1]
+            'user_ids': [1],
+            'extract_index': [0]
         }
     ]
 }

--- a/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
@@ -97,6 +97,7 @@ class TextOpticsTextUtils(unittest.TestCase):
         user_ids = [
             0
         ]
+        ext_index = [0, 0]
         expected = [
             {
                 'clusters_x': [1, 5],
@@ -112,6 +113,7 @@ class TextOpticsTextUtils(unittest.TestCase):
                 'line_slope': 0.0,
                 'consensus_score': 1.0,
                 'user_ids': [0],
+                'extract_index': [0],
                 'gold_standard': [False]
             },
             {
@@ -128,10 +130,11 @@ class TextOpticsTextUtils(unittest.TestCase):
                 'line_slope': 0.0,
                 'consensus_score': 1.0,
                 'user_ids': [0],
+                'extract_index': [0],
                 'gold_standard': [False]
             }
         ]
-        result = optics_text_utils.cluster_of_one(X, data, user_ids)
+        result = optics_text_utils.cluster_of_one(X, data, user_ids, ext_index)
         self.assertCountEqual(result, expected)
 
     def test_order_lines(self):

--- a/panoptes_aggregation/tests/utility_tests/test_text_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_text_utils.py
@@ -77,6 +77,7 @@ class TestTextUtils(unittest.TestCase):
                 [],
                 [],
                 [],
+                [],
                 {'dot_freq': 'bad_keyword'},
                 {}
             )

--- a/panoptes_aggregation/tests/utility_tests/test_text_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_text_utils.py
@@ -81,6 +81,12 @@ class TestTextUtils(unittest.TestCase):
                 {}
             )
 
+    def test_extractor_index(self):
+        input = [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3]
+        expected = [0, 1, 2, 3, 0, 1, 2, 3, 4, 0, 1, 2, 0]
+        result = text_utils.extractor_index(input)
+        self.assertEquals(result, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds an additional value `extract_index` to the text reducers.  This index can be used in combination with the `user_id` and `frame#` to find the original line of text within the extract.

This will be needed so the new text-editor app can match up reductions with the original lines drawn by the volunteers.