### PR TITLE
Optimize offline extractor and reducer scripts

### DIFF
--- a/panoptes_aggregation/extractors/question_extractor.py
+++ b/panoptes_aggregation/extractors/question_extractor.py
@@ -4,7 +4,7 @@ Question Extractor
 This module provides a function to extract question tasks (single and multiple)
 from panoptes annotations.
 '''
-from collections import Counter
+from collections import defaultdict
 from slugify import slugify
 from .extractor_wrapper import extractor_wrapper
 
@@ -50,7 +50,7 @@ def question_extractor(classification, **kwargs):
     {'yes': 1}
     '''
     #: assumes only one task is filtered into the extractor
-    answers = Counter()
+    answers = defaultdict(int)
     if len(classification['annotations']) > 0:
         annotation = classification['annotations'][0]
         if isinstance(annotation['value'], list):

--- a/panoptes_aggregation/reducers/question_reducer.py
+++ b/panoptes_aggregation/reducers/question_reducer.py
@@ -12,12 +12,13 @@ DEFAULTS = {
 }
 
 
-def process_data(data, pairs=False):
-    '''Process a list of extracted questions into `Counter` objects
+@reducer_wrapper(defaults_data=DEFAULTS)
+def question_reducer(data_list, pairs=False, **kwargs):
+    '''Reduce a list of extracted questions into a "counter" dict
 
     Parameters
     ----------
-    data : list
+    data_list : list
         A list of extractions created by
         :meth:`panoptes_aggregation.extractors.question_extractor.question_extractor`
     pairs : bool, optional
@@ -26,33 +27,15 @@ def process_data(data, pairs=False):
 
     Returns
     -------
