### PR TITLE
Fix RankWarning in poly-line-text-extractor

### DIFF
--- a/panoptes_aggregation/extractors/poly_line_text_extractor.py
+++ b/panoptes_aggregation/extractors/poly_line_text_extractor.py
@@ -95,15 +95,19 @@ def poly_line_text_extractor(classification, dot_freq='word', gold_standard=Fals
                         dy = y_fit[-1] - y_fit[0]
                         slope = np.rad2deg(np.arctan2(dy, dx))
                     except np.RankWarning:
-                        # rotate by 90 before fitting
-                        x_tmp = -np.array(y)
-                        y_tmp = np.array(x)
-                        fit = np.polyfit(x_tmp, y_tmp, 1)
-                        y_fit = np.polyval(fit, [x_tmp[0], x_tmp[-1]])
-                        dx = x_tmp[-1] - x_tmp[0]
-                        dy = y_fit[-1] - y_fit[0]
-                        # rotate by -90 to bring back into correct coordiates
-                        slope = np.rad2deg(np.arctan2(dy, dx)) - 90
+                        try:
+                            # rotate by 90 before fitting
+                            x_tmp = -np.array(y)
+                            y_tmp = np.array(x)
+                            fit = np.polyfit(x_tmp, y_tmp, 1)
+                            y_fit = np.polyval(fit, [x_tmp[0], x_tmp[-1]])
+                            dx = x_tmp[-1] - x_tmp[0]
+                            dy = y_fit[-1] - y_fit[0]
+                            # rotate by -90 to bring back into correct coordiates
+                            slope = np.rad2deg(np.arctan2(dy, dx)) - 90
+                        except np.RankWarning:
+                            # this is the case where dx = dy = 0 (a line of zero length)
+                            slope = 0
                 if dot_freq == 'word':
                     # NOTE: if `words` + 1 and `points` are differnt lengths
                     # the extract is not used

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
@@ -72,6 +72,19 @@ classification = {
                         {"value": "This is vertical text"}
                     ],
                     "tool_label": "Tool name"
+                },
+                {
+                    "tool": 0,
+                    "frame": 1,
+                    "closed": True,
+                    "points": [
+                        {"x": 800, "y": 900},
+                        {"x": 800, "y": 900}
+                    ],
+                    "details": [
+                        {"value": "This line has 0 length"}
+                    ],
+                    "tool_label": "Tool name"
                 }
             ]
         }
@@ -135,6 +148,10 @@ expected = {
                     [
                         600,
                         600
+                    ],
+                    [
+                        800,
+                        800
                     ]
                 ],
             'y':
@@ -146,16 +163,22 @@ expected = {
                     [
                         0,
                         100
+                    ],
+                    [
+                        900,
+                        900
                     ]
                 ]
         },
         'text': [
             ['know the prospects on the next page'],
-            ['This is vertical text']
+            ['This is vertical text'],
+            ['This line has 0 length']
         ],
         'slope': [
             1.157333,
-            90
+            90,
+            0
         ],
         'gold_standard': True
     }


### PR DESCRIPTION
This error comes about when a line of 0 length is passed into the extractor.