### PR TITLE
Fix optics reducer when processing line of length 0

### DIFF
--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -123,11 +123,12 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
         frame_unordered = []
         X = np.array(value['X'])
         data = np.array(value['data'])
-        ext_index = np.array(extractor_index(X[:, 1]))
         if X.size > 0:
             num_users = len(np.unique(X[:, 1]))
+            ext_index = np.array(extractor_index(X[:, 1]))
         else:
             num_users = 0
+            ext_index = np.array([])
         if min_samples_orig == 'auto':
             min_samples = get_min_samples(num_users)
         else:

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -639,3 +639,54 @@ TestOpticsLTReducerWithDolarSign = ReducerTest(
     okwargs={'min_samples': 'auto'},
     network_kwargs=kwargs_extra_data_with_dolar_sign
 )
+
+# this is a real classification that happened on ASM
+extracted_data_no_length = [
+    {
+        'frame5': {
+            'points': {
+                'x': [
+                    [620.4314017895185, 620.4314017895185]
+                ],
+                'y': [
+                    [142.3093310609288, 142.3093310609288]
+                ]
+            },
+            'text': [
+                ['[ no content]']
+            ],
+            'slope': [0.0],
+            'gold_standard': False
+        }
+    }
+]
+
+kwargs_extra_data_no_length = {
+    'user_id': [
+        1
+    ]
+}
+
+processed_data_no_length = {
+    'frame5': {
+        'X': [],
+        'data': []
+    }
+}
+
+reduced_data_no_length = {'frame5': []}
+
+TestOpticsLTReducerNoLengthLine = ReducerTest(
+    optics_line_text_reducer,
+    process_data,
+    extracted_data_no_length,
+    processed_data_no_length,
+    reduced_data_no_length,
+    'Text optics line-text reducer with a zero length line',
+    okwargs={
+        'min_samples': 'auto',
+        'angle_eps': 30,
+        'gutter_eps': 150
+    },
+    network_kwargs=kwargs_extra_data_no_length
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -1736,3 +1736,68 @@ TestPLTReducerWithMinWordCount = ReducerTest(
     },
     network_kwargs=kwargs_extra_data
 )
+
+# this is a real classification that happened on ASM
+extracted_data_no_length = [
+    {
+        'frame5': {
+            'points': {
+                'x': [
+                    [620.4314017895185, 620.4314017895185]
+                ],
+                'y': [
+                    [142.3093310609288, 142.3093310609288]
+                ]
+            },
+            'text': [
+                ['[ no content]']
+            ],
+            'slope': [0.0],
+            'gold_standard': False
+        }
+    }
+]
+
+kwargs_extra_data_no_length = {
+    'user_id': [
+        1
+    ]
+}
+
+processed_data_no_length = {
+    'frame5': {
+        'data_index': [0],
+        'gold_standard': [False],
+        'slope': [0.0],
+        'text': [['[ no content]']],
+        'x': [[620.4314017895185, 620.4314017895185]],
+        'y': [[142.3093310609288, 142.3093310609288]]
+    }
+}
+
+reduced_data_no_length = {'frame5': []}
+
+TestPolyLTReducerNoLengthLine = ReducerTest(
+    poly_line_text_reducer,
+    process_data,
+    extracted_data_no_length,
+    processed_data_no_length,
+    reduced_data_no_length,
+    'Text poly-line-text reducer with a zero length line',
+    okwargs={
+        'metric': 'euclidean',
+        'gutter_tol': 0
+    },
+    pkwargs={
+        'process_by_line': True
+    },
+    kwargs={
+        'eps_slope': 25,
+        'eps_line': 40,
+        'eps_word': 50,
+        'min_samples': 1,
+        'dot_freq': 'line',
+        'min_word_count': 1
+    },
+    network_kwargs=kwargs_extra_data_no_length
+)


### PR DESCRIPTION
This PR fixes an edge case when the only annotation made for a frame is a single line of length 0.  This case happened on ASM and an explicit test has been added to both of the text reducers.