### PR TITLE
Low consensus flag

### DIFF
--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -121,6 +121,12 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
           gold standard mode
         * `slope_label`: integer indicating what slope cluster the line belongs to
         * `gutter_label`: integer indicating what gutter cluster (i.e. column) the line belongs to
+        * `low_consensus` : True if the `consensus_score` is less than the threshold set by the
+          `low_consensus_threshold` keyword
+
+        For the entire subject the following is also returned:
+        * `low_consensus_lines` : The number of lines with low consensus
+        * `transcribed_lines` : The total number of lines transcribed on the subject
 
         Note: the image coordiate system has y increasing downward.
     '''

--- a/panoptes_aggregation/reducers/optics_text_utils.py
+++ b/panoptes_aggregation/reducers/optics_text_utils.py
@@ -191,7 +191,8 @@ def cluster_of_one(X, data, user_ids, extract_index):
             'consensus_score': 1.0,
             'user_ids': remove_nans([user_ids[user_index]]),
             'extract_index': [extract_index[rdx]],
-            'gold_standard': [line['gold_standard']]
+            'gold_standard': [line['gold_standard']],
+            'low_consensus': True
         }
         clusters.append(value)
     return clusters

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -559,8 +559,16 @@ def cluster_by_slope(
     return frame_slope
 
 
-def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan, user_ids_input):
+def cluster_by_frame(
+    data_by_frame,
+    kwargs_cluster,
+    kwargs_dbscan,
+    user_ids_input,
+    low_consensus_threshold
+):
     reduced_data = OrderedDict()
+    low_consensus_lines = 0
+    number_of_lines = 0
     for frame, value in data_by_frame.items():
         reduced_data[frame] = []
         gs_frame = np.array(copy.deepcopy(value['gold_standard']))
@@ -585,8 +593,16 @@ def cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan, user_ids_inpu
             kwargs_cluster,
             kwargs_dbscan
         )
+        number_of_lines += len(frame_slope)
         for line in frame_slope:
             data_index = line.pop('data_index')
             line['user_ids'] = [user_ids_input[di] for di in data_index]
+            if line['consensus_score'] < low_consensus_threshold:
+                line['low_consensus'] = True
+                low_consensus_lines += 1
+            else:
+                line['low_consensus'] = False
         reduced_data[frame] += frame_slope
+    reduced_data['low_consensus_lines'] = low_consensus_lines
+    reduced_data['transcribed_lines'] = number_of_lines
     return reduced_data

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -260,6 +260,8 @@ processed_data = {
 }
 
 reduced_data = {
+    'low_consensus_lines': 3,
+    'transcribed_lines': 10,
     'frame0': [
         {
             'clusters_text': [
@@ -277,7 +279,8 @@ reduced_data = {
             'extract_index': [2, 0, 3],
             'gold_standard': [False, True, False],
             'slope_label': 0,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -295,7 +298,8 @@ reduced_data = {
             'extract_index': [0, 1, 2],
             'gold_standard': [False, True, False],
             'slope_label': 0,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -313,7 +317,8 @@ reduced_data = {
             'extract_index': [4, 4, 7],
             'gold_standard': [False, True, False],
             'slope_label': 0,
-            'gutter_label': 1
+            'gutter_label': 1,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -329,7 +334,8 @@ reduced_data = {
             'extract_index': [5, 5, 5],
             'gold_standard': [False, True, False],
             'slope_label': 0,
-            'gutter_label': 1
+            'gutter_label': 1,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -346,7 +352,8 @@ reduced_data = {
             'extract_index': [1, 6, 4],
             'gold_standard': [False, True, False],
             'slope_label': 1,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -363,7 +370,8 @@ reduced_data = {
             'extract_index': [3, 7, 6],
             'gold_standard': [False, True, False],
             'slope_label': 1,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -379,7 +387,8 @@ reduced_data = {
             'extract_index': [6, 2, 0],
             'gold_standard': [False, True, False],
             'slope_label': 1,
-            'gutter_label': 1
+            'gutter_label': 1,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -396,7 +405,8 @@ reduced_data = {
             'extract_index': [7, 3, 1],
             'gold_standard': [False, True, False],
             'slope_label': 1,
-            'gutter_label': 1
+            'gutter_label': 1,
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -414,7 +424,8 @@ reduced_data = {
             'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 2,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': True
         }
     ],
     'frame1': [
@@ -432,7 +443,8 @@ reduced_data = {
             'extract_index': [0, 0],
             'gold_standard': [True, False],
             'slope_label': 0,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': True
         }
     ],
     'frame2': [
@@ -450,7 +462,8 @@ reduced_data = {
             'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 0,
-            'gutter_label': 0
+            'gutter_label': 0,
+            'low_consensus': True
         }
     ]
 }
@@ -464,7 +477,8 @@ TestOpticsLTReducer = ReducerTest(
     'Test optics line-text reducer with auto min_samples',
     kwargs={
         'angle_eps': 30,
-        'gutter_eps': 150
+        'gutter_eps': 150,
+        'low_consensus_threshold': 3
     },
     okwargs={
         'min_samples': 'auto'
@@ -482,7 +496,8 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
     kwargs={
         'min_samples': 2,
         'angle_eps': 30,
-        'gutter_eps': 150
+        'gutter_eps': 150,
+        'low_consensus_threshold': 3
     },
     network_kwargs=kwargs_extra_data
 )
@@ -603,6 +618,8 @@ processed_data_with_dolar_sign = {
 }
 
 reduced_data_with_dolar_sign = {
+    'low_consensus_lines': 0,
+    'transcribed_lines': 1,
     'frame0': [{
         'clusters_x': [0.0, 100.0],
         'clusters_y': [0.0, 0.0],
@@ -621,7 +638,8 @@ reduced_data_with_dolar_sign = {
         'extract_index': [0, 0, 0, 0, 0, 0, 0],
         'gold_standard': [False, False, False, False, False, False, False],
         'slope_label': 0,
-        'gutter_label': 0
+        'gutter_label': 0,
+        'low_consensus': False
     }]
 }
 
@@ -634,7 +652,8 @@ TestOpticsLTReducerWithDolarSign = ReducerTest(
     'Test optics line-text reducer with dolar sign',
     kwargs={
         'angle_eps': 30,
-        'gutter_eps': 150
+        'gutter_eps': 150,
+        'low_consensus_threshold': 3
     },
     okwargs={'min_samples': 'auto'},
     network_kwargs=kwargs_extra_data_with_dolar_sign
@@ -674,7 +693,11 @@ processed_data_no_length = {
     }
 }
 
-reduced_data_no_length = {'frame5': []}
+reduced_data_no_length = {
+    'low_consensus_lines': 0,
+    'transcribed_lines': 0,
+    'frame5': []
+}
 
 TestOpticsLTReducerNoLengthLine = ReducerTest(
     optics_line_text_reducer,
@@ -686,7 +709,8 @@ TestOpticsLTReducerNoLengthLine = ReducerTest(
     okwargs={
         'min_samples': 'auto',
         'angle_eps': 30,
-        'gutter_eps': 150
+        'gutter_eps': 150,
+        'low_consensus_threshold': 3
     },
     network_kwargs=kwargs_extra_data_no_length
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -596,6 +596,8 @@ processed_data = {
 }
 
 reduced_data = {
+    'low_consensus_lines': 5,
+    'transcribed_lines': 10,
     'frame0': [
         {
             'clusters_x': [
@@ -626,7 +628,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
             'user_ids': [1, 2, 3, 3, None, 5, 5],
-            'extract_index': [2, 0, 0, 1, 3, 2, 8]
+            'extract_index': [2, 0, 0, 1, 3, 2, 8],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -657,7 +660,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [0, 1, 6, 2, 3]
+            'extract_index': [0, 1, 6, 2, 3],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -688,7 +692,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [4, 4, 2, 7, 0, 1]
+            'extract_index': [4, 4, 2, 7, 0, 1],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -713,7 +718,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
             'user_ids': [1, 2, 3, None],
-            'extract_index': [5, 5, 7, 5]
+            'extract_index': [5, 5, 7, 5],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -741,7 +747,8 @@ reduced_data = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [1, 6, 5, 4, 7]
+            'extract_index': [1, 6, 5, 4, 7],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -769,7 +776,8 @@ reduced_data = {
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
             'user_ids': [1, 2, None, 5],
-            'extract_index': [3, 7, 6, 4]
+            'extract_index': [3, 7, 6, 4],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -797,7 +805,8 @@ reduced_data = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [6, 2, 4, 0, 6]
+            'extract_index': [6, 2, 4, 0, 6],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -825,7 +834,8 @@ reduced_data = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [7, 3, 3, 1, 5, 9]
+            'extract_index': [7, 3, 3, 1, 5, 9],
+            'low_consensus': False
         }
     ],
     'frame1': [
@@ -852,7 +862,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, True],
             'user_ids': [2, None],
-            'extract_index': [0, 0]
+            'extract_index': [0, 0],
+            'low_consensus': True
         }
     ],
     'frame2': [
@@ -879,7 +890,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False],
             'user_ids': [None],
-            'extract_index': [0]
+            'extract_index': [0],
+            'low_consensus': True
         }
     ]
 }
@@ -893,7 +905,7 @@ TestPLTReducer = ReducerTest(
     'Test poly-line-text reducer by word',
     okwargs={
         'metric': 'euclidean',
-        'gutter_tol': 0,
+        'gutter_tol': 0
     },
     kwargs={
         'eps_slope': 25,
@@ -901,7 +913,8 @@ TestPLTReducer = ReducerTest(
         'eps_word': 50,
         'min_samples': 1,
         'dot_freq': 'word',
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 4
     },
     network_kwargs=kwargs_extra_data
 )
@@ -1222,6 +1235,8 @@ processed_data_by_line = {
 }
 
 reduced_data_by_line = {
+    'low_consensus_lines': 5,
+    'transcribed_lines': 10,
     'frame0': [
         {
             'clusters_x': [
@@ -1245,7 +1260,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
             'user_ids': [1, 2, 3, 3, None, 5, 5],
-            'extract_index': [2, 0, 0, 1, 3, 2, 8]
+            'extract_index': [2, 0, 0, 1, 3, 2, 8],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1269,7 +1285,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [0, 1, 6, 2, 3]
+            'extract_index': [0, 1, 6, 2, 3],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -1293,7 +1310,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [4, 4, 2, 7, 0, 1]
+            'extract_index': [4, 4, 2, 7, 0, 1],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1315,7 +1333,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
             'user_ids': [1, 2, 3, None],
-            'extract_index': [5, 5, 7, 5]
+            'extract_index': [5, 5, 7, 5],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -1338,7 +1357,8 @@ reduced_data_by_line = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [1, 6, 5, 4, 7]
+            'extract_index': [1, 6, 5, 4, 7],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1361,7 +1381,8 @@ reduced_data_by_line = {
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
             'user_ids': [1, 2, None, 5],
-            'extract_index': [3, 7, 6, 4]
+            'extract_index': [3, 7, 6, 4],
+            'low_consensus': True
         },
         {
             'clusters_x': [
@@ -1384,7 +1405,8 @@ reduced_data_by_line = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [6, 2, 4, 0, 6]
+            'extract_index': [6, 2, 4, 0, 6],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1407,7 +1429,8 @@ reduced_data_by_line = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [7, 3, 3, 1, 5, 9]
+            'extract_index': [7, 3, 3, 1, 5, 9],
+            'low_consensus': False
         }
     ],
     'frame1': [
@@ -1431,7 +1454,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False, True],
             'user_ids': [2, None],
-            'extract_index': [0, 0]
+            'extract_index': [0, 0],
+            'low_consensus': True
         }
     ],
     'frame2': [
@@ -1449,7 +1473,8 @@ reduced_data_by_line = {
             'slope_label': 0,
             'gold_standard': [False],
             'user_ids': [None],
-            'extract_index': [0]
+            'extract_index': [0],
+            'low_consensus': True
         }
     ]
 }
@@ -1474,12 +1499,15 @@ TestPLTReducerByLine = ReducerTest(
         'eps_word': 50,
         'min_samples': 1,
         'dot_freq': 'line',
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 4
     },
     network_kwargs=kwargs_extra_data
 )
 
 reduced_data_min_word = {
+    'low_consensus_lines': 2,
+    'transcribed_lines': 10,
     'frame0': [
         {
             'clusters_x': [
@@ -1503,7 +1531,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, True, False, False],
             'user_ids': [1, 2, 3, 3, None, 5, 5],
-            'extract_index': [2, 0, 0, 1, 3, 2, 8]
+            'extract_index': [2, 0, 0, 1, 3, 2, 8],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1527,7 +1556,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [0, 1, 6, 2, 3]
+            'extract_index': [0, 1, 6, 2, 3],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1551,7 +1581,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [4, 4, 2, 7, 0, 1]
+            'extract_index': [4, 4, 2, 7, 0, 1],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1573,7 +1604,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False, False, False, True],
             'user_ids': [1, 2, 3, None],
-            'extract_index': [5, 5, 7, 5]
+            'extract_index': [5, 5, 7, 5],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1596,7 +1628,8 @@ reduced_data_min_word = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [1, 6, 5, 4, 7]
+            'extract_index': [1, 6, 5, 4, 7],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1619,7 +1652,8 @@ reduced_data_min_word = {
             'slope_label': 1,
             'gold_standard': [False, False, True, False],
             'user_ids': [1, 2, None, 5],
-            'extract_index': [3, 7, 6, 4]
+            'extract_index': [3, 7, 6, 4],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1642,7 +1676,8 @@ reduced_data_min_word = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False],
             'user_ids': [1, 2, 3, None, 5],
-            'extract_index': [6, 2, 4, 0, 6]
+            'extract_index': [6, 2, 4, 0, 6],
+            'low_consensus': False
         },
         {
             'clusters_x': [
@@ -1665,7 +1700,8 @@ reduced_data_min_word = {
             'slope_label': 1,
             'gold_standard': [False, False, False, True, False, False],
             'user_ids': [1, 2, 3, None, 5, 5],
-            'extract_index': [7, 3, 3, 1, 5, 9]
+            'extract_index': [7, 3, 3, 1, 5, 9],
+            'low_consensus': False
         }
     ],
     'frame1': [
@@ -1689,7 +1725,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False, True],
             'user_ids': [2, None],
-            'extract_index': [0, 0]
+            'extract_index': [0, 0],
+            'low_consensus': True
         }
     ],
     'frame2': [
@@ -1707,7 +1744,8 @@ reduced_data_min_word = {
             'slope_label': 0,
             'gold_standard': [False],
             'user_ids': [None],
-            'extract_index': [0]
+            'extract_index': [0],
+            'low_consensus': True
         }
     ]
 }
@@ -1732,7 +1770,8 @@ TestPLTReducerWithMinWordCount = ReducerTest(
         'eps_word': 50,
         'min_samples': 1,
         'dot_freq': 'line',
-        'min_word_count': 4
+        'min_word_count': 4,
+        'low_consensus_threshold': 4
     },
     network_kwargs=kwargs_extra_data
 )
@@ -1775,7 +1814,11 @@ processed_data_no_length = {
     }
 }
 
-reduced_data_no_length = {'frame5': []}
+reduced_data_no_length = {
+    'low_consensus_lines': 0,
+    'transcribed_lines': 0,
+    'frame5': []
+}
 
 TestPolyLTReducerNoLengthLine = ReducerTest(
     poly_line_text_reducer,
@@ -1797,7 +1840,8 @@ TestPolyLTReducerNoLengthLine = ReducerTest(
         'eps_word': 50,
         'min_samples': 1,
         'dot_freq': 'line',
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 4
     },
     network_kwargs=kwargs_extra_data_no_length
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -854,6 +854,8 @@ processed_data = {
 }
 
 reduced_data = {
+    'low_consensus_lines': 8,
+    'transcribed_lines': 16,
     'frame0': [
         {
             'clusters_text': [
@@ -869,7 +871,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [1, 4, 5, 6],
-            'extract_index': [0, 0, 0, 0]
+            'extract_index': [0, 0, 0, 0],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -887,7 +890,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [2, 4, 5, 6],
-            'extract_index': [0, 1, 1, 1]
+            'extract_index': [0, 1, 1, 1],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -905,7 +909,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False],
             'user_ids': [2, 3, 4, 5, 6],
-            'extract_index': [1, 0, 2, 2, 2]
+            'extract_index': [1, 0, 2, 2, 2],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -923,7 +928,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [3, 4, 5, 6],
-            'extract_index': [1, 3, 3, 3]
+            'extract_index': [1, 3, 3, 3],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -941,7 +947,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False, False],
             'user_ids': [3, 3, 4, 5, 5, 6],
-            'extract_index': [3, 4, 4, 4, 5, 4]
+            'extract_index': [3, 4, 4, 4, 5, 4],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -960,7 +967,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False],
             'user_ids': [1, 4, 6],
-            'extract_index': [2, 5, 5]
+            'extract_index': [2, 5, 5],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -979,7 +987,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [3, 4, 5, 6],
-            'extract_index': [5, 6, 6, 6]
+            'extract_index': [5, 6, 6, 6],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -997,7 +1006,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [3, 4, 5, 6],
-            'extract_index': [2, 7, 8, 7]
+            'extract_index': [2, 7, 8, 7],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -1015,7 +1025,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False, False],
             'user_ids': [1, 4, 5, 5, 6],
-            'extract_index': [4, 8, 9, 10, 8]
+            'extract_index': [4, 8, 9, 10, 8],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1032,7 +1043,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False],
             'user_ids': [4, 5, 6],
-            'extract_index': [9, 11, 9]
+            'extract_index': [9, 11, 9],
+            'low_consensus': False
         },
         {
             'clusters_text': [
@@ -1051,7 +1063,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False],
             'user_ids': [4, 5, 6],
-            'extract_index': [10, 12, 10]
+            'extract_index': [10, 12, 10],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1069,7 +1082,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False],
             'user_ids': [5, 5, 6],
-            'extract_index': [13, 23, 16]
+            'extract_index': [13, 23, 16],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1087,7 +1101,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False],
             'user_ids': [4, 5, 6],
-            'extract_index': [11, 24, 11]
+            'extract_index': [11, 24, 11],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1103,7 +1118,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False],
             'user_ids': [5, 6],
-            'extract_index': [15, 12]
+            'extract_index': [15, 12],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1121,7 +1137,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False],
             'user_ids': [5, 6],
-            'extract_index': [16, 14]
+            'extract_index': [16, 14],
+            'low_consensus': True
         },
         {
             'clusters_text': [
@@ -1140,7 +1157,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False, False, False, False],
             'user_ids': [1, 4, 5, 6],
-            'extract_index': [7, 12, 17, 15]
+            'extract_index': [7, 12, 17, 15],
+            'low_consensus': False
         }
     ]
 }
@@ -1155,7 +1173,8 @@ TestSWReducer = ReducerTest(
     okwargs={
         'metric': 'euclidean',
         'gutter_tol': 0,
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 3
     },
     kwargs={
         'eps_slope': 0.5,
@@ -1220,6 +1239,8 @@ processed_data_all_blank = {
 }
 
 reduced_data_all_blank = {
+    'low_consensus_lines': 0,
+    'transcribed_lines': 0,
     'frame0': []
 }
 
@@ -1233,7 +1254,8 @@ TestSWReducerAllBlank = ReducerTest(
     okwargs={
         'metric': 'euclidean',
         'gutter_tol': 0,
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 3
     },
     kwargs={
         'eps_slope': 0.5,

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
@@ -53,6 +53,8 @@ processed_data = {
 }
 
 reduced_data = {
+    'low_consensus_lines': 1,
+    'transcribed_lines': 1,
     'frame0': [
         {
             'clusters_text': [
@@ -70,7 +72,8 @@ reduced_data = {
             'slope_label': 0,
             'gold_standard': [False],
             'user_ids': [1],
-            'extract_index': [0]
+            'extract_index': [0],
+            'low_consensus': True
         }
     ]
 }
@@ -85,7 +88,8 @@ TestSWReducer = ReducerTest(
     okwargs={
         'metric': 'euclidean',
         'gutter_tol': 0,
-        'min_word_count': 1
+        'min_word_count': 1,
+        'low_consensus_threshold': 3
     },
     kwargs={
         'eps_slope': 0.5,

--- a/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
@@ -114,7 +114,8 @@ class TextOpticsTextUtils(unittest.TestCase):
                 'consensus_score': 1.0,
                 'user_ids': [0],
                 'extract_index': [0],
-                'gold_standard': [False]
+                'gold_standard': [False],
+                'low_consensus': True
             },
             {
                 'clusters_x': [1, 3],
@@ -131,7 +132,8 @@ class TextOpticsTextUtils(unittest.TestCase):
                 'consensus_score': 1.0,
                 'user_ids': [0],
                 'extract_index': [0],
-                'gold_standard': [False]
+                'gold_standard': [False],
+                'low_consensus': True
             }
         ]
         result = optics_text_utils.cluster_of_one(X, data, user_ids, ext_index)


### PR DESCRIPTION
Update text reducers to track low consensus lines.

The threshold can be set with the new `low_consensus_threshold` keyword (default 3).  It also adds counts for `low_consensus_lines` and `transcribed_lines` for an entire subject.