-    processed_data : list
-        A list of `Counter` objects, one for each extraction
-    '''
-    data_out = []
-    for d in data:
-        if pairs:
-            new_key = '+'.join(sorted(d))
-            data_out.append(Counter({new_key: 1}))
-        else:
-            data_out.append(Counter(d))
-    return data_out
-
-
-@reducer_wrapper(process_data=process_data, defaults_process=DEFAULTS)
-def question_reducer(votes_list):
-    '''Reduce a list of `Counter` objects into a single dict
-
-    Parameters
-    ----------
-    votes_list : list
-        A list of `Counter` objects from :meth:`process_data`
-
-    Returns
-    -------
     reduction : dict
         A dictionary (formated as a `Counter`) giving the vote count for each
         `key`
     '''
-    counter_total = sum(votes_list, Counter())
+    answer_list = []
+    for data in data_list:
+        if pairs:
+            answer_list.append('+'.join(sorted(data)))
+        else:
+            answer_list += list(data)
+    counter_total = Counter(answer_list)
     return dict(counter_total)

--- a/panoptes_aggregation/scripts/aggregation_parser.py
+++ b/panoptes_aggregation/scripts/aggregation_parser.py
@@ -167,6 +167,13 @@ def main(args=None):
         action="store_true"
     )
     extract_options.add_argument(
+        "-c",
+        "--cpu_count",
+        help="How many cpu cores to use during extraction",
+        type=int,
+        default=1
+    )
+    extract_options.add_argument(
         "-vv",
         "--verbose",
         help="increase output verbosity",
@@ -273,7 +280,8 @@ def main(args=None):
             output_name=args.output,
             output_dir=args.dir,
             order=args.order,
-            verbose=args.verbose
+            verbose=args.verbose,
+            cpu_count=args.cpu_count
         )
     elif args.subparser == 'reduce':
         panoptes_aggregation.scripts.reduce_csv(

--- a/panoptes_aggregation/scripts/aggregation_parser.py
+++ b/panoptes_aggregation/scripts/aggregation_parser.py
@@ -225,6 +225,13 @@ def main(args=None):
         help="Arrange the data columns in alphabetical order before saving",
         action="store_true"
     )
+    reduce_options.add_argument(
+        "-c",
+        "--cpu_count",
+        help="How many cpu cores to use during reduction",
+        type=int,
+        default=os.cpu_count()
+    )
     reduce_save_files.add_argument(
         "-d",
         "--dir",
@@ -276,7 +283,8 @@ def main(args=None):
             output_name=args.output,
             output_dir=args.dir,
             order=args.order,
-            stream=args.stream
+            stream=args.stream,
+            cpu_count=args.cpu_count
         )
     return 0
 

--- a/panoptes_aggregation/scripts/aggregation_parser.py
+++ b/panoptes_aggregation/scripts/aggregation_parser.py
@@ -230,7 +230,7 @@ def main(args=None):
         "--cpu_count",
         help="How many cpu cores to use during reduction",
         type=int,
-        default=os.cpu_count()
+        default=1
     )
     reduce_save_files.add_argument(
         "-d",

--- a/panoptes_aggregation/scripts/extract_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/extract_panoptes_csv.py
@@ -1,4 +1,5 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
+from multiprocessing import Pool
 import copy
 import json
 import io
@@ -27,13 +28,61 @@ def get_major_version(s):
     return s.split('.')[0]
 
 
+def extract_classification(
+    classification_by_task,
+    classification_info,
+    extractor_key,
+    extractor_name,
+    keyword,
+    verbose
+):
+    try:
+        extract = extractors.extractors[extractor_key](classification_by_task, **keyword)
+        new_extract_row = []
+        if isinstance(extract, list):
+            for e in extract:
+                new_extract_row.append(OrderedDict([
+                    ('classification_id', classification_info['classification_id']),
+                    ('user_name', classification_info['user_name']),
+                    ('user_id', classification_info['user_id']),
+                    ('workflow_id', classification_info['workflow_id']),
+                    ('task', keyword['task']),
+                    ('created_at', classification_info['created_at']),
+                    ('subject_id', classification_info['subject_ids']),
+                    ('extractor', extractor_name),
+                    ('data', e)
+                ]))
+        else:
+            new_extract_row.append(OrderedDict([
+                ('classification_id', classification_info['classification_id']),
+                ('user_name', classification_info['user_name']),
+                ('user_id', classification_info['user_id']),
+                ('workflow_id', classification_info['workflow_id']),
+                ('task', keyword['task']),
+                ('created_at', classification_info['created_at']),
+                ('subject_id', classification_info['subject_ids']),
+                ('extractor', extractor_name),
+                ('data', extract)
+            ]))
+    except:
+        new_extract_row = None
+        if verbose:
+            print()
+            print('Incorrectly formatted annotation')
+            print(classification_info)
+            print(extractor_key)
+            print(classification_by_task)
+    return extractor_name, new_extract_row
+
+
 def extract_csv(
     classification_csv,
     config,
     output_dir=os.path.abspath('.'),
     output_name='extractions',
     order=False,
-    verbose=False
+    verbose=False,
+    cpu_count=1
 ):
     config = get_file_instance(config)
     with config as config_in:
@@ -42,20 +91,9 @@ def extract_csv(
     extractor_config = config_yaml['extractor_config']
     workflow_id = config_yaml['workflow_id']
     version = config_yaml['workflow_version']
+    number_of_extractors = sum([len(value) for key, value in extractor_config.items()])
 
-    blank_extracted_data = OrderedDict([
-        ('classification_id', []),
-        ('user_name', []),
-        ('user_id', []),
-        ('workflow_id', []),
-        ('task', []),
-        ('created_at', []),
-        ('subject_id', []),
-        ('extractor', []),
-        ('data', [])
-    ])
-
-    extracted_data = {}
+    extracted_data = defaultdict(list)
 
     classification_csv = get_file_instance(classification_csv)
     with classification_csv as classification_csv_in:
@@ -77,53 +115,83 @@ def extract_csv(
         ' ', progressbar.Bar(),
         ' ', progressbar.ETA()
     ]
-    pbar = progressbar.ProgressBar(widgets=widgets, max_value=(wdx & vdx).sum())
+    max_pbar = (wdx & vdx).sum() * number_of_extractors
+    pbar = progressbar.ProgressBar(widgets=widgets, max_value=max_pbar)
     counter = 0
-    pbar.start()
-    for cdx, classification in classifications[wdx & vdx].iterrows():
-        classification_by_task = annotation_by_task({'annotations': json.loads(classification.annotations)})
-        for extractor_name, keywords in extractor_config.items():
-            extractor_key = extractor_name
-            if 'shape_extractor' in extractor_name:
-                extractor_key = 'shape_extractor'
-            for keyword in keywords:
-                if extractor_key in extractors.extractors:
-                    try:
-                        extract = extractors.extractors[extractor_key](copy.deepcopy(classification_by_task), **keyword)
-                    except:
-                        if verbose:
-                            print()
-                            print('Incorrectly formatted annotation')
-                            print(classification)
-                            print(extractor_key)
-                            print(classification_by_task)
-                            print(keyword)
-                        continue
-                    if isinstance(extract, list):
-                        for e in extract:
-                            extracted_data.setdefault(extractor_name, copy.deepcopy(blank_extracted_data))
-                            extracted_data[extractor_name]['classification_id'].append(classification.classification_id)
-                            extracted_data[extractor_name]['user_name'].append(classification.user_name)
-                            extracted_data[extractor_name]['user_id'].append(classification.user_id)
-                            extracted_data[extractor_name]['workflow_id'].append(classification.workflow_id)
-                            extracted_data[extractor_name]['task'].append(keyword['task'])
-                            extracted_data[extractor_name]['created_at'].append(classification.created_at)
-                            extracted_data[extractor_name]['subject_id'].append(classification.subject_ids)
-                            extracted_data[extractor_name]['extractor'].append(extractor_name)
-                            extracted_data[extractor_name]['data'].append(e)
-                    else:
-                        extracted_data.setdefault(extractor_name, copy.deepcopy(blank_extracted_data))
-                        extracted_data[extractor_name]['classification_id'].append(classification.classification_id)
-                        extracted_data[extractor_name]['user_name'].append(classification.user_name)
-                        extracted_data[extractor_name]['user_id'].append(classification.user_id)
-                        extracted_data[extractor_name]['workflow_id'].append(classification.workflow_id)
-                        extracted_data[extractor_name]['task'].append(keyword['task'])
-                        extracted_data[extractor_name]['created_at'].append(classification.created_at)
-                        extracted_data[extractor_name]['subject_id'].append(classification.subject_ids)
-                        extracted_data[extractor_name]['extractor'].append(extractor_name)
-                        extracted_data[extractor_name]['data'].append(extract)
+
+    def callback(name_with_row):
+        nonlocal extracted_data
+        nonlocal counter
+        nonlocal pbar
+        extractor_name, new_extract_row = name_with_row
+        if new_extract_row is not None:
+            extracted_data[extractor_name] += new_extract_row
         counter += 1
         pbar.update(counter)
+
+    pbar.start()
+    if cpu_count > 1:
+        pool = Pool(cpu_count)
+        for cdx, classification in classifications[wdx & vdx].iterrows():
+            classification_by_task = annotation_by_task({'annotations': json.loads(classification.annotations)})
+            classification_info = {
+                'classification_id': classification.classification_id,
+                'user_name': classification.user_name,
+                'user_id': classification.user_id,
+                'workflow_id': classification.workflow_id,
+                'created_at': classification.created_at,
+                'subject_ids': classification.subject_ids
+            }
+            for extractor_name, keywords in extractor_config.items():
+                extractor_key = extractor_name
+                if 'shape_extractor' in extractor_name:
+                    extractor_key = 'shape_extractor'
+                for keyword in keywords:
+                    if extractor_key in extractors.extractors:
+                        pool.apply_async(
+                            extract_classification,
+                            args=(
+                                copy.deepcopy(classification_by_task),
+                                classification_info,
+                                extractor_key,
+                                extractor_name,
+                                keyword,
+                                verbose
+                            ),
+                            callback=callback
+                        )
+                    else:
+                        callback((None, None))
+        pool.close()
+        pool.join()
+    else:
+        for cdx, classification in classifications[wdx & vdx].iterrows():
+            classification_by_task = annotation_by_task({'annotations': json.loads(classification.annotations)})
+            classification_info = {
+                'classification_id': classification.classification_id,
+                'user_name': classification.user_name,
+                'user_id': classification.user_id,
+                'workflow_id': classification.workflow_id,
+                'created_at': classification.created_at,
+                'subject_ids': classification.subject_ids
+            }
+            for extractor_name, keywords in extractor_config.items():
+                extractor_key = extractor_name
+                if 'shape_extractor' in extractor_name:
+                    extractor_key = 'shape_extractor'
+                for keyword in keywords:
+                    if extractor_key in extractors.extractors:
+                        name_with_row = extract_classification(
+                            copy.deepcopy(classification_by_task),
+                            classification_info,
+                            extractor_key,
+                            extractor_name,
+                            keyword,
+                            verbose
+                        )
+                        callback(name_with_row)
+                    else:
+                        callback((None, None))
     pbar.finish()
 
     # create one flat csv file for each extractor used
@@ -132,7 +200,8 @@ def extract_csv(
     for extractor_name, data in extracted_data.items():
         output_path = os.path.join(output_dir, '{0}_{1}.csv'.format(extractor_name, output_base_name))
         output_files.append(output_path)
-        flat_extract = flatten_data(data)
+        non_flat_extract = pandas.DataFrame(data)
+        flat_extract = flatten_data(non_flat_extract)
         if order:
             flat_extract = order_columns(flat_extract, front=['choice'])
         flat_extract.to_csv(output_path, index=False, encoding='utf-8')

--- a/panoptes_aggregation/scripts/extract_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/extract_panoptes_csv.py
@@ -75,10 +75,13 @@ def extract_classification(
     return extractor_name, new_extract_row
 
 
+CURRENT_PATH = os.path.abspath('.')
+
+
 def extract_csv(
     classification_csv,
     config,
-    output_dir=os.path.abspath('.'),
+    output_dir=CURRENT_PATH,
     output_name='extractions',
     order=False,
     verbose=False,

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -54,7 +54,8 @@ def reduce_subject(
         jdx = extracted.task == task
         classifications = extracted[idx & jdx]
         classifications = classifications.drop_duplicates()
-        if filter in FILTER_TYPES:
+        unique_users = classifications['user_name'].unique().shape[0]
+        if (filter in FILTER_TYPES) and (unique_users < classifications.shape[0]):
             classifications = classifications.groupby(['user_name'], group_keys=False).apply(FILTER_TYPES[filter])
         data = [unflatten_data(c) for cdx, c in classifications.iterrows()]
         user_ids = [c.user_id for cdx, c in classifications.iterrows()]

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -154,13 +154,16 @@ def reduce_csv(
         pbar.update(sdx)
 
     pbar.start()
-    pool = Pool(cpu_count)
-    for subject in subjects:
-        pool.apply_async(reduce_subject, args=(subject,), kwds=apply_keywords, callback=callback)
-        # reduced_data_list = reduce_subject(subject, **apply_keywords)
-        # callback(reduced_data_list)
-    pool.close()
-    pool.join()
+    if cpu_count > 1:
+        pool = Pool(cpu_count)
+        for subject in subjects:
+            pool.apply_async(reduce_subject, args=(subject,), kwds=apply_keywords, callback=callback)
+        pool.close()
+        pool.join()
+    else:
+        for subject in subjects:
+            reduced_data_list = reduce_subject(subject, **apply_keywords)
+            callback(reduced_data_list)
     pbar.finish()
 
     if stream:

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -84,7 +84,7 @@ def reduce_csv(
     output_dir=os.path.abspath('.'),
     order=False,
     stream=False,
-    cpu_count=os.cpu_count()
+    cpu_count=1
 ):
     extracted_csv = get_file_instance(extracted_csv)
     with extracted_csv as extracted_csv_in:

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -45,6 +45,7 @@ def reduce_subject(
     tasks=None,
     reducer_name=None,
     workflow_id=None,
+    filter=None,
     keywords={}
 ):
     reduced_data_list = []
@@ -127,6 +128,7 @@ def reduce_csv(
         'tasks': tasks,
         'reducer_name': reducer_name,
         'workflow_id': workflow_id,
+        'filter': filter,
         'keywords': keywords
     }
 

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -79,15 +79,16 @@ def reduce_csv(
                 reduced_csv = pandas.read_csv(reduced_file, encoding='utf-8')
                 subjects = np.setdiff1d(subjects, reduced_csv.subject_id)
 
-    blank_reduced_data = OrderedDict([
-        ('subject_id', []),
-        ('workflow_id', []),
-        ('task', []),
-        ('reducer', []),
-        ('data', [])
-    ])
+    # blank_reduced_data = OrderedDict([
+    #     ('subject_id', []),
+    #     ('workflow_id', []),
+    #     ('task', []),
+    #     ('reducer', []),
+    #     ('data', [])
+    # ])
 
-    reduced_data = copy.deepcopy(blank_reduced_data)
+    # reduced_data = copy.deepcopy(blank_reduced_data)
+    reduced_data = []
 
     widgets = [
         'Reducing: ',
@@ -111,23 +112,27 @@ def reduce_csv(
             reduction = reducers.reducers[reducer_name](data, user_id=user_ids, **keywords)
             if isinstance(reduction, list):
                 for r in reduction:
-                    reduced_data['subject_id'].append(subject)
-                    reduced_data['workflow_id'].append(workflow_id)
-                    reduced_data['task'].append(task)
-                    reduced_data['reducer'].append(reducer_name)
-                    reduced_data['data'].append(r)
+                    reduced_data.append(OrderedDict([
+                        ('subject_id', subject),
+                        ('workflow_id', workflow_id),
+                        ('task', task),
+                        ('reducer', reducer_name),
+                        ('data', r)
+                    ]))
             else:
-                reduced_data['subject_id'].append(subject)
-                reduced_data['workflow_id'].append(workflow_id)
-                reduced_data['task'].append(task)
-                reduced_data['reducer'].append(reducer_name)
-                reduced_data['data'].append(reduction)
+                reduced_data.append(OrderedDict([
+                    ('subject_id', subject),
+                    ('workflow_id', workflow_id),
+                    ('task', task),
+                    ('reducer', reducer_name),
+                    ('data', reduction)
+                ]))
         if stream:
             if (sdx == 0) and (not resume):
                 pandas.DataFrame(reduced_data).to_csv(output_path, mode='w', index=False, encoding='utf-8')
             else:
                 pandas.DataFrame(reduced_data).to_csv(output_path, mode='a', index=False, header=False, encoding='utf-8')
-            reduced_data = copy.deepcopy(blank_reduced_data)
+            reduced_data = []
         pbar.update(sdx + 1)
     pbar.finish()
 
@@ -139,7 +144,8 @@ def reduce_csv(
         else:
             return output_path
     else:
-        flat_reduced_data = flatten_data(reduced_data)
+        non_flat_data = pandas.DataFrame(reduced_data)
+        flat_reduced_data = flatten_data(non_flat_data)
     if order:
         flat_reduced_data = order_columns(flat_reduced_data, front=['choice', 'total_vote_count', 'choice_count'])
     flat_reduced_data.to_csv(output_path, index=False, encoding='utf-8')

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -76,12 +76,15 @@ def reduce_subject(
     return reduced_data_list
 
 
+CURRENT_PATH = os.path.abspath('.')
+
+
 def reduce_csv(
     extracted_csv,
     reducer_config,
     filter='first',
     output_name='reductions',
-    output_dir=os.path.abspath('.'),
+    output_dir=CURRENT_PATH,
     order=False,
     stream=False,
     cpu_count=1

--- a/panoptes_aggregation/tests/reducer_tests/test_question_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_question_reducer.py
@@ -1,6 +1,5 @@
-from collections import Counter
-from panoptes_aggregation.reducers.question_reducer import process_data, question_reducer
-from .base_test_class import ReducerTest
+from panoptes_aggregation.reducers.question_reducer import question_reducer
+from .base_test_class import ReducerTestNoProcessing
 
 extracted_data = [
     {'a': 1, 'b': 1},
@@ -9,35 +8,18 @@ extracted_data = [
     {'b': 1, 'a': 1}
 ]
 
-processed_data = [
-    Counter({'a': 1, 'b': 1}),
-    Counter({'a': 1}),
-    Counter({'b': 1, 'c': 1}),
-    Counter({'b': 1, 'a': 1})
-]
-
 reduced_data = {
     'a': 3,
     'b': 3,
     'c': 1
 }
 
-TestQuestionReducer = ReducerTest(
+TestQuestionReducer = ReducerTestNoProcessing(
     question_reducer,
-    process_data,
     extracted_data,
-    processed_data,
     reduced_data,
-    'Test question reducer',
-    processed_type='list'
+    'Test question reducer'
 )
-
-processed_data_pairs = [
-    Counter({'a+b': 1}),
-    Counter({'a': 1}),
-    Counter({'b+c': 1}),
-    Counter({'a+b': 1})
-]
 
 reduced_data_pairs = {
     'a+b': 2,
@@ -45,13 +27,10 @@ reduced_data_pairs = {
     'b+c': 1
 }
 
-TestQuestionReducerPairs = ReducerTest(
+TestQuestionReducerPairs = ReducerTestNoProcessing(
     question_reducer,
-    process_data,
     extracted_data,
-    processed_data_pairs,
     reduced_data_pairs,
     'Test question reducer as pairs',
-    pkwargs={'pairs': True},
-    processed_type='list'
+    kwargs={'pairs': True}
 )

--- a/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
@@ -32,7 +32,8 @@ class TestAggregationParser(unittest.TestCase):
             order=False,
             output_dir=os.getcwd(),
             verbose=False,
-            output_name='extractions'
+            output_name='extractions',
+            cpu_count=1
         )
 
     @patch('panoptes_aggregation.scripts.aggregation_parser.argparse.FileType')

--- a/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
@@ -47,5 +47,6 @@ class TestAggregationParser(unittest.TestCase):
             order=False,
             output_dir=os.getcwd(),
             stream=False,
-            output_name='reductions'
+            output_name='reductions',
+            cpu_count=os.cpu_count()
         )

--- a/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_aggregation_parser.py
@@ -48,5 +48,5 @@ class TestAggregationParser(unittest.TestCase):
             output_dir=os.getcwd(),
             stream=False,
             output_name='reductions',
-            cpu_count=os.cpu_count()
+            cpu_count=1
         )

--- a/panoptes_aggregation/tests/scripts_tests/test_config_workflow.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_config_workflow.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, call
 from io import StringIO
+import os
 import panoptes_aggregation.scripts.config_workflow_panoptes
 
 
@@ -81,9 +82,9 @@ class TestConfigWorkflowCL(unittest.TestCase):
             output_dir='home'
         )
         open_calls = [
-            call('home/Extractor_config_workflow_4249_V14.18.yaml', 'w', encoding='utf-8'),
-            call('home/Reducer_config_workflow_4249_V14.18_question_extractor.yaml', 'w', encoding='utf-8'),
-            call('home/Task_labels_workflow_4249_V14.18.yaml', 'w', encoding='utf-8')
+            call(os.path.join('home', 'Extractor_config_workflow_4249_V14.18.yaml'), 'w', encoding='utf-8'),
+            call(os.path.join('home', 'Reducer_config_workflow_4249_V14.18_question_extractor.yaml'), 'w', encoding='utf-8'),
+            call(os.path.join('home', 'Task_labels_workflow_4249_V14.18.yaml'), 'w', encoding='utf-8')
         ]
         mock_open.assert_has_calls(open_calls, any_order=True)
 

--- a/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
@@ -5,7 +5,6 @@ import os
 import pandas
 from pandas.util.testing import assert_frame_equal
 import panoptes_aggregation.scripts.reduce_panoptes_csv as reduce_panoptes_csv
-import logging
 
 extracted_csv_question = '''classification_id,user_name,user_id,workflow_id,task,created_at,subject_id,extractor,data.blue,data.green,data.no,data.yes
 1,1,1,4249,T0,2017-05-31 12:33:46 UTC,1,question_extractor,,,,1.0
