### PR TITLE
Edit README: GUI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -U panoptes_aggregation
 #### Install the Graphical User Interface (GUI)
 If you would like to use the GUI instead of the command line install the package with:
 ```bash
-pip install panoptes_aggregation[gui]
+pip install "panoptes_aggregation[gui]"
 ```
 
 #### Anaconda build of python


### PR DESCRIPTION
Adds quotes around package name when using bracket argument enabling GUI option to pip parses the command correctly.