### PR TITLE
match gunicorn worker timeout to load balancer

### DIFF
--- a/start-flask.sh
+++ b/start-flask.sh
@@ -6,4 +6,4 @@ if ! [ -f endpoints.yml ]; then
 fi
 
 LISTEN_PORT=${LISTEN_PORT:=80}
-exec gunicorn -b 0.0.0.0:$LISTEN_PORT -w 4 "panoptes_aggregation.routes:make_application()"
+exec gunicorn -b 0.0.0.0:$LISTEN_PORT -w 4 -t 60 "panoptes_aggregation.routes:make_application()"


### PR DESCRIPTION
give the application more time to process a request before it gets killed.

ideally all our end points finish within a decent time frame (sub 30/10s), however an upper limit of 60s is ok for data processing tasks.

If these errors keep occurring then we will have to look at optimizing the underlying code to service these requests without timing out.

http://docs.gunicorn.org/en/stable/settings.html#timeout