@@ -66,10 +65,6 @@ class CaptureValues(object):
 
 mock_question_reducer = MagicMock()
 mock_question_reducer.side_effect = [
-    {'yes': 1, 'no': 1},
-    {'blue': 1, 'green': 1},
-    {'yes': 1, 'no': 1},
-    {'blue': 1, 'green': 1},
     {'yes': 1, 'no': 1},
     {'blue': 1, 'green': 1},
     {'yes': 1, 'no': 1},
@@ -156,16 +151,27 @@ class TestReduceCSV(unittest.TestCase):
             filter='all',
             cpu_count=1
         )
-        # mock_question_reducer.assert_any_call([{'yes': 1.0}, {'no': 1.0}], user_id=[1, 2])
+        mock_question_reducer.assert_any_call([{'yes': 1.0}, {'no': 1.0}], user_id=[1, 2])
         output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
         self.assertEqual(output_file_name, output_path)
         result_dataframe = reduce_panoptes_csv.flatten_data.return_values[0]
-        try:
-            assert_frame_equal(result_dataframe, self.reduced_dataframe_question, check_like=True)
-        except:
-            print(result_dataframe)
-            print(self.reduced_dataframe_question)
-            raise
+        assert_frame_equal(result_dataframe, self.reduced_dataframe_question, check_like=True)
+        mock_to_csv.assert_called_once_with(output_path, index=False, encoding='utf-8')
+
+    @patch('panoptes_aggregation.scripts.reduce_panoptes_csv.progressbar.ProgressBar')
+    @patch('panoptes_aggregation.scripts.reduce_panoptes_csv.pandas.DataFrame.to_csv')
+    @patch.dict('panoptes_aggregation.scripts.reduce_panoptes_csv.reducers.reducers', mock_reducers_dict)
+    @patch('panoptes_aggregation.scripts.reduce_panoptes_csv.flatten_data', CaptureValues(reduce_panoptes_csv.flatten_data))
+    def test_reduce_csv_object_multi(self, mock_to_csv, mock_pbar):
+        '''Test object reducer makes one csv file with cpu_count=2'''
+        output_file_name = reduce_panoptes_csv.reduce_csv(
+            self.extracted_csv_question,
+            self.config_yaml_question,
+            filter='all',
+            cpu_count=2
+        )
+        output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
+        self.assertEqual(output_file_name, output_path)
         mock_to_csv.assert_called_once_with(output_path, index=False, encoding='utf-8')
 
     @patch('panoptes_aggregation.scripts.reduce_panoptes_csv.progressbar.ProgressBar')

