### PR TITLE
Add git commit tag to status page

### DIFF
--- a/panoptes_aggregation/routes.py
+++ b/panoptes_aggregation/routes.py
@@ -4,6 +4,7 @@ try:
     from panoptes_aggregation import panoptes
     import sentry_sdk
     from sentry_sdk.integrations.flask import FlaskIntegration
+    import git
 except ImportError:  # pragma: no cover
     print('You must install `flask` to use panoptes_aggregation.routes')  # pragma: no cover
     raise  # pragma: no cover
@@ -67,7 +68,13 @@ def make_application():
                         static_folder='../docs/build/html')
     application.json_encoder = MyEncoder
 
-    home_screen_message = 'Python extractors and reducers for panoptes aggregation. Code version {0}'.format(__version__)
+    repo = git.Repo(search_parent_directories=True)
+    sha = repo.head.object.hexsha
+    home_screen_message = {
+        'status': 'ok',
+        'version': __version__,
+        'commit_id': sha
+    }
 
     @application.route('/')
     def index():

--- a/panoptes_aggregation/tests/router_tests/test_routes.py
+++ b/panoptes_aggregation/tests/router_tests/test_routes.py
@@ -1,5 +1,6 @@
 try:
     import panoptes_aggregation.routes as routes
+    import git
     OFFLINE = False
 except ImportError:
     OFFLINE = True
@@ -31,9 +32,16 @@ class RouterTest(unittest.TestCase):
 
     def test_home_route(self):
         '''Test home page returns version'''
+        repo = git.Repo(search_parent_directories=True)
+        sha = repo.head.object.hexsha
+        home_screen_message = {
+            'status': 'ok',
+            'version': panoptes_aggregation.__version__,
+            'commit_id': sha
+        }
         self.route_exists(
             '/',
-            'Python extractors and reducers for panoptes aggregation. Code version {0}'.format(panoptes_aggregation.__version__)
+            home_screen_message
         )
 
     def test_extractor_routes(self):

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
             'requests>=2.4.2,<2.23',
             'gunicorn>=20.0,<20.1',
             'sentry-sdk[flask]>=0.13.5,<0.14',
-            'newrelic>=5.4.0,<5.4.2'
+            'newrelic>=5.4.0,<5.4.2',
+            'gitpython>=3.0.0,<3.1'
         ],
         'doc': [
             'recommonmark>=0.5.0,<0.7',


### PR DESCRIPTION
The status page now produces a json object with the latest git commit id, status, and version number.  Closes #203