### PR TITLE
add SENTRY_DSN env var for error reporting

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -42,5 +42,10 @@ spec:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
                   key: MAST_PROD_TOKEN
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: SENTRY_DSN
           ports:
             - containerPort: 80


### PR DESCRIPTION
Enable sentry error reporting for aggregation caesar web errors.

I've updated the secrets file with the required sentry DSN value.