--- a/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
@@ -200,6 +200,8 @@ class TestReduceCSV(unittest.TestCase):
         to_csv_calls = [
             call(output_path, mode='w', index=False, encoding='utf-8'),
             call(output_path, mode='a', index=False, header=False, encoding='utf-8'),
+            call(output_path, mode='a', index=False, header=False, encoding='utf-8'),
+            call(output_path, mode='a', index=False, header=False, encoding='utf-8'),
             call(output_path, index=False, encoding='utf-8')
         ]
         mock_to_csv.assert_has_calls(to_csv_calls, any_order=False)

--- a/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
@@ -5,6 +5,7 @@ import os
 import pandas
 from pandas.util.testing import assert_frame_equal
 import panoptes_aggregation.scripts.reduce_panoptes_csv as reduce_panoptes_csv
+import logging
 
 extracted_csv_question = '''classification_id,user_name,user_id,workflow_id,task,created_at,subject_id,extractor,data.blue,data.green,data.no,data.yes
 1,1,1,4249,T0,2017-05-31 12:33:46 UTC,1,question_extractor,,,,1.0
@@ -65,6 +66,10 @@ class CaptureValues(object):
 
 mock_question_reducer = MagicMock()
 mock_question_reducer.side_effect = [
+    {'yes': 1, 'no': 1},
+    {'blue': 1, 'green': 1},
+    {'yes': 1, 'no': 1},
+    {'blue': 1, 'green': 1},
     {'yes': 1, 'no': 1},
     {'blue': 1, 'green': 1},
     {'yes': 1, 'no': 1},
@@ -148,13 +153,19 @@ class TestReduceCSV(unittest.TestCase):
         output_file_name = reduce_panoptes_csv.reduce_csv(
             self.extracted_csv_question,
             self.config_yaml_question,
-            filter='all'
+            filter='all',
+            cpu_count=1
         )
-        mock_question_reducer.assert_any_call([{'yes': 1.0}, {'no': 1.0}], user_id=[1, 2])
+        # mock_question_reducer.assert_any_call([{'yes': 1.0}, {'no': 1.0}], user_id=[1, 2])
         output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
         self.assertEqual(output_file_name, output_path)
         result_dataframe = reduce_panoptes_csv.flatten_data.return_values[0]
-        assert_frame_equal(result_dataframe, self.reduced_dataframe_question, check_like=True)
+        try:
+            assert_frame_equal(result_dataframe, self.reduced_dataframe_question, check_like=True)
+        except:
+            print(result_dataframe)
+            print(self.reduced_dataframe_question)
+            raise
         mock_to_csv.assert_called_once_with(output_path, index=False, encoding='utf-8')
 
     @patch('panoptes_aggregation.scripts.reduce_panoptes_csv.progressbar.ProgressBar')
@@ -174,7 +185,8 @@ class TestReduceCSV(unittest.TestCase):
             self.extracted_csv_question,
             self.config_yaml_question,
             filter='all',
-            stream=True
+            stream=True,
+            cpu_count=1
         )
         output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
         mock_is_file.assert_called_once_with(output_path)
@@ -208,7 +220,8 @@ class TestReduceCSV(unittest.TestCase):
             self.extracted_csv_question,
             self.config_yaml_question,
             filter='all',
-            stream=True
+            stream=True,
+            cpu_count=1
         )
         output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
         mock_is_file.assert_called_once_with(output_path)
@@ -241,7 +254,8 @@ class TestReduceCSV(unittest.TestCase):
             self.extracted_csv_question,
             self.config_yaml_question,
             filter='all',
-            stream=True
+            stream=True,
+            cpu_count=1
         )
         output_path = os.path.join(os.getcwd(), 'question_reducer_reductions.csv')
         mock_is_file.assert_called_once_with(output_path)
@@ -258,7 +272,8 @@ class TestReduceCSV(unittest.TestCase):
         output_file_name = reduce_panoptes_csv.reduce_csv(
             self.extracted_csv_survey,
             self.config_yaml_survey,
-            order=True
+            order=True,
+            cpu_count=1
         )
         output_path = os.path.join(os.getcwd(), 'survey_reducer_reductions.csv')
         self.assertEqual(output_file_name, output_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 format = pylint
 exclude = dist/*,cover/*,build/*,.ropeproject/*,docs/*,__init__.py
-ignore = E402,E501,E722,W503,E128,BLK100
+ignore = E402,E501,E722,W503,E128,BLK100,B006,B001
 
 [nosetests]
 with-coverage = 1

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
             'coverage>=4.5.3,<5.1',
             'coveralls>=1.8,<1.10.1',
             'flake8>=3.7,<3.8',
-            'flake8-black>=0.1.1,<0.2'
+            'flake8-black>=0.1.1,<0.2',
+            'flake8-bugbear>=20.1.2,<20.2'
         ],
         'gui': [
             'Gooey>=1.0.3,<1.1'


### PR DESCRIPTION
The question reducer used `Counter` as an intermediate container for the data. It turns out that summing these `Counter`s is quite slow.

To speed up the reducer a list is made of all answers given (across all extracts) and `Counter` is called at the end to get a count for all unique answers.  This new code is 60% to 85% faster than the previous method (more speed up for larger extracts).