### PR TITLE
 Update import statement for gooey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *,cover
 .hypothesis/
 cover/
+.noseids
 
 # Translations
 *.mo

--- a/panoptes_aggregation/scripts/gui.py
+++ b/panoptes_aggregation/scripts/gui.py
@@ -18,6 +18,7 @@ if sys.platform == 'win32':
 
 try:
     import gooey
+    import gooey.gui.components.console
 except ImportError:
     raise ImportError('The GUI component is not installed, reinstall with `pip install -U panoptes_aggregation[gui]`')
 

--- a/panoptes_aggregation/scripts/path_type.py
+++ b/panoptes_aggregation/scripts/path_type.py
@@ -29,7 +29,7 @@ class PathType(object):
             if not os.path.isfile(string):
                 raise err("path is not a file: '{0}'".format(string))
         elif self._type == 'symlink':
-            if not os.path.symlink(string):
+            if not os.path.islink(string):
                 raise err("path is not a symlink: '{0}'".format(string))
         elif self._type == 'dir':
             if not os.path.isdir(string):

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
             'flake8'
         ],
         'gui': [
-            'Gooey'
+            'Gooey==1.0.3'
         ]
     },
     install_requires=[


### PR DESCRIPTION
This fixes the import error when updating to gooey 1.0.3. The Gooey version has also been locked down to a working version.

This is the one bit of code that does not have any tests associated with it. This is because GUIs can't start up in a docker container.