### PR TITLE
Only tokenize on white space and `$`

### DIFF
--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -14,8 +14,7 @@ import re
 
 def tokenize(self, contents):
     '''Tokenize only on space so angle bracket tags are not split'''
-    return re.findall(r'[^\w\[\]\{\}\<\>\s]+|[\w\[\]\<\>\{\}?]+', contents)
-    # return contents.split()
+    return re.findall(r'[^\s$]+|[$]', contents)
 
 
 # override the built-in tokenize

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -284,8 +284,7 @@ reduced_data = {
                 ['words', 'words', 'words'],
                 ['on', 'on', 'on'],
                 ['a', 'a', 'a'],
-                ['page', 'page', 'page'],
-                ['.', '.', '.']
+                ['page.', 'page.', 'page.']
             ],
             'clusters_x': [30.157958984375, 984.8629150390625],
             'clusters_y': [402.3798522949219, 395.2015686035156],
@@ -319,8 +318,7 @@ reduced_data = {
         {
             'clusters_text': [
                 ['of', 'of', 'of'],
-                ['text', 'text', 'text'],
-                ['.', '.', '.']
+                ['text.', 'text.', 'text.']
             ],
             'clusters_x': [1118.8565673828125, 1587.8343505859375],
             'clusters_y': [390.4161071777344, 373.6669006347656],

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -1260,11 +1260,10 @@ reduced_data_by_line = {
                 ['words', 'words', 'words', 'words', 'words'],
                 ['on', 'on', '', 'on', ''],
                 ['a', 'a', '', 'a', ''],
-                ['page', 'page', '', 'page', ''],
-                ['.', '.', '', '.', '']
+                ['page.', 'page.', '', 'page.', '']
             ],
             'number_views': 5,
-            'consensus_score': 3.4,
+            'consensus_score': 3.5,
             'gutter_label': 0,
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
@@ -1307,11 +1306,10 @@ reduced_data_by_line = {
             ],
             'clusters_text': [
                 ['of', 'of', '', 'of'],
-                ['text', 'text', 'text', 'text'],
-                ['.', '.', '.', '.']
+                ['text.', 'text.', 'text.', 'text.']
             ],
             'number_views': 4,
-            'consensus_score': 3.6666666666666665,
+            'consensus_score': 3.5,
             'gutter_label': 1,
             'line_slope': -1.5696676279703352,
             'slope_label': 0,
@@ -1520,7 +1518,6 @@ reduced_data_min_word = {
                 ['words', 'words', 'words', 'words', 'words'],
                 ['', '', '', '', ''],
                 ['', '', '', '', ''],
-                ['', '', '', '', ''],
                 ['', '', '', '', '']
             ],
             'number_views': 5,
@@ -1567,8 +1564,7 @@ reduced_data_min_word = {
             ],
             'clusters_text': [
                 ['', '', '', ''],
-                ['text', 'text', 'text', 'text'],
-                ['.', '.', '.', '.']
+                ['text.', 'text.', 'text.', 'text.']
             ],
             'number_views': 4,
             'consensus_score': 4.0,


### PR DESCRIPTION
The `$` tokenization is needed for collatex to not crash (I think it is not properly escaped when it is not sitting on its own in a string).