### PR TITLE
Increase timeout to 60 sec

### DIFF
--- a/start-flask.sh
+++ b/start-flask.sh
@@ -6,4 +6,4 @@ if ! [ -f endpoints.yml ]; then
 fi
 
 LISTEN_PORT=${LISTEN_PORT:=80}
-exec gunicorn -b 0.0.0.0:$LISTEN_PORT -w 4 "panoptes_aggregation.routes:make_application()"
+exec gunicorn -b 0.0.0.0:$LISTEN_PORT -w 4 -t 60 "panoptes_aggregation.routes:make_application()"


### PR DESCRIPTION
The text alignment code can be on the slow side, this should fix the `SystemExit: 1` errors showing up in sentry.