### PR TITLE
only mount the code in docker-compose volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./
     volumes:
-      - ./:/usr/src/aggregation
+      - ./panoptes_aggregation:/usr/src/aggregation/panoptes_aggregation
       - ~/.aws:/root/.aws
     environment:
       - AWS_REGION=${AWS_REGION}


### PR DESCRIPTION
allow the underlying resource like docs to be available in docker-compose run containers, this ensures the tests work and the docs work locally

Without this change, when running tests via `docker-compose run --rm aggregation nosetest` i get a test failure for missing docs as they were clobbered by my local file system, which had not build the docs.