### PR TITLE
Fix 213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ dist_installer/
 
 # endpoints file
 endpoints.yml
+
+.vscode/
+.noseids

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -60,12 +60,9 @@ class ClassificationParser(object):
 
 
 def check_decade(parser):
-    if 'year' in parser.params:
-        year = parser.get_basic('year')
-        if year and len(str(year)) == 4:
-            return "%s0s" % str(year)[-2]
-        else:
-            return None
+    year = parser.get_basic('year')
+    if year and len(str(year)) == 4:
+        return "%s0s" % str(year)[-2]
     else:
         return None
 

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -62,7 +62,7 @@ class ClassificationParser(object):
 def check_decade(parser):
     if 'year' in parser.params:
         year = parser.get_basic('year')
-        if year:
+        if year and len(str(year)) == 4:
             return "%s0s" % str(year)[-2]
         else:
             return None

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -45,7 +45,7 @@ class ClassificationParser(object):
     def get_basic(self, label):
         if label in self.subject_metadata:
             return self.subject_metadata[label]
-        elif label in self.params:
+        else:
             task = self.params[label]
             if task in self.tasks:
                 value = self.tasks[task]
@@ -55,8 +55,6 @@ class ClassificationParser(object):
                     return value
             else:
                 return None
-        else:
-            return None
 
 
 def check_decade(parser):

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -138,7 +138,7 @@ classification_bad_year = {
     "created_at": "2019-05-22T06:28:13.667Z",
 }
 
-expected_bad_year = {
+expected_no_year = {
     "workflow": "herbarium",
     "time": "lunchbreak"
 }
@@ -146,7 +146,15 @@ expected_bad_year = {
 TestNfNBadYear = ExtractorTest(
     extractors.nfn_extractor,
     classification_bad_year,
-    expected_bad_year,
+    expected_no_year,
     'Test NfN bare integer year annotation at lunchtime with porly formatted year',
     kwargs={'year': 'T10', 'workflow': 'herbarium'}
+)
+
+TestNfNNoYear = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_1,
+    expected_no_year,
+    'Test NfN bare integer year annotation at lunchtime with no year keyword',
+    kwargs={'workflow': 'herbarium'}
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -158,3 +158,71 @@ TestNfNNoYear = ExtractorTest(
     'Test NfN bare integer year annotation at lunchtime with no year keyword',
     kwargs={'workflow': 'herbarium'}
 )
+
+classification_earlybird = {
+    "annotations": [
+        {
+            "task": "T10",
+            "value": 1976
+        }
+    ],
+    "metadata": {
+        "utc_offset": "21600",
+    },
+    "subject": {
+        "metadata": {}
+    },
+    "created_at": "2019-05-22T22:28:13.667Z",
+}
+
+expected_earlybird = {
+    "workflow": "herbarium",
+    "decade": "70s",
+    "time": "earlybird"
+}
+
+TestNfNEarlybird = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_earlybird,
+    expected_earlybird,
+    'Test NfN bare integer year annotation at earlybird ',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+)
+
+classification_dinnertime = {
+    "annotations": [
+        {
+            "task": "T10",
+            "value": 1976
+        }
+    ],
+    "metadata": {
+        "utc_offset": "21600",
+    },
+    "subject": {
+        "metadata": {}
+    },
+    "created_at": "2019-05-22T10:28:13.667Z",
+}
+
+expected_dinnertime = {
+    "workflow": "herbarium",
+    "decade": "70s",
+    "time": "dinnertime"
+}
+
+TestNfNDinnertime = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_dinnertime,
+    expected_dinnertime,
+    'Test NfN bare integer year annotation at dinnertime',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+)
+
+TestNfNNotInMetadataOrParams = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_dinnertime,
+    expected_dinnertime,
+    'Test NfN bare integer year annotation at dinnertime with no state info in metadata',
+    kwargs={'year': 'T10', 'workflow': 'herbarium', 'state': 'metadata'}
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -121,3 +121,32 @@ TestNfNThree = ExtractorTest(
     'Test NfN bare integer year annotation at lunchtime.',
     kwargs={'year': 'T10', 'workflow': 'herbarium'}
 )
+
+classification_bad_year = {
+    "annotations": [
+        {
+            "task": "T10",
+            "value": "n"
+        }
+    ],
+    "metadata": {
+        "utc_offset": "21600",
+    },
+    "subject": {
+        "metadata": {}
+    },
+    "created_at": "2019-05-22T06:28:13.667Z",
+}
+
+expected_bad_year = {
+    "workflow": "herbarium",
+    "time": "lunchbreak"
+}
+
+TestNfNBadYear = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_bad_year,
+    expected_bad_year,
+    'Test NfN bare integer year annotation at lunchtime with porly formatted year',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+)


### PR DESCRIPTION
This PR fixes #213 and increases the test coverage for the `nfn_extractor`.

Some new tests were added to test every `if` statement and two of the `if` statements were removed as they always evaluate to `True`.  In these two cases the `nfn_extractor` does the same check these statements did.