### PR TITLE
Gravity spy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/_build/
 docs/source/*.md
 docs/source/_static/*.png
 

--- a/docs/source/Gravity_Spy.rst
+++ b/docs/source/Gravity_Spy.rst
@@ -1,0 +1,200 @@
+.. _gravity-spy:
+
+Gravity Spy Notes
+=================
+
+Gravity Spy's leveling up and aggregation work as follows.
+
+Confusion Matrix
+----------------
+
+After classifying on a gold standard subject a volunteer's
+confusion matrix is estimated/updated. All gold standard subjects
+have a machine learning (ML) label. This matrix has one row and one
+column for each of the categories available to pick from in the
+front-end (22 at the top level). The column indicates the value
+the volunteer voted on and row indicates the value of the ML label.
+
+As and example lets look at a case where there are only 5 categories
+to pick from.
+
+.. math::
+
+    \text{CM} = \overbrace{\begin{bmatrix}
+        5 & 1 & 1 & 0 & 0 \\
+        2 & 4 & 1 & 0 & 0 \\
+        1 & 0 & 6 & 0 & 1 \\
+        0 & 2 & 0 & 6 & 2 \\
+        0 & 1 & 2 & 3 & 3 \\
+    \end{bmatrix}}^{
+        \textstyle
+        \text{Answer index}
+    }\left.\rule{0cm}{1.2cm}\right\}\text{ML index}
+
+What this looks like in the code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Within the `gravity_spy_user_reducer` store this is
+structured as two nested dictionaries with the first key indicating
+the column and the second key indicating the row (category labels will
+be used as keys):
+
+.. code-block:: python
+
+    confusion_matrix = {
+        '1': {'1': 5, '2': 2, '3': 1},
+        '2': {'1': 1, '2': 4, '4': 2, '5': 1},
+        '3': {'1': 1, '2': 1, '3': 6, '5': 2},
+        '4': {'4': 6, '5': 3},
+        '5': {'3': 1, '4': 2, '5': 3}
+    }
+
+Volunteer skill
+---------------
+
+To get the volunteer skill the columns of the CM need to be normalized so
+they sum to 1 (i.e. divide each column by the number N of times a category
+was voted for).
+
+In this example:
+
+.. math::
+
+    \text{N} = \begin{bmatrix}
+        8,
+        8,
+        10,
+        9,
+        6
+    \end{bmatrix}
+
+.. math::
+
+    \frac{\text{CM}}{\text{N}} =
+    \text{CM}_{\text{Norm}} = \begin{bmatrix}
+        5/8 & 1/8  & 1/10 & 0   & 0   \\
+        2/8 & 4/8  & 1/10 & 0   & 0   \\
+        1/8 & 0    & 6/10 & 0   & 1/6 \\
+        0   & 2/8 & 0     & 6/9 & 2/6 \\
+        0   & 1/8  & 2/10 & 3/9 & 3/6 \\
+    \end{bmatrix}
+
+The diagonal of this normalized matrix gives how often the volunteer correctly
+identifies each of the categories. Once all of these values pass a given
+threshold (set in the reducer's configuration) the volunteer is promoted to
+the next level.
+
+.. math::
+
+    \alpha = \text{diag}(\text{CM}_{\text{Norm}}) = \left[
+        \frac{5}{8},
+        \frac{4}{8},
+        \frac{6}{10},
+        \frac{6}{9},
+        \frac{3}{6}
+    \right]
+
+In this example this volunteer will not be promoted to the next level since not
+every value of :math:`\alpha` is above :math:`0.7`.
+
+What this looks like in the code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`running_reducer/gravity_spy_user_reducer.py` returns `alpha`, `level_up`,
+`max_workflow_id`, `max_level`, and `normalized_confusion_matrix` directly
+on the reducer, and `max_level`, `column_normalization` (N above), and
+`confusion_matrix` in the store. The `alpha` keys to check at each level and
+the threshold they need to pass are set with `level_config` and `first_level`
+key words. When a level up is triggered the `level_up` value will switch from
+`False` to `True` and the `max_workflow_id` will indicate the ID for the new
+workflow to unlock.
+
+An example of the level_config is:
+
+.. code-block:: python
+
+    {
+        'level_1': {
+            'workflow_id': 1,
+            'new_categories': [
+                'BLIP',
+                'WHISTLE'
+            ],
+            'threshold': 0.7,
+            'next_level': 'level_2'
+        },
+        'level_2': {
+            'workflow_id': 2
+        }
+    }
+
+and in this case `first_level` would be set to `'level_1'`.
+
+Retiring subjects
+-----------------
+
+When the volunteer above classifies a new subject the
+:math:`\text{CM}_{\text{Norm}}` is used to determine how much
+their vote contributes towards retirement.
+
+Let's assume this volunteer voted for the 3rd category. Their
+contribution will be the 3rd column:
+
+.. math::
+
+    \text{W}_i = \left[\frac{1}{10}, \frac{1}{10}, \frac{6}{10}, 0, \frac{2}{10} \right]
+
+This is averaged with the contributions from the other volunteers
+who voted on the subject and the ML score :math:`p^{ML}`
+
+.. math::
+
+    \text{W} = \frac{\sum_{i=1}^{n}{\text{W}_i} + p^{ML}}{n + 1}
+
+When the maximum value of W passes the threshold (currently set
+to 0.9) the image is retired. W is normalized so that all the
+values in the vector sum to 1.
+
+When the maximum value of :math:`\text{W}` passes the threshold
+(e.g. 0.9) the image is retired.
+
+What this looks like in the code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`running_reducer/gravity_spy_subject_reducer.py` returns `number_views`,
+`none_of_the_above_count`, `category_weights` (W above), and
+`max_category_weight`. The store has the two counts above and a
+running sum `category_weights_sum`.
+
+The subject retirement rule can use a combination of `number_views` and
+`max_category_weight` (e.g. when `number_views >= 3` and
+`max_category_weight > 0.9` retire the subject)
+
+Moving subjects to the next level
+---------------------------------
+
+If three or more volunteers vote for "None of the above" the subject
+is moved to the next level up.
+
+What this looks like in the code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`running_reducer/gravity_spy_subject_reducer.py` returns
+`none_of_the_above_count` to use for this rule (e.g.
+when `none_of_the_above_count >= 3` move subject to the next level).
+
+Other notes
+-----------
+
+A volunteer's classification is ignored if their CM column is all
+zeros for the answer they have given (i.e. they have never voted
+for a particular category on any gold standard subject). Additionally,
+if they classify a subject as "none of the above" the `number_views`
+counter is not incremented and the current `category_weights` is not
+changed. This also means classifications from non-logged in volunteers
+are ignored (although if you are not logged in you can not see past the
+level 1 workflow so not that big a deal).
+
+The ML weights count as 1 view (treated the same as any of the volunteers),
+so until `number_views >= 2` it has not been classified by a volunteer with
+a non-zero CM column.

--- a/docs/source/Task_lookup_table.rst
+++ b/docs/source/Task_lookup_table.rst
@@ -96,3 +96,18 @@ These reducers were designed for use with the TESS project to handle real-time u
 |                                   |                                                        +-------------------------------------------------------------------------+
 |                                   |                                                        | :mod:`panoptes_aggregation.running_reducers.tess_gold_standard_reducer` |
 +-----------------------------------+--------------------------------------------------------+-------------------------------------------------------------------------+
+
+----
+
+Gravity Spy project
+-------------------
+These reducers were designed for use with the Gravity Spy project to handle real-time user weighting and user promotion between workflows.  This process
+requires proper `relevant_reduction` beins sent from the user reducer into the subject recducer.
+
++-----------------------------------+----------------------------------+--------------------------------------------------------------------------+
+| Task Type                         | Extractor                        | Reducer                                                                  |
++===================================+==================================+==========================================================================+
+| Gravity Spy Survey Task           | Caesar's `PluckFieldExtractor`   | :mod:`panoptes_aggregation.running_reducers.gravity_spy_subject_reducer` |
++-----------------------------------+----------------------------------+--------------------------------------------------------------------------+
+| Gravity Spy User Reducer          | Caesar's `PluckFieldExtractor`   | :mod:`panoptes_aggregation.running_reducers.gravity_spy_user_reducer`    |
++-----------------------------------+----------------------------------+--------------------------------------------------------------------------+

--- a/docs/source/Task_lookup_table.rst
+++ b/docs/source/Task_lookup_table.rst
@@ -25,9 +25,9 @@ Basic task types
 |                    |                                                                      +---------------------------------------------------------------------------------------+
 |                    |                                                                      | :mod:`panoptes_aggregation.reducers.point_reducer_hdbscan` (includes cov information) |
 |                    +----------------------------------------------------------------------+---------------------------------------------------------------------------------------+
-|                    | :mod:`panoptes_aggregation.extractors.shape_extractor`               | :mod:`panoptes_aggregation.reducers.shape_reducer_dbscan` (no cov infromation)        |
+|                    | :mod:`panoptes_aggregation.extractors.shape_extractor`               | :mod:`panoptes_aggregation.reducers.shape_reducer_dbscan` (no cov information)        |
 |                    |                                                                      +---------------------------------------------------------------------------------------+
-|                    |                                                                      | :mod:`panoptes_aggregation.reducers.shape_reducer_hdbscan` (no cov infromation)       |
+|                    |                                                                      | :mod:`panoptes_aggregation.reducers.shape_reducer_hdbscan` (no cov information)       |
 |                    +----------------------------------------------------------------------+---------------------------------------------------------------------------------------+
 |                    | :mod:`panoptes_aggregation.extractors.point_extractor` (depreciated) | :mod:`panoptes_aggregation.reducers.point_reducer` (depreciated)                      |
 +--------------------+----------------------------------------------------------------------+---------------------------------------------------------------------------------------+
@@ -102,7 +102,7 @@ These reducers were designed for use with the TESS project to handle real-time u
 Gravity Spy project
 -------------------
 These reducers were designed for use with the Gravity Spy project to handle real-time user weighting and user promotion between workflows.  This process
-requires proper `relevant_reduction` beins sent from the user reducer into the subject recducer.
+requires proper `relevant_reduction` being sent from the user reducer into the subject reducer.  See :ref:`gravity-spy`
 
 +-----------------------------------+----------------------------------+--------------------------------------------------------------------------+
 | Task Type                         | Extractor                        | Reducer                                                                  |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Welcome to panoptes_aggregation's documentation
    reducers
    running_reducers
    panoptes
+   Gravity_Spy
    Contributing
    CODE_OF_CONDUCT
 

--- a/docs/source/running_reducers.rst
+++ b/docs/source/running_reducers.rst
@@ -13,3 +13,13 @@ Running Reducers
 
 .. automodule:: panoptes_aggregation.running_reducers.tess_gold_standard_reducer
   :members:
+
+----
+
+.. automodule:: panoptes_aggregation.running_reducers.gravity_spy_user_reducer
+  :members:
+
+----
+
+.. automodule:: panoptes_aggregation.running_reducers.gravity_spy_subject_reducer
+  :members:

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -27,8 +27,8 @@ def gravity_spy_subject_reducer(data, none_key="NONEOFTHEABOVE", **kwargs):
     store : keyword, dict
         A dictionary with two keys:
 
-        * `number_views` : The number of times the subject has been seen (the ML results count for 1 of these)
-        * `category_weights_sum` : The running sum for the weights in each category
+        * `number_views`: The number of times the subject has been seen (the ML results count for 1 of these)
+        * `category_weights_sum`: The running sum for the weights in each category
 
     relevant_reduction : keyword, list
         A list with one item containing the results of the current user's confusion matrix reducer
@@ -39,10 +39,10 @@ def gravity_spy_subject_reducer(data, none_key="NONEOFTHEABOVE", **kwargs):
     reduction: dict
         A dictionary with the following keys:
 
-        * `number_views` : Number of times the subject has been seen (the ML results count for 1 of these)
-        * `category_weights` : A dictionary of values corresponding to the probability the subject belongs
+        * `number_views`: Number of times the subject has been seen (the ML results count for 1 of these)
+        * `category_weights`: A dictionary of values corresponding to the probability the subject belongs
           to each listed category (all values sum to 1)
-        * `max_category_weight` : The max value from the `category_weights` dict, used to retire the subject
+        * `max_category_weight`: The max value from the `category_weights` dict, used to retire the subject
         * `_store` : The updated store (see above)
 
     '''

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -2,7 +2,7 @@
 Gravity Spy Subject Reducer
 ---------------------------
 This module provides functions to calculate subject reductions for the Gravity Spy
-project. Extracts are from Ceasar's `PluckFieldExtractor`.
+project. Extracts are from caesar's `PluckFieldExtractor`.
 '''
 from .running_reducer_wrapper import running_reducer_wrapper
 from collections import Counter

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -1,0 +1,75 @@
+'''
+Gravity Spy Subject Reducer
+---------------------------
+This module porvides functions to calculate subject reducions for the Gravity Spy
+project. Extracts are from Ceasars `PluckFieldExtractor`.
+'''
+from .running_reducer_wrapper import running_reducer_wrapper
+from collections import Counter
+
+
+@running_reducer_wrapper(relevant_reduction=True)
+def gravity_spy_subject_reducer(data, **kwargs):
+    '''Calculate Gravity Spy catagory weights for a subject using volunteer's
+    confusion matrices.
+
+    Parameters
+    ----------
+    data : list
+        A list with one item containing the extract with the user's choice and
+        the resulting weights from the ML code (stored in the subject metadata)
+    store : keyword, dict
+        A dictonary with two keys:
+
+        * `number_views`: The number of times the subject has been seen (the ML results count for 1 of these)
+        * `catagory_weights_sum`: The running sum for the weights in each catagory
+    relevant_reduction : keyword, list
+        A list with one item containing the results of the current user's confusion matrix reducer
+        (see :meth:`panoptes_aggregation.running_reducers.gravity_spy_user_reduce.gravity_spy_user_reduce`)
+
+    Returns
+    -------
+    reduction: dict
+        A dictonary with four keys:
+
+        * `number_views`: Number of times the subject has been seen (the ML results count for 1 of these)
+        * `catagory_weights`: A dictonary of values corrisponding to the probability the subject belongs
+            to each listed catagory (all values sum to 1)
+        * `max_catagory_weight`: The max value from the `catagory_weights ` dict, used to retire the subject
+        * `_store`: The updated store (see above)
+    '''
+    store = kwargs.pop('store')
+    relevant_reduction = kwargs.pop('relevant_reduction')[0]
+    user_label = data[0]['user_label']
+    try:
+        user_weight = Counter(relevant_reduction['data']['normalized_confusion_matrix'][user_label])
+    except TypeError:
+        # There are no votes on *any* gold standard subjects for this user
+        user_weight = Counter({})
+    except KeyError:
+        # this will happen if the user has never voted for this particular *catagory* on any
+        # gold standard subject (i.e. the column of the confusion matrix is all zeros)
+        user_weight = Counter({})
+    number_views = store.get('number_views', 0)
+    if number_views == 0:
+        # This is the first time the subject has been viewed.
+        # Use the ML weigths as the "first vote"
+        number_views += 1
+        catagory_weights_sum = Counter(data[0]['ml_weights'])
+    else:
+        catagory_weights_sum = Counter(store['catagory_weights_sum'])
+    if len(user_weight) > 0:
+        # Only update values if there is a non-zero weight to add
+        number_views += 1
+        catagory_weights_sum += user_weight
+    catagory_weights = {key: value / number_views for key, value in catagory_weights_sum.items()}
+    max_catagory_weight = max(catagory_weights.values())
+    return {
+        'number_views': number_views,
+        'catagory_weights': catagory_weights,
+        'max_catagory_weight': max_catagory_weight,
+        '_store': {
+            'number_views': number_views,
+            'catagory_weights_sum': dict(catagory_weights_sum)
+        }
+    }

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -27,8 +27,9 @@ def gravity_spy_subject_reducer(data, none_key="NONEOFTHEABOVE", **kwargs):
     store : keyword, dict
         A dictionary with two keys:
 
-        * `number_views`: The number of times the subject has been seen (the ML results count for 1 of these)
-        * `category_weights_sum`: The running sum for the weights in each category
+        * `number_views` : The number of times the subject has been seen (the ML results count for 1 of these)
+        * `category_weights_sum` : The running sum for the weights in each category
+
     relevant_reduction : keyword, list
         A list with one item containing the results of the current user's confusion matrix reducer
         (see :meth:`panoptes_aggregation.running_reducers.gravity_spy_user_reduce.gravity_spy_user_reduce`)
@@ -36,13 +37,14 @@ def gravity_spy_subject_reducer(data, none_key="NONEOFTHEABOVE", **kwargs):
     Returns
     -------
     reduction: dict
-        A dictionary with four keys:
+        A dictionary with the following keys:
 
-        * `number_views`: Number of times the subject has been seen (the ML results count for 1 of these)
-        * `category_weights`: A dictionary of values corresponding to the probability the subject belongs
-            to each listed category (all values sum to 1)
-        * `max_category_weight`: The max value from the `category_weights ` dict, used to retire the subject
-        * `_store`: The updated store (see above)
+        * `number_views` : Number of times the subject has been seen (the ML results count for 1 of these)
+        * `category_weights` : A dictionary of values corresponding to the probability the subject belongs
+          to each listed category (all values sum to 1)
+        * `max_category_weight` : The max value from the `category_weights` dict, used to retire the subject
+        * `_store` : The updated store (see above)
+
     '''
     store = kwargs.pop('store')
     relevant_reduction = kwargs.pop('relevant_reduction')[0]

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -1,8 +1,8 @@
 '''
 Gravity Spy Subject Reducer
 ---------------------------
-This module porvides functions to calculate subject reducions for the Gravity Spy
-project. Extracts are from Ceasars `PluckFieldExtractor`.
+This module provides functions to calculate subject reductions for the Gravity Spy
+project. Extracts are from Ceasar's `PluckFieldExtractor`.
 '''
 from .running_reducer_wrapper import running_reducer_wrapper
 from collections import Counter
@@ -10,7 +10,7 @@ from collections import Counter
 
 @running_reducer_wrapper(relevant_reduction=True)
 def gravity_spy_subject_reducer(data, **kwargs):
-    '''Calculate Gravity Spy catagory weights for a subject using volunteer's
+    '''Calculate Gravity Spy category weights for a subject using volunteer's
     confusion matrices.
 
     Parameters
@@ -19,10 +19,10 @@ def gravity_spy_subject_reducer(data, **kwargs):
         A list with one item containing the extract with the user's choice and
         the resulting weights from the ML code (stored in the subject metadata)
     store : keyword, dict
-        A dictonary with two keys:
+        A dictionary with two keys:
 
         * `number_views`: The number of times the subject has been seen (the ML results count for 1 of these)
-        * `catagory_weights_sum`: The running sum for the weights in each catagory
+        * `category_weights_sum`: The running sum for the weights in each category
     relevant_reduction : keyword, list
         A list with one item containing the results of the current user's confusion matrix reducer
         (see :meth:`panoptes_aggregation.running_reducers.gravity_spy_user_reduce.gravity_spy_user_reduce`)
@@ -30,12 +30,12 @@ def gravity_spy_subject_reducer(data, **kwargs):
     Returns
     -------
     reduction: dict
-        A dictonary with four keys:
+        A dictionary with four keys:
 
         * `number_views`: Number of times the subject has been seen (the ML results count for 1 of these)
-        * `catagory_weights`: A dictonary of values corrisponding to the probability the subject belongs
-            to each listed catagory (all values sum to 1)
-        * `max_catagory_weight`: The max value from the `catagory_weights ` dict, used to retire the subject
+        * `category_weights`: A dictionary of values corresponding to the probability the subject belongs
+            to each listed category (all values sum to 1)
+        * `max_category_weight`: The max value from the `category_weights ` dict, used to retire the subject
         * `_store`: The updated store (see above)
     '''
     store = kwargs.pop('store')
@@ -53,23 +53,23 @@ def gravity_spy_subject_reducer(data, **kwargs):
     number_views = store.get('number_views', 0)
     if number_views == 0:
         # This is the first time the subject has been viewed.
-        # Use the ML weigths as the "first vote"
+        # Use the ML weights as the "first vote"
         number_views += 1
-        catagory_weights_sum = Counter(data[0]['ml_weights'])
+        category_weights_sum = Counter(data[0]['ml_weights'])
     else:
-        catagory_weights_sum = Counter(store['catagory_weights_sum'])
+        category_weights_sum = Counter(store['catagory_weights_sum'])
     if len(user_weight) > 0:
         # Only update values if there is a non-zero weight to add
         number_views += 1
-        catagory_weights_sum += user_weight
-    catagory_weights = {key: value / number_views for key, value in catagory_weights_sum.items()}
-    max_catagory_weight = max(catagory_weights.values())
+        category_weights_sum += user_weight
+    category_weights = {key: value / number_views for key, value in category_weights_sum.items()}
+    max_category_weight = max(category_weights.values())
     return {
         'number_views': number_views,
-        'catagory_weights': catagory_weights,
-        'max_catagory_weight': max_catagory_weight,
+        'category_weights': category_weights,
+        'max_category_weight': max_category_weight,
         '_store': {
             'number_views': number_views,
-            'catagory_weights_sum': dict(catagory_weights_sum)
+            'catagory_weights_sum': dict(category_weights_sum)
         }
     }

--- a/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_subject_reducer.py
@@ -7,9 +7,13 @@ project. Extracts are from Ceasar's `PluckFieldExtractor`.
 from .running_reducer_wrapper import running_reducer_wrapper
 from collections import Counter
 
+DEFAULTS = {
+    'none_key': {'default': 'NONEOFTHEABOVE', 'type': str}
+}
 
-@running_reducer_wrapper(relevant_reduction=True)
-def gravity_spy_subject_reducer(data, **kwargs):
+
+@running_reducer_wrapper(relevant_reduction=True, defaults_data=DEFAULTS)
+def gravity_spy_subject_reducer(data, none_key="NONEOFTHEABOVE", **kwargs):
     '''Calculate Gravity Spy category weights for a subject using volunteer's
     confusion matrices.
 
@@ -18,6 +22,8 @@ def gravity_spy_subject_reducer(data, **kwargs):
     data : list
         A list with one item containing the extract with the user's choice and
         the resulting weights from the ML code (stored in the subject metadata)
+    none_key : string
+        The key used for a "none of the above" answer
     store : keyword, dict
         A dictionary with two keys:
 
@@ -41,15 +47,20 @@ def gravity_spy_subject_reducer(data, **kwargs):
     store = kwargs.pop('store')
     relevant_reduction = kwargs.pop('relevant_reduction')[0]
     user_label = data[0]['user_label']
-    try:
-        user_weight = Counter(relevant_reduction['data']['normalized_confusion_matrix'][user_label])
-    except TypeError:
-        # There are no votes on *any* gold standard subjects for this user
+    none_of_the_above_count = store.get('none_of_the_above_count', 0)
+    if user_label == none_key:
+        none_of_the_above_count += 1
         user_weight = Counter({})
-    except KeyError:
-        # this will happen if the user has never voted for this particular *catagory* on any
-        # gold standard subject (i.e. the column of the confusion matrix is all zeros)
-        user_weight = Counter({})
+    else:
+        try:
+            user_weight = Counter(relevant_reduction['data']['normalized_confusion_matrix'][user_label])
+        except TypeError:
+            # There are no votes on *any* gold standard subjects for this user
+            user_weight = Counter({})
+        except KeyError:
+            # this will happen if the user has never voted for this particular *category* on any
+            # gold standard subject (i.e. the column of the confusion matrix is all zeros)
+            user_weight = Counter({})
     number_views = store.get('number_views', 0)
     if number_views == 0:
         # This is the first time the subject has been viewed.
@@ -57,7 +68,7 @@ def gravity_spy_subject_reducer(data, **kwargs):
         number_views += 1
         category_weights_sum = Counter(data[0]['ml_weights'])
     else:
-        category_weights_sum = Counter(store['catagory_weights_sum'])
+        category_weights_sum = Counter(store['category_weights_sum'])
     if len(user_weight) > 0:
         # Only update values if there is a non-zero weight to add
         number_views += 1
@@ -66,10 +77,12 @@ def gravity_spy_subject_reducer(data, **kwargs):
     max_category_weight = max(category_weights.values())
     return {
         'number_views': number_views,
+        'none_of_the_above_count': none_of_the_above_count,
         'category_weights': category_weights,
         'max_category_weight': max_category_weight,
         '_store': {
             'number_views': number_views,
-            'catagory_weights_sum': dict(category_weights_sum)
+            'none_of_the_above_count': none_of_the_above_count,
+            'category_weights_sum': dict(category_weights_sum)
         }
     }

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -1,0 +1,64 @@
+'''
+Gravity Spy User Reducer
+------------------------
+This module porvides functions to calculate uesr weights for the Gravity Spy
+project. Extracts are from Ceasars `PluckFieldExtractor`.
+'''
+from .running_reducer_wrapper import running_reducer_wrapper
+
+
+@running_reducer_wrapper()
+def gravity_spy_user_reducer(data, **kwargs):
+    '''Calculate Gravity Spy user weights based on a confusion matrix
+    from gold standard data.
+
+    Parameters
+    ----------
+    data : list
+        A list with one item containing the extract with the user's choice
+        and the gold standard label.
+    store : keyword, list
+        A dictonary with two keys:
+
+        * `confusion_matrix`: The confusion matrix for the user (stored as nested dict).
+            The frist key is the choice given by the user, the second key is the gold
+            standard label.
+        * `column_normalization`: The sum of each of the columns (used for normaliztion).
+            i.e. The total number of time the user has vote for each choice.
+    
+    Returns
+    -------
+    reduction : dict
+        A dictionary with four keys:
+
+        * `alpha`: A dictionary of values indicating how well the user classifies each 
+            catagory they have seen gold standard images for (diagonal of the normalized
+            confusion matrix).
+        * `alpha_min`: The minimum value of `alpha`, this is used to determin when a user
+            should be promoted.
+        * `alpha_length`: The number of values in the `alpha` dict, used to make sure the
+            user has seen every gold standard class of a level before being promoted
+        * `_store`: The updated store (see above).
+    '''
+    store = kwargs.pop('store')
+    store.setdefault('confusion_matrix', {})
+    store.setdefault('column_normalization', {})
+    user_label = data[0]['user_label']
+    gold_label = data[0]['gold_label']
+    store['confusion_matrix'].setdefault(user_label, {}).setdefault(gold_label, 0)
+    store['confusion_matrix'][user_label][gold_label] += 1
+    store['column_normalization'].setdefault(user_label, 0)
+    store['column_normalization'][user_label] += 1
+    alpha = {}
+    for column_key, norm_value in store['column_normalization'].items():
+        cm_value = store['confusion_matrix'][column_key].get(column_key, 0)
+        if cm_value > 0:
+            alpha[column_key] = cm_value / norm_value
+    alpha_length = len(alpha)
+    alpha_min = min(alpha.values())
+    return {
+        'alpha': alpha,
+        'alpha_min': alpha_min,
+        'alpha_length': alpha_length,
+        '_store': store
+    }

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -1,8 +1,8 @@
 '''
 Gravity Spy User Reducer
 ------------------------
-This module porvides functions to calculate uesr weights for the Gravity Spy
-project. Extracts are from Ceasars `PluckFieldExtractor`.
+This module provides functions to calculate user weights for the Gravity Spy
+project. Extracts are from caesar's `PluckFieldExtractor`.
 '''
 from .running_reducer_wrapper import running_reducer_wrapper
 

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -6,8 +6,12 @@ project. Extracts are from Ceasars `PluckFieldExtractor`.
 '''
 from .running_reducer_wrapper import running_reducer_wrapper
 
+DEFAULTS = {
+    'level_config': {'default': None, 'type': dict}
+}
 
-@running_reducer_wrapper()
+
+@running_reducer_wrapper(defaults_data=DEFAULTS)
 def gravity_spy_user_reducer(data, **kwargs):
     '''Calculate Gravity Spy user weights based on a confusion matrix
     from gold standard data.
@@ -17,6 +21,28 @@ def gravity_spy_user_reducer(data, **kwargs):
     data : list
         A list with one item containing the extract with the user's choice
         and the gold standard label.
+    level_config : dict
+        This dictionary holds information about each level in the project.  The keys should
+        be intigers for each level, and the values are a dict with up to three keys:
+        * `workflow_id`: the workflow ID for the level
+        * `new_categories`: the categories added in this level (not included for the final level)
+        * `threshold`: the min value of `alpha` these categories need to trigger a level up
+            (not included for the final level)
+        example:
+            level_config = {
+                1: {
+                    'workflow_id': 1,
+                    'new_categories': [
+                        'BLIP',
+                        'WHISTLE'
+                    ],
+                    'threshold': 0.7
+                },
+                2: {
+                    'workflow_id': 2
+                }
+            }
+
     store : keyword, dict
         A dictionary with two keys:
 
@@ -25,6 +51,7 @@ def gravity_spy_user_reducer(data, **kwargs):
             standard label.
         * `column_normalization`: The sum of each of the columns (used for normalization).
             i.e. The total number of time the user has vote for each choice.
+        * `level`: the current workflow level of the user
 
     Returns
     -------
@@ -34,16 +61,18 @@ def gravity_spy_user_reducer(data, **kwargs):
         * `alpha`: A dictionary of values indicating how well the user classifies each
             category they have seen gold standard images for (diagonal of the normalized
             confusion matrix).
-        * `alpha_min`: The minimum value of `alpha`, this is used to determin when a user
-            should be promoted.
+        * `level_up`: Bool indicating if the user should level up (used to trigger effect)
+        * `max_workflow_id`: The workflow ID for the user's highest unlocked level
         * `alpha_length`: The number of values in the `alpha` dict, used to make sure the
             user has seen every gold standard class of a level before being promoted
         * `normalized_confusion_matrix`: The column normalized confusion matrix for the user
         * `_store`: The updated store (see above)
     '''
+    level_config = kwargs.pop('level_config')
     store = kwargs.pop('store')
     cm = store.get('confusion_matrix', {})
     n = store.get('column_normalization', {})
+    level = store.get('level', 1)
     user_label = data[0]['user_label']
     gold_label = data[0]['gold_label']
     cm.setdefault(user_label, {}).setdefault(gold_label, 0)
@@ -56,15 +85,24 @@ def gravity_spy_user_reducer(data, **kwargs):
         } for column_key, column_value in cm.items()
     }
     alpha = {key: value[key] for key, value in normalized_confusion_matrix.items() if key in value}
-    alpha_length = len(alpha)
-    alpha_min = min(alpha.values())
+    level_up = False
+    max_workflow_id = None
+    if (level_config is not None) and (level in level_config):
+        if {'workflow_id', 'new_categories', 'threshold'} <= level_config[level].keys():
+            level_up = True
+            for key in level_config[level]['new_categories']:
+                level_up &= (alpha.get(key, 0) >= level_config[level]['threshold'])
+            if level_up:
+                level += 1
+            max_workflow_id = level_config[level]['workflow_id']
     return {
         'alpha': alpha,
-        'alpha_min': alpha_min,
-        'alpha_length': alpha_length,
+        'level_up': level_up,
+        'max_workflow_id': max_workflow_id,
         'normalized_confusion_matrix': normalized_confusion_matrix,
         '_store': {
             'confusion_matrix': cm,
-            'column_normalization': n
+            'column_normalization': n,
+            'level': level
         }
     }

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -18,12 +18,12 @@ def gravity_spy_user_reducer(data, **kwargs):
         A list with one item containing the extract with the user's choice
         and the gold standard label.
     store : keyword, dict
-        A dictonary with two keys:
+        A dictionary with two keys:
 
         * `confusion_matrix`: The confusion matrix for the user (stored as nested dict).
-            The frist key is the choice given by the user, the second key is the gold
+            The first key is the choice given by the user, the second key is the gold
             standard label.
-        * `column_normalization`: The sum of each of the columns (used for normaliztion).
+        * `column_normalization`: The sum of each of the columns (used for normalization).
             i.e. The total number of time the user has vote for each choice.
 
     Returns
@@ -32,7 +32,7 @@ def gravity_spy_user_reducer(data, **kwargs):
         A dictionary with four keys:
 
         * `alpha`: A dictionary of values indicating how well the user classifies each
-            catagory they have seen gold standard images for (diagonal of the normalized
+            category they have seen gold standard images for (diagonal of the normalized
             confusion matrix).
         * `alpha_min`: The minimum value of `alpha`, this is used to determin when a user
             should be promoted.

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -28,11 +28,11 @@ def gravity_spy_user_reducer(data, **kwargs):
         This dictionary holds information about each level in the project.  The key must be
         strings and the values are a dict with up to four keys:
 
-        * `workflow_id` : the workflow ID for the level
-        * `new_categories` : the categories added in this level (not included for the final level)
-        * `threshold` : the min value of `alpha` these categories need to trigger a level up
+        * `workflow_id`: the workflow ID for the level
+        * `new_categories`: the categories added in this level (not included for the final level)
+        * `threshold`: the min value of `alpha` these categories need to trigger a level up
           (not included for the final level)
-        * `next_level` : the key for the next level (not included for the final level).
+        * `next_level`: the key for the next level (not included for the final level).
           Example:
 
           .. code-block:: python

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -25,13 +25,13 @@ def gravity_spy_user_reducer(data, **kwargs):
             standard label.
         * `column_normalization`: The sum of each of the columns (used for normaliztion).
             i.e. The total number of time the user has vote for each choice.
-    
+
     Returns
     -------
     reduction : dict
         A dictionary with four keys:
 
-        * `alpha`: A dictionary of values indicating how well the user classifies each 
+        * `alpha`: A dictionary of values indicating how well the user classifies each
             catagory they have seen gold standard images for (diagonal of the normalized
             confusion matrix).
         * `alpha_min`: The minimum value of `alpha`, this is used to determin when a user

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -17,7 +17,7 @@ def gravity_spy_user_reducer(data, **kwargs):
     data : list
         A list with one item containing the extract with the user's choice
         and the gold standard label.
-    store : keyword, list
+    store : keyword, dict
         A dictonary with two keys:
 
         * `confusion_matrix`: The confusion matrix for the user (stored as nested dict).
@@ -39,7 +39,7 @@ def gravity_spy_user_reducer(data, **kwargs):
         * `alpha_length`: The number of values in the `alpha` dict, used to make sure the
             user has seen every gold standard class of a level before being promoted
         * `normalized_confusion_matrix`: The column normalized confusion matrix for the user
-        * `_store`: The updated store (see above).
+        * `_store`: The updated store (see above)
     '''
     store = kwargs.pop('store')
     cm = store.get('confusion_matrix', {})

--- a/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/gravity_spy_user_reducer.py
@@ -26,53 +26,58 @@ def gravity_spy_user_reducer(data, **kwargs):
         A string containing the key for the first level in the `level_config` object
     level_config : dict
         This dictionary holds information about each level in the project.  The key must be
-        strings and the values are a dict with up to three keys:
-        * `workflow_id`: the workflow ID for the level
-        * `new_categories`: the categories added in this level (not included for the final level)
-        * `threshold`: the min value of `alpha` these categories need to trigger a level up
-            (not included for the final level)
-        * `next_level`: the key for the next level (not included for the final level)
-        example:
-            level_config = {
-                'level_1': {
-                    'workflow_id': 1,
-                    'new_categories': [
-                        'BLIP',
-                        'WHISTLE'
-                    ],
-                    'threshold': 0.7,
-                    'next_level': 'level_2'
-                },
-                'level_2': {
-                    'workflow_id': 2
-                }
-            }
+        strings and the values are a dict with up to four keys:
+
+        * `workflow_id` : the workflow ID for the level
+        * `new_categories` : the categories added in this level (not included for the final level)
+        * `threshold` : the min value of `alpha` these categories need to trigger a level up
+          (not included for the final level)
+        * `next_level` : the key for the next level (not included for the final level).
+          Example:
+
+          .. code-block:: python
+
+              level_config = {
+                  'level_1': {
+                      'workflow_id': 1,
+                      'new_categories': [
+                          'BLIP',
+                          'WHISTLE'
+                      ],
+                      'threshold': 0.7,
+                      'next_level': 'level_2'
+                  },
+                  'level_2': {
+                      'workflow_id': 2
+                  }
+              }
 
     store : keyword, dict
-        A dictionary with two keys:
+        A dictionary with three keys:
 
         * `confusion_matrix`: The confusion matrix for the user (stored as nested dict).
-            The first key is the choice given by the user, the second key is the gold
-            standard label.
+          The first key is the choice given by the user, the second key is the gold
+          standard label.
         * `column_normalization`: The sum of each of the columns (used for normalization).
-            i.e. The total number of time the user has vote for each choice.
+          i.e. The total number of time the user has vote for each choice.
         * `max_level`: The maximum workflow level of the user
 
     Returns
     -------
     reduction : dict
-        A dictionary with four keys:
+        A dictionary with the following keys:
 
         * `alpha`: A dictionary of values indicating how well the user classifies each
-            category they have seen gold standard images for (diagonal of the normalized
-            confusion matrix).
+          category they have seen gold standard images for (diagonal of the normalized
+          confusion matrix).
         * `level_up`: Bool indicating if the user should level up (used to trigger effect)
         * `max_workflow_id`: The workflow ID for the user's highest unlocked level
         * `max_level`: The maximum workflow level of the user
         * `alpha_length`: The number of values in the `alpha` dict, used to make sure the
-            user has seen every gold standard class of a level before being promoted
+          user has seen every gold standard class of a level before being promoted
         * `normalized_confusion_matrix`: The column normalized confusion matrix for the user
         * `_store`: The updated store (see above)
+
     '''
     first_level_key = kwargs.pop('first_level')
     level_config = kwargs.pop('level_config')

--- a/panoptes_aggregation/running_reducers/running_reducer_wrapper.py
+++ b/panoptes_aggregation/running_reducers/running_reducer_wrapper.py
@@ -47,7 +47,7 @@ def running_reducer_wrapper(
             if not no_version:
                 append_version(reduction)
             return reduction
-        #: keep the orignal function around for testing
+        #: keep the original function around for testing
         #: and access by other reducers
         wrapper._original = func
         return wrapper

--- a/panoptes_aggregation/running_reducers/running_reducer_wrapper.py
+++ b/panoptes_aggregation/running_reducers/running_reducer_wrapper.py
@@ -1,3 +1,4 @@
+import ast
 from functools import wraps
 from ..reducers.process_kwargs import process_kwargs
 from ..append_version import append_version, remove_version
@@ -22,6 +23,8 @@ def running_reducer_wrapper(
                 argument_json = argument.get_json()
                 data_in = [d['data'] for d in argument_json['extracts']]
                 store = argument_json['store']
+                if 'level_config' in kwargs:
+                    kwargs['level_config'] = ast.literal_eval(kwargs['level_config'])
                 if user_id:
                     kwargs_extra_data['user_id'] = [d['user_id'] for d in argument_json['extracts']]
                 if relevant_reduction:

--- a/panoptes_aggregation/running_reducers/tess_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/tess_user_reducer.py
@@ -18,8 +18,7 @@ def tess_user_reducer(data, **kwargs):
         A list with one item containing the extract with the user's feedback on a
         gold standard subject
     store : keyword, list
-        A list with one item containing the user's current store.  This item is a
-        dictinary with two keys:
+        A dictinary with two keys:
 
         * `seed`: sum of all previous `seed` values
         * `count`: sum of all previous gold standard transits seen

--- a/panoptes_aggregation/running_reducers/tess_user_reducer.py
+++ b/panoptes_aggregation/running_reducers/tess_user_reducer.py
@@ -17,7 +17,7 @@ def tess_user_reducer(data, **kwargs):
     data : list
         A list with one item containing the extract with the user's feedback on a
         gold standard subject
-    store : keyword, list
+    store : keyword, dict
         A dictinary with two keys:
 
         * `seed`: sum of all previous `seed` values

--- a/panoptes_aggregation/tests/extractor_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/extractor_tests/base_test_class.py
@@ -13,7 +13,16 @@ except ImportError:
     OFFLINE = True
 
 
-def ExtractorTest(function, classification, expected, name, blank_extract={}, kwargs={}, test_type='assertDictEqual'):
+def ExtractorTest(
+    function,
+    classification,
+    expected,
+    name,
+    blank_extract={},
+    kwargs={},
+    test_type='assertDictEqual',
+    test_name=None
+):
     class ExtractorTest(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -59,10 +68,22 @@ def ExtractorTest(function, classification, expected, name, blank_extract={}, kw
                 result = function(flask.request)
                 self.assertTestType(result, expected)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    ExtractorTest.__name__ = test_name
+    ExtractorTest.__qualname__ = test_name
     return ExtractorTest
 
 
-def TextExtractorTest(function, classification, expected, name, blank_extract={}, kwargs={}):
+def TextExtractorTest(
+    function,
+    classification,
+    expected,
+    name,
+    blank_extract={},
+    kwargs={},
+    test_name=None
+):
     class TextExtractorTest(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -115,10 +136,20 @@ def TextExtractorTest(function, classification, expected, name, blank_extract={}
                 result = function(flask.request)
                 self.assertTextExtractor(result, expected)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    TextExtractorTest.__name__ = test_name
+    TextExtractorTest.__qualname__ = test_name
     return TextExtractorTest
 
 
-def TextExtractorBadKeywordTest(function, classification, expected, name):
+def TextExtractorBadKeywordTest(
+    function,
+    classification,
+    expected,
+    name,
+    test_name=None
+):
     class TextExtractorTestBadKeyword(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -131,4 +162,8 @@ def TextExtractorBadKeywordTest(function, classification, expected, name):
             with self.assertRaises(ValueError):
                 function(annotation_by_task(classification), dot_freq='bad_keyword')
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    TextExtractorTestBadKeyword.__name__ = test_name
+    TextExtractorTestBadKeyword.__qualname__ = test_name
     return TextExtractorTestBadKeyword

--- a/panoptes_aggregation/tests/extractor_tests/test_dropdown_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_dropdown_extractor.py
@@ -35,5 +35,6 @@ TestDropdown = ExtractorTest(
     extractors.dropdown_extractor,
     classification,
     expected,
-    'Test dropdown list'
+    'Test dropdown list',
+    test_name='TestDropdown'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_i2a_extractor.py
@@ -56,7 +56,8 @@ TestI2A = ExtractorTest(
     extractors.i2a_extractor,
     classification,
     expected,
-    'Test i2a'
+    'Test i2a',
+    test_name='TestI2A'
 )
 
 classification_blank = {
@@ -96,5 +97,6 @@ TestI2A_blank = ExtractorTest(
     extractors.i2a_extractor,
     classification_blank,
     expected_blank,
-    'Test i2a with blank annotation'
+    'Test i2a with blank annotation',
+    test_name='TestI2A_blank'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_line_text_extractor.py
@@ -141,7 +141,8 @@ TestLineText = TextExtractorTest(
     extractors.line_text_extractor,
     classification,
     expected,
-    'Test line-text extractor'
+    'Test line-text extractor',
+    test_name='TestLineText'
 )
 
 TestLineTextTool = TextExtractorTest(
@@ -149,5 +150,6 @@ TestLineTextTool = TextExtractorTest(
     classification,
     expected,
     'Test line-text extractor with tool specified',
-    kwargs={'tools': [0]}
+    kwargs={'tools': [0]},
+    test_name='TestLineTextTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -47,7 +47,8 @@ TestNfN = ExtractorTest(
     classification,
     expected,
     'Test NfN with year and country tasks specified done at night',
-    kwargs={'year': 'T10', 'workflow': 'herbarium', 'country': "T1"}
+    kwargs={'year': 'T10', 'workflow': 'herbarium', 'country': "T1"},
+    test_name='TestNfN'
 )
 
 classification_0 = {
@@ -88,8 +89,9 @@ TestNfNTwo = ExtractorTest(
     extractors.nfn_extractor,
     classification_0,
     expected_0,
-    'Test NfN on Earth Day with year as nested task and country from metadata. At lunchtime, local time.',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'}
+    'Test NfN on Earth Day with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNTwo'
 )
 
 classification_1 = {
@@ -118,8 +120,9 @@ TestNfNThree = ExtractorTest(
     extractors.nfn_extractor,
     classification_1,
     expected_1,
-    'Test NfN bare integer year annotation at lunchtime.',
-    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+    'Test NfN bare integer year annotation at lunchtime',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'},
+    test_name='TestNfNThree'
 )
 
 classification_bad_year = {
@@ -147,8 +150,9 @@ TestNfNBadYear = ExtractorTest(
     extractors.nfn_extractor,
     classification_bad_year,
     expected_no_year,
-    'Test NfN bare integer year annotation at lunchtime with porly formatted year',
-    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+    'Test NfN bare integer year annotation at lunchtime with poorly formatted year',
+    kwargs={'year': 'T10', 'workflow': 'herbarium'},
+    test_name='TestNfNBadYear'
 )
 
 TestNfNNoYear = ExtractorTest(
@@ -156,7 +160,8 @@ TestNfNNoYear = ExtractorTest(
     classification_1,
     expected_no_year,
     'Test NfN bare integer year annotation at lunchtime with no year keyword',
-    kwargs={'workflow': 'herbarium'}
+    kwargs={'workflow': 'herbarium'},
+    test_name='TestNfNNoYear'
 )
 
 classification_earlybird = {
@@ -186,7 +191,8 @@ TestNfNEarlybird = ExtractorTest(
     classification_earlybird,
     expected_earlybird,
     'Test NfN bare integer year annotation at earlybird ',
-    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+    kwargs={'year': 'T10', 'workflow': 'herbarium'},
+    test_name='TestNfNEarlybird'
 )
 
 classification_dinnertime = {
@@ -216,7 +222,8 @@ TestNfNDinnertime = ExtractorTest(
     classification_dinnertime,
     expected_dinnertime,
     'Test NfN bare integer year annotation at dinnertime',
-    kwargs={'year': 'T10', 'workflow': 'herbarium'}
+    kwargs={'year': 'T10', 'workflow': 'herbarium'},
+    test_name='TestNfNDinnertime'
 )
 
 TestNfNNotInMetadataOrParams = ExtractorTest(
@@ -224,5 +231,6 @@ TestNfNNotInMetadataOrParams = ExtractorTest(
     classification_dinnertime,
     expected_dinnertime,
     'Test NfN bare integer year annotation at dinnertime with no state info in metadata',
-    kwargs={'year': 'T10', 'workflow': 'herbarium', 'state': 'metadata'}
+    kwargs={'year': 'T10', 'workflow': 'herbarium', 'state': 'metadata'},
+    test_name='TestNfNNotInMetadataOrParams'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_point_extractor.py
@@ -105,7 +105,8 @@ TestPoint = ExtractorTest(
     extractors.point_extractor,
     classification,
     expected,
-    'Test point'
+    'Test point',
+    test_name='TestPoint'
 )
 
 TestPointTask = ExtractorTest(
@@ -113,7 +114,8 @@ TestPointTask = ExtractorTest(
     classification,
     expected,
     'Test point with task specified',
-    kwargs={'task': 'T0'}
+    kwargs={'task': 'T0'},
+    test_name='TestPointTask'
 )
 
 TestPointAllTools = ExtractorTest(
@@ -124,7 +126,8 @@ TestPointAllTools = ExtractorTest(
     kwargs={
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestPointAllTools'
 )
 
 expected_0 = {
@@ -140,5 +143,6 @@ TestPointOneTool = ExtractorTest(
     kwargs={
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestPointOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_point_extractor_by_frame.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_point_extractor_by_frame.py
@@ -107,7 +107,8 @@ TestPointByFrame = ExtractorTest(
     extractors.point_extractor_by_frame,
     classification,
     expected,
-    'Test point by frame'
+    'Test point by frame',
+    test_name='TestPointByFrame'
 )
 
 TestPointByFrameTask = ExtractorTest(
@@ -115,7 +116,8 @@ TestPointByFrameTask = ExtractorTest(
     classification,
     expected,
     'Test point by frame with task specified',
-    kwargs={'task': 'T0'}
+    kwargs={'task': 'T0'},
+    test_name='TestPointByFrameTask'
 )
 
 TestPointByFrameAllTools = ExtractorTest(
@@ -127,6 +129,7 @@ TestPointByFrameAllTools = ExtractorTest(
         'task': 'T0',
         'tools': [0, 1]
     },
+    test_name='TestPointByFrameAllTools'
 )
 
 expected_0 = {
@@ -144,5 +147,6 @@ TestPointByFrameOneTool = ExtractorTest(
     kwargs={
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestPointByFrameOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor.py
@@ -212,7 +212,8 @@ TestPolyLineText = TextExtractorTest(
     classification,
     expected,
     'Test poly-line-text extractor by word',
-    kwargs={'dot_freq': 'word'}
+    kwargs={'dot_freq': 'word'},
+    test_name='TestPolyLineText'
 )
 
 TestPolyLineTextTool = TextExtractorTest(
@@ -223,12 +224,14 @@ TestPolyLineTextTool = TextExtractorTest(
     kwargs={
         'tools': [0],
         'dot_freq': 'word'
-    }
+    },
+    test_name='TestPolyLineTextTool'
 )
 
 TestPolyLineTextBadKeyword = TextExtractorBadKeywordTest(
     extractors.poly_line_text_extractor,
     classification,
     expected,
-    'Test poly-line-text extractor by word with bad keyword'
+    'Test poly-line-text extractor by word with bad keyword',
+    test_name='TestPolyLineTextBadKeyword'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_poly_line_text_extractor_by_line.py
@@ -189,7 +189,8 @@ TestPolyLineTextByLine = TextExtractorTest(
     classification,
     expected,
     'Test poly-line-text extractor by line',
-    kwargs={'dot_freq': 'line'}
+    kwargs={'dot_freq': 'line'},
+    test_name='TestPolyLineTextByLine'
 )
 
 TestPolyLineTextByLineTool = TextExtractorTest(
@@ -197,12 +198,14 @@ TestPolyLineTextByLineTool = TextExtractorTest(
     classification,
     expected,
     'Test poly-line-text extractor by line with tool specified',
-    kwargs={'dot_freq': 'line', 'tools': [0]}
+    kwargs={'dot_freq': 'line', 'tools': [0]},
+    test_name='TestPolyLineTextByLineTool'
 )
 
 TestPolyLineTextByLineBadKeyword = TextExtractorBadKeywordTest(
     extractors.poly_line_text_extractor,
     classification,
     expected,
-    'Test poly-line-text extractor by line with bad keyword'
+    'Test poly-line-text extractor by line with bad keyword',
+    test_name='TestPolyLineTextByLineBadKeyword'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_question_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_question_extractor.py
@@ -15,7 +15,8 @@ TestSingle = ExtractorTest(
     extractors.question_extractor,
     single_classification,
     single_expected,
-    'Test single question'
+    'Test single question',
+    test_name='TestSingle'
 )
 
 multiple_classification = {
@@ -32,7 +33,8 @@ TestMultiple = ExtractorTest(
     extractors.question_extractor,
     multiple_classification,
     multiple_expected,
-    'Test multiple question'
+    'Test multiple question',
+    test_name='TestMultiple'
 )
 
 null_classification = {
@@ -49,7 +51,8 @@ TestNull = ExtractorTest(
     extractors.question_extractor,
     null_classification,
     null_expected,
-    'Test null question'
+    'Test null question',
+    test_name='TestNull'
 )
 
 single_classification_two_tasks = {
@@ -67,18 +70,20 @@ single_classification_two_tasks = {
 single_expected_1 = {'yes': 1}
 single_expected_2 = {'no': 1}
 
-TestSingleTwoTasks = ExtractorTest(
+TestSingleTwoTasksNoKey = ExtractorTest(
     extractors.question_extractor,
     single_classification_two_tasks,
     single_expected_1,
-    'Test multiple single questions passed in without task keyword'
+    'Test multiple single questions passed in without task keyword',
+    test_name='TestSingleTwoTasksNoKey'
 )
 
 
-TestSingleTwoTasks = ExtractorTest(
+TestSingleTwoTasksKey = ExtractorTest(
     extractors.question_extractor,
     single_classification_two_tasks,
     single_expected_2,
     'Test multiple single questions passed in with task keyword',
-    kwargs={'task': 'T1'}
+    kwargs={'task': 'T1'},
+    test_name='TestSingleTwoTasksKey'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_rectangle_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_rectangle_extractor.py
@@ -66,7 +66,8 @@ TestRectangle = ExtractorTest(
     extractors.rectangle_extractor,
     classification,
     expected,
-    'Test rectangle'
+    'Test rectangle',
+    test_name='TestRectangle'
 )
 
 TestRectangleTask = ExtractorTest(
@@ -74,7 +75,8 @@ TestRectangleTask = ExtractorTest(
     classification,
     expected,
     'Test rectangle with task specified',
-    kwargs={'task': 'T2'}
+    kwargs={'task': 'T2'},
+    test_name='TestRectangleTask'
 )
 
 TestRectangleAllTools = ExtractorTest(
@@ -85,7 +87,8 @@ TestRectangleAllTools = ExtractorTest(
     kwargs={
         'task': 'T2',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestRectangleAllTools'
 )
 
 expected_0 = {
@@ -106,5 +109,6 @@ TestRectangleOneTool = ExtractorTest(
     kwargs={
         'task': 'T2',
         'tools': [0]
-    }
+    },
+    test_name='TestRectangleOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_circle.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_circle.py
@@ -64,7 +64,8 @@ TestShapeCircle = ExtractorTest(
     classification,
     expected,
     'Test shape circle',
-    kwargs={'shape': 'circle'}
+    kwargs={'shape': 'circle'},
+    test_name='TestShapeCircle'
 )
 
 TestShapeCircleTask = ExtractorTest(
@@ -75,7 +76,8 @@ TestShapeCircleTask = ExtractorTest(
     kwargs={
         'shape': 'circle',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeCircleTask'
 )
 
 TestShapeCircleAllTools = ExtractorTest(
@@ -87,7 +89,8 @@ TestShapeCircleAllTools = ExtractorTest(
         'shape': 'circle',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeCircleAllTools'
 )
 
 expected_0 = {
@@ -108,5 +111,6 @@ TestShapeCircleOneTool = ExtractorTest(
         'shape': 'circle',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeCircleOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_column.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_column.py
@@ -53,7 +53,8 @@ TestShapeColumn = ExtractorTest(
     classification,
     expected,
     'Test shape column',
-    kwargs={'shape': 'column'}
+    kwargs={'shape': 'column'},
+    test_name='TestShapeColumn'
 )
 
 TestShapeColumnTask = ExtractorTest(
@@ -64,7 +65,8 @@ TestShapeColumnTask = ExtractorTest(
     kwargs={
         'shape': 'column',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeColumnTask'
 )
 
 TestShapeColumnAllTools = ExtractorTest(
@@ -76,7 +78,8 @@ TestShapeColumnAllTools = ExtractorTest(
         'shape': 'column',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeColumnAllTools'
 )
 
 expected_0 = {
@@ -96,7 +99,8 @@ TestShapeColumnOneTool = ExtractorTest(
         'shape': 'column',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeColumnOneTool'
 )
 
 classification_blank = {
@@ -126,5 +130,6 @@ TestShapeColumnBlank = ExtractorTest(
         'shape': 'column',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeColumnBlank'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_ellipse.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_ellipse.py
@@ -74,7 +74,8 @@ TestShapeEllipse = ExtractorTest(
     classification,
     expected,
     'Test shape ellipse',
-    kwargs={'shape': 'ellipse'}
+    kwargs={'shape': 'ellipse'},
+    test_name='TestShapeEllipse'
 )
 
 TestShapeEllipseTask = ExtractorTest(
@@ -85,7 +86,8 @@ TestShapeEllipseTask = ExtractorTest(
     kwargs={
         'shape': 'ellipse',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeEllipseTask'
 )
 
 TestShapeEllipseAllTools = ExtractorTest(
@@ -97,7 +99,8 @@ TestShapeEllipseAllTools = ExtractorTest(
         'shape': 'ellipse',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeEllipseAllTools'
 )
 
 expected_0 = {
@@ -120,5 +123,6 @@ TestShapeEllipseOneTool = ExtractorTest(
         'shape': 'ellipse',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeEllipseOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_fan.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_fan.py
@@ -74,7 +74,8 @@ TestShapeFan = ExtractorTest(
     classification,
     expected,
     'Test shape fan',
-    kwargs={'shape': 'fan'}
+    kwargs={'shape': 'fan'},
+    test_name='TestShapeFan'
 )
 
 TestShapeFanTask = ExtractorTest(
@@ -85,7 +86,8 @@ TestShapeFanTask = ExtractorTest(
     kwargs={
         'shape': 'fan',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeFanTask'
 )
 
 TestShapeFanAllTools = ExtractorTest(
@@ -97,7 +99,8 @@ TestShapeFanAllTools = ExtractorTest(
         'shape': 'fan',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeFanAllTools'
 )
 
 expected_0 = {
@@ -120,5 +123,6 @@ TestShapeFanOneTool = ExtractorTest(
         'shape': 'fan',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeFanOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_full_height_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_full_height_line.py
@@ -46,7 +46,8 @@ TestShapeFullWidthLine = ExtractorTest(
     classification,
     expected,
     'Test shape fullWidthLine',
-    kwargs={'shape': 'fullWidthLine'}
+    kwargs={'shape': 'fullWidthLine'},
+    test_name='TestShapeFullWidthLine'
 )
 
 TestShapeFullWidthLineTask = ExtractorTest(
@@ -57,7 +58,8 @@ TestShapeFullWidthLineTask = ExtractorTest(
     kwargs={
         'shape': 'fullWidthLine',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeFullWidthLineTask'
 )
 
 TestShapeFullWidthLineAllTools = ExtractorTest(
@@ -69,7 +71,8 @@ TestShapeFullWidthLineAllTools = ExtractorTest(
         'shape': 'fullWidthLine',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeFullWidthLineAllTools'
 )
 
 expected_0 = {
@@ -88,5 +91,6 @@ TestShapeFullWidthLineOneTool = ExtractorTest(
         'shape': 'fullWidthLine',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeFullWidthLineOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_full_width_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_full_width_line.py
@@ -46,7 +46,8 @@ TestShapeFullHeightLine = ExtractorTest(
     classification,
     expected,
     'Test shape fullHeightLine',
-    kwargs={'shape': 'fullHeightLine'}
+    kwargs={'shape': 'fullHeightLine'},
+    test_name='TestShapeFullHeightLine'
 )
 
 TestShapeFullHeightLineTask = ExtractorTest(
@@ -57,7 +58,8 @@ TestShapeFullHeightLineTask = ExtractorTest(
     kwargs={
         'shape': 'fullHeightLine',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeFullHeightLineTask'
 )
 
 TestShapeFullHeightLineAllTools = ExtractorTest(
@@ -69,7 +71,8 @@ TestShapeFullHeightLineAllTools = ExtractorTest(
         'shape': 'fullHeightLine',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeFullHeightLineAllTools'
 )
 
 expected_0 = {
@@ -88,5 +91,6 @@ TestShapeFullHeightLineOneTool = ExtractorTest(
         'shape': 'fullHeightLine',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeFullHeightLineOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_line.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_line.py
@@ -67,7 +67,8 @@ TestShapeLine = ExtractorTest(
     classification,
     expected,
     'Test shape line',
-    kwargs={'shape': 'line'}
+    kwargs={'shape': 'line'},
+    test_name='TestShapeLine'
 )
 
 TestShapeLineTask = ExtractorTest(
@@ -78,7 +79,8 @@ TestShapeLineTask = ExtractorTest(
     kwargs={
         'shape': 'line',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeLineTask'
 )
 
 TestShapeLineAllTools = ExtractorTest(
@@ -90,7 +92,8 @@ TestShapeLineAllTools = ExtractorTest(
         'shape': 'line',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeLineAllTools'
 )
 
 expected_0 = {
@@ -112,5 +115,6 @@ TestShapeLineOneTool = ExtractorTest(
         'shape': 'line',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeLineOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_point.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_point.py
@@ -53,7 +53,8 @@ TestShapePoint = ExtractorTest(
     classification,
     expected,
     'Test shape point',
-    kwargs={'shape': 'point'}
+    kwargs={'shape': 'point'},
+    test_name='TestShapePoint'
 )
 
 TestShapePointTask = ExtractorTest(
@@ -64,7 +65,8 @@ TestShapePointTask = ExtractorTest(
     kwargs={
         'shape': 'point',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapePointTask'
 )
 
 TestShapePointAllTools = ExtractorTest(
@@ -76,7 +78,8 @@ TestShapePointAllTools = ExtractorTest(
         'shape': 'point',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapePointAllTools'
 )
 
 expected_0 = {
@@ -96,5 +99,6 @@ TestShapePointOneTool = ExtractorTest(
         'shape': 'point',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapePointOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_rectangle.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_rectangle.py
@@ -67,7 +67,8 @@ TestShapeRectangle = ExtractorTest(
     classification,
     expected,
     'Test shape rectangle',
-    kwargs={'shape': 'rectangle'}
+    kwargs={'shape': 'rectangle'},
+    test_name='TestShapeRectangle'
 )
 
 TestShapeRectangleTask = ExtractorTest(
@@ -78,7 +79,8 @@ TestShapeRectangleTask = ExtractorTest(
     kwargs={
         'shape': 'rectangle',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeRectangleTask'
 )
 
 TestShapeRectangleAllTools = ExtractorTest(
@@ -90,7 +92,8 @@ TestShapeRectangleAllTools = ExtractorTest(
         'shape': 'rectangle',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeRectangleAllTools'
 )
 
 expected_0 = {
@@ -112,5 +115,6 @@ TestShapeRectangleOneTool = ExtractorTest(
         'shape': 'rectangle',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeRectangleOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_rotate_rectangle.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_rotate_rectangle.py
@@ -74,7 +74,8 @@ TestShapeRotateRectangle = ExtractorTest(
     classification,
     expected,
     'Test shape rotateRectangle',
-    kwargs={'shape': 'rotateRectangle'}
+    kwargs={'shape': 'rotateRectangle'},
+    test_name='TestShapeRotateRectangle'
 )
 
 TestShapeRotateRectangleTask = ExtractorTest(
@@ -85,7 +86,8 @@ TestShapeRotateRectangleTask = ExtractorTest(
     kwargs={
         'shape': 'rotateRectangle',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeRotateRectangleTask'
 )
 
 TestShapeRotateRectangleAllTools = ExtractorTest(
@@ -97,7 +99,8 @@ TestShapeRotateRectangleAllTools = ExtractorTest(
         'shape': 'rotateRectangle',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeRotateRectangleAllTools'
 )
 
 expected_0 = {
@@ -120,5 +123,6 @@ TestShapeRotateRectangleOneTool = ExtractorTest(
         'shape': 'rotateRectangle',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeRotateRectangleOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_triangle.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_triangle.py
@@ -67,7 +67,8 @@ TestShapeTriangle = ExtractorTest(
     classification,
     expected,
     'Test shape triangle',
-    kwargs={'shape': 'triangle'}
+    kwargs={'shape': 'triangle'},
+    test_name='TestShapeTriangle'
 )
 
 TestShapeTriangleTask = ExtractorTest(
@@ -78,7 +79,8 @@ TestShapeTriangleTask = ExtractorTest(
     kwargs={
         'shape': 'triangle',
         'task': 'T0'
-    }
+    },
+    test_name='TestShapeTriangleTask'
 )
 
 TestShapeTriangleAllTools = ExtractorTest(
@@ -90,7 +92,8 @@ TestShapeTriangleAllTools = ExtractorTest(
         'shape': 'triangle',
         'task': 'T0',
         'tools': [0, 1]
-    }
+    },
+    test_name='TestShapeTriangleAllTools'
 )
 
 expected_0 = {
@@ -112,5 +115,6 @@ TestShapeTriangleOneTool = ExtractorTest(
         'shape': 'triangle',
         'task': 'T0',
         'tools': [0]
-    }
+    },
+    test_name='TestShapeTriangleOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_slider_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_slider_extractor.py
@@ -14,5 +14,6 @@ TestSlider = ExtractorTest(
     extractors.slider_extractor,
     classification,
     expected,
-    'Test slider'
+    'Test slider',
+    test_name='TestSlider'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor.py
@@ -123,7 +123,8 @@ TestSubtask = ExtractorTest(
                 None
             ]
         }
-    }
+    },
+    test_name='TestSubtask'
 )
 
 TestSubtaskTask = ExtractorTest(
@@ -141,7 +142,8 @@ TestSubtaskTask = ExtractorTest(
                 None
             ]
         }
-    }
+    },
+    test_name='TestSubtaskTask'
 )
 
 TestSubtaskAllTools = ExtractorTest(
@@ -159,7 +161,8 @@ TestSubtaskAllTools = ExtractorTest(
                 None
             ]
         }
-    }
+    },
+    test_name='TestSubtaskAllTools'
 )
 
 expected_0 = {
@@ -208,5 +211,6 @@ TestSubtaskOneTool = ExtractorTest(
                 None
             ]
         }
-    }
+    },
+    test_name='TestSubtaskOneTool'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_survey_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_survey_extractor.py
@@ -44,5 +44,6 @@ TestSurvey = ExtractorTest(
     expected,
     'Test survey',
     blank_extract=[],
-    test_type='assertCountEqual'
+    test_type='assertCountEqual',
+    test_name='TestSurvey'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_extractor.py
@@ -160,8 +160,9 @@ TestSW = TextExtractorTest(
     extractors.sw_extractor,
     classification,
     expected,
-    'Test SW/AT text extractor',
-    blank_extract=expected_blank
+    'Test SW AT text extractor',
+    blank_extract=expected_blank,
+    test_name='TestSW'
 )
 
 classification_wrong = {
@@ -177,6 +178,7 @@ TestSWWrong = ExtractorTest(
     extractors.sw_extractor,
     classification_wrong,
     expected_blank,
-    'Test SW/AT wrong input',
-    blank_extract=expected_blank
+    'Test SW AT wrong input',
+    blank_extract=expected_blank,
+    test_name='TestSWWrong'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_graphic_extractor.py
@@ -53,7 +53,8 @@ TestSWGraphic = ExtractorTest(
     extractors.sw_graphic_extractor,
     classification_sw,
     expected_sw,
-    'Test SW graphic'
+    'Test SW graphic',
+    test_name='TestSWGraphic'
 )
 
 classification_at = {
@@ -100,7 +101,8 @@ TestATGraphic = ExtractorTest(
     extractors.sw_graphic_extractor,
     classification_at,
     expected_at,
-    'Test AT graphic'
+    'Test AT graphic',
+    test_name='TestATGraphic'
 )
 
 
@@ -114,7 +116,8 @@ TestSWGraphicBlank = ExtractorTest(
     extractors.sw_graphic_extractor,
     classification_blank,
     expected_blank,
-    'Test SW/AT graphic blank input'
+    'Test SW AT graphic blank input',
+    test_name='TestSWGraphicBlank'
 )
 
 classification_wrong = {
@@ -130,5 +133,6 @@ TestSWGraphicWrong = ExtractorTest(
     extractors.sw_graphic_extractor,
     classification_wrong,
     expected_blank,
-    'Test SW/AT graphic wrong input'
+    'Test SW AT graphic wrong input',
+    test_name='TestSWGraphicWrong'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_sw_variant_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_sw_variant_extractor.py
@@ -91,7 +91,8 @@ TestSWVariant = ExtractorTest(
     extractors.sw_variant_extractor,
     classification,
     expected,
-    'Test SW variant'
+    'Test SW variant',
+    test_name='TestSWVariant'
 )
 
 classification_blank = {
@@ -104,5 +105,6 @@ TestSWVariantBlank = ExtractorTest(
     extractors.sw_variant_extractor,
     classification_blank,
     expected_blank,
-    'Test SW variant blank input'
+    'Test SW variant blank input',
+    test_name='TestSWVariantBlank'
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_text_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_text_extractor.py
@@ -16,5 +16,6 @@ TestTextExtractor = ExtractorTest(
     extractors.text_extractor,
     classification,
     expected,
-    'Test text extractor'
+    'Test text extractor',
+    test_name='TestTextExtractor'
 )

--- a/panoptes_aggregation/tests/reducer_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/reducer_tests/base_test_class.py
@@ -38,7 +38,8 @@ def ReducerTest(
     network_kwargs={},
     processed_type='dict',
     add_version=True,
-    output_kwargs=False
+    output_kwargs=False,
+    test_name=None
 ):
     # pkwargs: keywords passed into the process_data function
     # okwargs: keywords only passed into the _original function
@@ -97,10 +98,21 @@ def ReducerTest(
                 result = reducer(flask.request)
                 self.assertDictEqual(cast_to_dict(result), self.reduced_with_version)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    ReducerTest.__name__ = test_name
+    ReducerTest.__qualname__ = test_name
     return ReducerTest
 
 
-def ReducerTestNoProcessing(reducer, extracted, reduced, name, kwargs={}):
+def ReducerTestNoProcessing(
+    reducer,
+    extracted,
+    reduced,
+    name,
+    kwargs={},
+    test_name=None
+):
     class ReducerTestNoProcessing(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -135,10 +147,22 @@ def ReducerTestNoProcessing(reducer, extracted, reduced, name, kwargs={}):
                 result = reducer(flask.request)
                 self.assertDictEqual(result, self.reduced_with_version)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    ReducerTestNoProcessing.__name__ = test_name
+    ReducerTestNoProcessing.__qualname__ = test_name
     return ReducerTestNoProcessing
 
 
-def ReducerTestSurvey(reducer, processer, extracted, processed, reduced, name):
+def ReducerTestSurvey(
+    reducer,
+    processer,
+    extracted,
+    processed,
+    reduced,
+    name,
+    test_name=None
+):
     class ReducerTest(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -181,10 +205,24 @@ def ReducerTestSurvey(reducer, processer, extracted, processed, reduced, name):
                 result = reducer(flask.request)
                 self.assertCountEqual(result, self.reduced_with_version)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    ReducerTest.__name__ = test_name
+    ReducerTest.__qualname__ = test_name
     return ReducerTest
 
 
-def ReducerTestPoints(reducer, processer, extracted, processed, reduced, name, kwargs={}, atol=2):
+def ReducerTestPoints(
+    reducer,
+    processer,
+    extracted,
+    processed,
+    reduced,
+    name,
+    kwargs={},
+    atol=2,
+    test_name=None
+):
     class ReducerTest(unittest.TestCase):
         def setUp(self):
             self.maxDiff = None
@@ -257,4 +295,8 @@ def ReducerTestPoints(reducer, processer, extracted, processed, reduced, name, k
                 result = reducer(flask.request)
                 self.assertPoints(result, self.reduced_with_version)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    ReducerTest.__name__ = test_name
+    ReducerTest.__qualname__ = test_name
     return ReducerTest

--- a/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
@@ -59,5 +59,6 @@ TestDropdownReducer = ReducerTest(
     processed_data,
     reduced_data,
     'Test dropdown reducer',
-    processed_type='list'
+    processed_type='list',
+    test_name='TestDropdownReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -506,7 +506,8 @@ TestOpticsLTReducer = ReducerTest(
         'min_samples': 'auto'
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestOpticsLTReducer'
 )
 
 reduced_data2 = copy.deepcopy(reduced_data)
@@ -525,7 +526,8 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
         'low_consensus_threshold': 3.0
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestOpticsLTReducerWithMinSamples'
 )
 
 extracted_data_with_dollar_sign = [
@@ -694,7 +696,8 @@ TestOpticsLTReducerWithDollarSign = ReducerTest(
     },
     okwargs={'min_samples': 'auto'},
     network_kwargs=kwargs_extra_data_with_dollar_sign,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestOpticsLTReducerWithDollarSign'
 )
 
 # this is a real classification that happened on ASM
@@ -761,5 +764,6 @@ TestOpticsLTReducerNoLengthLine = ReducerTest(
         'low_consensus_threshold': 3.0
     },
     network_kwargs=kwargs_extra_data_no_length,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestOpticsLTReducerNoLengthLine'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer.py
@@ -56,7 +56,8 @@ TestPointsCluster = ReducerTestPoints(
         'eps': 5,
         'min_samples': 3
     },
-    atol=2
+    atol=2,
+    test_name='TestPointsCluster'
 )
 
 extracted_data_one_point = [
@@ -91,5 +92,6 @@ TestOnePointCluster = ReducerTestPoints(
         'eps': 5,
         'min_samples': 1
     },
-    atol=2
+    atol=2,
+    test_name='TestOnePointCluster'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer_dbscan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer_dbscan.py
@@ -64,7 +64,8 @@ TestPointsCluster = ReducerTestPoints(
         'eps': 5,
         'min_samples': 3
     },
-    atol=2
+    atol=2,
+    test_name='TestPointsCluster'
 )
 
 extracted_data_one_point = [
@@ -105,5 +106,6 @@ TestOnePointCluster = ReducerTestPoints(
         'eps': 5,
         'min_samples': 1
     },
-    atol=2
+    atol=2,
+    test_name='TestOnePointCluster'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer_hdbscan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer_hdbscan.py
@@ -91,5 +91,6 @@ TestPointsCluster = ReducerTestPoints(
         'min_cluster_size': 5,
         'min_samples': 3
     },
-    atol=2.5
+    atol=2.5,
+    test_name='TestPointsCluster'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -938,7 +938,8 @@ TestPLTReducer = ReducerTest(
         'low_consensus_threshold': 4.0
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestPLTReducer'
 )
 
 processed_data_by_line = {
@@ -1546,7 +1547,8 @@ TestPLTReducerByLine = ReducerTest(
         'low_consensus_threshold': 4.0
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestPLTReducerByLine'
 )
 
 reduced_data_min_word = {
@@ -1839,7 +1841,8 @@ TestPLTReducerWithMinWordCount = ReducerTest(
         'low_consensus_threshold': 4
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestPLTReducerWithMinWordCount'
 )
 
 # this is a real classification that happened on ASM
@@ -1921,5 +1924,6 @@ TestPolyLTReducerNoLengthLine = ReducerTest(
         'low_consensus_threshold': 4.0
     },
     network_kwargs=kwargs_extra_data_no_length,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestPolyLTReducerNoLengthLine'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_question_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_question_reducer.py
@@ -18,7 +18,8 @@ TestQuestionReducer = ReducerTestNoProcessing(
     question_reducer,
     extracted_data,
     reduced_data,
-    'Test question reducer'
+    'Test question reducer',
+    test_name='TestQuestionReducer'
 )
 
 reduced_data_pairs = {
@@ -32,5 +33,6 @@ TestQuestionReducerPairs = ReducerTestNoProcessing(
     extracted_data,
     reduced_data_pairs,
     'Test question reducer as pairs',
-    kwargs={'pairs': True}
+    kwargs={'pairs': True},
+    test_name='TestQuestionReducerPairs'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
@@ -131,7 +131,8 @@ TestRectReducer = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestRectReducer'
 )
 
 extracted_data_sw = [
@@ -209,5 +210,6 @@ TestSWRectReducer = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestSWRectReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_circle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_circle.py
@@ -122,7 +122,8 @@ TestShapeReducerCircle = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerCircle'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -146,5 +147,6 @@ TestShapeReducerCircleHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerCircleHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_column.py
@@ -108,7 +108,8 @@ TestShapeReducerColumn = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerColumn'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -132,5 +133,6 @@ TestShapeReducerColumnHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerColumnHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_ellipse.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_ellipse.py
@@ -150,7 +150,8 @@ TestShapeReducerEllipse = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerEllipse'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -174,5 +175,6 @@ TestShapeReducerEllipseHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerEllipseHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_fan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_fan.py
@@ -150,7 +150,8 @@ TestShapeReducerFan = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerFan'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -162,7 +163,7 @@ reduced_data_hdbscan['frame1']['T0_tool0_cluster_probabilities'] = [0.0]
 reduced_data_hdbscan['frame1']['T0_tool1_cluster_probabilities'] = [1.0, 1.0]
 reduced_data_hdbscan['frame1']['T0_tool1_clusters_persistance'] = [1.0]
 
-TestShapeReducerRotateRectangleHdbscan = ReducerTest(
+TestShapeReducerFanHdbscan = ReducerTest(
     shape_reducer_hdbscan,
     process_data_hdbscan,
     extracted_data,
@@ -174,5 +175,6 @@ TestShapeReducerRotateRectangleHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerFanHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_height_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_height_line.py
@@ -92,7 +92,8 @@ TestShapeReducerFullHeightLine = ReducerTestNoProcessing(
         'eps': 5,
         'min_samples': 2,
         'shape': 'fullHeightLine'
-    }
+    },
+    test_name='TestShapeReducerFullHeightLine'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -114,5 +115,6 @@ TestShapeReducerFullHeightLineHdbscan = ReducerTestNoProcessing(
         'min_samples': 1,
         'allow_single_cluster': True,
         'shape': 'fullHeightLine'
-    }
+    },
+    test_name='TestShapeReducerFullHeightLineHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_width_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_width_line.py
@@ -92,7 +92,8 @@ TestShapeReducerFullWidthLine = ReducerTestNoProcessing(
         'eps': 5,
         'min_samples': 2,
         'shape': 'fullWidthLine'
-    }
+    },
+    test_name='TestShapeReducerFullWidthLine'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -114,5 +115,6 @@ TestShapeReducerFullWidthLineHdbscan = ReducerTestNoProcessing(
         'min_samples': 1,
         'allow_single_cluster': True,
         'shape': 'fullWidthLine'
-    }
+    },
+    test_name='TestShapeReducerFullWidthLineHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_line.py
@@ -132,7 +132,8 @@ TestShapeReducerLine = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerLine'
 )
 
 processed_data_symmetric = {
@@ -219,7 +220,8 @@ TestShapeReducerLineSymmetric = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerLineSymmetric'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -250,7 +252,8 @@ TestShapeReducerLineHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerLineHdbscan'
 )
 
 reduced_data_hdbscan_symmetric = copy.deepcopy(reduced_data_symmetric)
@@ -277,5 +280,6 @@ TestShapeReducerLineHdbscanSymmetric = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerLineHdbscanSymmetric'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_point.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_point.py
@@ -108,7 +108,8 @@ TestShapeReducerPoint = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerPoint'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -132,5 +133,6 @@ TestShapeReducerPointHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerPointHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rectangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rectangle.py
@@ -136,7 +136,8 @@ TestShapeReducerRectangle = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerRectangle'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -160,5 +161,6 @@ TestShapeReducerRectangleHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerRectangleHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rotate_rectangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rotate_rectangle.py
@@ -150,7 +150,8 @@ TestShapeReducerRotateRectangle = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerRotateRectangle'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -174,5 +175,6 @@ TestShapeReducerRotateRectangleHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerRotateRectangleHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_triangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_triangle.py
@@ -125,7 +125,7 @@ reduced_data = {
     }
 }
 
-TestShapeReducerRotateRectangle = ReducerTest(
+TestShapeReducerTriangle = ReducerTest(
     shape_reducer_dbscan,
     process_data_dbscan,
     extracted_data,
@@ -136,7 +136,8 @@ TestShapeReducerRotateRectangle = ReducerTest(
     kwargs={
         'eps': 5,
         'min_samples': 2
-    }
+    },
+    test_name='TestShapeReducerTriangle'
 )
 
 reduced_data_hdbscan = copy.deepcopy(reduced_data)
@@ -160,5 +161,6 @@ TestShapeReducerTriangleHdbscan = ReducerTest(
         'min_cluster_size': 2,
         'min_samples': 1,
         'allow_single_cluster': True
-    }
+    },
+    test_name='TestShapeReducerTriangleHdbscan'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_slider_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_slider_reducer.py
@@ -28,5 +28,6 @@ TestSliderReducer = ReducerTest(
     processed_data,
     reduced_data,
     'Test slider reducer',
-    processed_type='list'
+    processed_type='list',
+    test_name='TestSliderReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer.py
@@ -185,5 +185,6 @@ TestSubtaskReducer = ReducerTestNoProcessing(
                 None
             ]
         }
-    }
+    },
+    test_name='TestSubtaskReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_survey_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_survey_reducer.py
@@ -95,5 +95,6 @@ TestSurvey = ReducerTestSurvey(
     extracted_data,
     processed_data,
     reduced_data,
-    'Test survey reducer'
+    'Test survey reducer',
+    test_name='TestSurvey'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -1211,7 +1211,8 @@ TestSWReducer = ReducerTest(
         'min_samples': 2
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestSWReducer'
 )
 
 extracted_data_all_blank = [
@@ -1304,5 +1305,6 @@ TestSWReducerAllBlank = ReducerTest(
         'min_samples': 2
     },
     network_kwargs=kwargs_extra_data_all_blank,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestSWReducerAllBlank'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
@@ -91,7 +91,7 @@ reduced_data = {
     }
 }
 
-TestSWReducer = ReducerTest(
+TestSWReducerMinSample = ReducerTest(
     poly_line_text_reducer,
     process_data,
     extracted_data,
@@ -111,5 +111,6 @@ TestSWReducer = ReducerTest(
         'min_samples': 1
     },
     network_kwargs=kwargs_extra_data,
-    output_kwargs=True
+    output_kwargs=True,
+    test_name='TestSWReducerMinSample'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_variant_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_variant_reducer.py
@@ -19,5 +19,6 @@ TestSWVariantsReducer = ReducerTestNoProcessing(
     reducers.sw_variant_reducer,
     extracted_data,
     reduced_data,
-    'Test SW variants reducer'
+    'Test SW variants reducer',
+    test_name='TestSWVariantsReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_gold_standard_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_gold_standard_reducer.py
@@ -67,7 +67,8 @@ TestTESSGoldStandardReducer = ReducerTest(
     reduced_data,
     'Test TESS gold standard reducer',
     add_version=False,
-    processed_type='list'
+    processed_type='list',
+    test_name='TestTESSGoldStandardReducer'
 )
 
 extracted_data_empty = []
@@ -84,5 +85,6 @@ TestTESSGoldStandardReducerEmpty = ReducerTest(
     reduced_data_empty,
     'Test TESS gold standard reducer with no extracts',
     add_version=False,
-    processed_type='list'
+    processed_type='list',
+    test_name='TestTESSGoldStandardReducerEmpty'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
@@ -133,7 +133,8 @@ TestTESSReducerColumnLeft = ReducerTest(
         'eps': 50,
         'min_samples': 2
     },
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSReducerColumnLeft'
 )
 
 reduced_data_center = copy.deepcopy(reduced_data)
@@ -155,7 +156,8 @@ TestTESSReducerColumnCenter = ReducerTest(
         'eps': 50,
         'min_samples': 2
     },
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSReducerColumnCenter'
 )
 
 extracted_data_no_cluster = [
@@ -213,5 +215,6 @@ TestTESSReducerNoCluster = ReducerTest(
         'eps': 50,
         'min_samples': 2
     },
-    network_kwargs=kwargs_extra_data_no_cluster
+    network_kwargs=kwargs_extra_data_no_cluster,
+    test_name='TestTESSReducerNoCluster'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_reducer.py
@@ -35,7 +35,8 @@ TestTextReducer = ReducerTest(
     processed_data,
     reduced_data,
     'Test text reducer',
-    processed_type='list'
+    processed_type='list',
+    test_name='TestTextReducer'
 )
 
 extracted_data_blank = [
@@ -47,12 +48,13 @@ extracted_data_blank = [
 processed_data_blank = []
 reduced_data_blank = {}
 
-TextBalnkTextReducer = ReducerTest(
+TextBlankTextReducer = ReducerTest(
     text_reducer,
     process_data,
     extracted_data_blank,
     processed_data_blank,
     reduced_data_blank,
-    'Test text reducer all extracts balnk',
-    processed_type='list'
+    'Test text reducer all extracts blank',
+    processed_type='list',
+    test_name='TextBlankTextReducer'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/base_test_class.py
@@ -18,7 +18,8 @@ def RunningReducerTestNoProcessing(
     reduced,
     name,
     kwargs={},
-    network_kwargs={}
+    network_kwargs={},
+    test_name=None
 ):
     class RunningReducerTestNoProcessing(unittest.TestCase):
         def setUp(self):
@@ -53,4 +54,8 @@ def RunningReducerTestNoProcessing(
                 result = reducer(flask.request)
                 self.assertDictEqual(result, self.reduced_with_version)
 
+    if test_name is None:
+        test_name = '_'.join(name.split())
+    RunningReducerTestNoProcessing.__name__ = test_name
+    RunningReducerTestNoProcessing.__qualname__ = test_name
     return RunningReducerTestNoProcessing

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
@@ -32,7 +32,7 @@ kwargs_extra_data = {
     ],
     'store': {
         'number_views': 3,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 2.4,
             'WHISTLE': 0.6
         }
@@ -41,14 +41,14 @@ kwargs_extra_data = {
 
 reduced_data = {
     'number_views': 4,
-    'catagory_weights': {
+    'category_weights': {
         'BLIP': 0.7875,
         'WHISTLE': 0.2125
     },
-    'max_catagory_weight': 0.7875,
+    'max_category_weight': 0.7875,
     '_store': {
         'number_views': 4,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 3.15,
             'WHISTLE': 0.85
         }
@@ -89,14 +89,14 @@ kwargs_extra_data_no_store = {
 
 reduced_data_no_store = {
     'number_views': 2,
-    'catagory_weights': {
+    'category_weights': {
         'BLIP': 0.425,
         'WHISTLE': 0.575
     },
-    'max_catagory_weight': 0.575,
+    'max_category_weight': 0.575,
     '_store': {
         'number_views': 2,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 0.85,
             'WHISTLE': 1.15
         }
@@ -120,14 +120,14 @@ kwargs_extra_data_no_rr = {
 
 reduced_data_no_rr = {
     'number_views': 1,
-    'catagory_weights': {
+    'category_weights': {
         'BLIP': 0.1,
         'WHISTLE': 0.9
     },
-    'max_catagory_weight': 0.9,
+    'max_category_weight': 0.9,
     '_store': {
         'number_views': 1,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
         }
@@ -160,7 +160,7 @@ kwargs_extra_data_no_column = {
     ],
     'store': {
         'number_views': 1,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
         }
@@ -169,14 +169,14 @@ kwargs_extra_data_no_column = {
 
 reduced_data_no_column = {
     'number_views': 1,
-    'catagory_weights': {
+    'category_weights': {
         'BLIP': 0.1,
         'WHISTLE': 0.9
     },
-    'max_catagory_weight': 0.9,
+    'max_category_weight': 0.9,
     '_store': {
         'number_views': 1,
-        'catagory_weights_sum': {
+        'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
         }

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
@@ -32,6 +32,7 @@ kwargs_extra_data = {
     ],
     'store': {
         'number_views': 3,
+        'none_of_the_above_count': 0,
         'category_weights_sum': {
             'BLIP': 2.4,
             'WHISTLE': 0.6
@@ -41,6 +42,7 @@ kwargs_extra_data = {
 
 reduced_data = {
     'number_views': 4,
+    'none_of_the_above_count': 0,
     'category_weights': {
         'BLIP': 0.7875,
         'WHISTLE': 0.2125
@@ -48,6 +50,7 @@ reduced_data = {
     'max_category_weight': 0.7875,
     '_store': {
         'number_views': 4,
+        'none_of_the_above_count': 0,
         'category_weights_sum': {
             'BLIP': 3.15,
             'WHISTLE': 0.85
@@ -89,12 +92,14 @@ kwargs_extra_data_no_store = {
 
 reduced_data_no_store = {
     'number_views': 2,
+    'none_of_the_above_count': 0,
     'category_weights': {
         'BLIP': 0.425,
         'WHISTLE': 0.575
     },
     'max_category_weight': 0.575,
     '_store': {
+        'none_of_the_above_count': 0,
         'number_views': 2,
         'category_weights_sum': {
             'BLIP': 0.85,
@@ -120,6 +125,7 @@ kwargs_extra_data_no_rr = {
 
 reduced_data_no_rr = {
     'number_views': 1,
+    'none_of_the_above_count': 0,
     'category_weights': {
         'BLIP': 0.1,
         'WHISTLE': 0.9
@@ -127,6 +133,7 @@ reduced_data_no_rr = {
     'max_category_weight': 0.9,
     '_store': {
         'number_views': 1,
+        'none_of_the_above_count': 0,
         'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
@@ -160,6 +167,7 @@ kwargs_extra_data_no_column = {
     ],
     'store': {
         'number_views': 1,
+        'none_of_the_above_count': 0,
         'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
@@ -169,6 +177,7 @@ kwargs_extra_data_no_column = {
 
 reduced_data_no_column = {
     'number_views': 1,
+    'none_of_the_above_count': 0,
     'category_weights': {
         'BLIP': 0.1,
         'WHISTLE': 0.9
@@ -176,6 +185,7 @@ reduced_data_no_column = {
     'max_category_weight': 0.9,
     '_store': {
         'number_views': 1,
+        'none_of_the_above_count': 0,
         'category_weights_sum': {
             'BLIP': 0.1,
             'WHISTLE': 0.9
@@ -189,4 +199,39 @@ TestGravitySpySubjectReducerNoColumn = RunningReducerTestNoProcessing(
     reduced_data_no_column,
     'Test Gravity Spy Subject reducer no confusion matrix',
     network_kwargs=kwargs_extra_data_no_column
+)
+
+extracted_data_none_key = [{
+    'user_label': 'NONE',
+    'ml_weights': {
+        'BLIP': 0.1,
+        'WHISTLE': 0.9
+    }
+}]
+
+reduced_data_none_key = {
+    'number_views': 1,
+    'none_of_the_above_count': 1,
+    'category_weights': {
+        'BLIP': 0.1,
+        'WHISTLE': 0.9
+    },
+    'max_category_weight': 0.9,
+    '_store': {
+        'number_views': 1,
+        'none_of_the_above_count': 1,
+        'category_weights_sum': {
+            'BLIP': 0.1,
+            'WHISTLE': 0.9
+        }
+    }
+}
+
+TestGravitySpySubjectReducerNoneKey = RunningReducerTestNoProcessing(
+    gravity_spy_subject_reducer,
+    extracted_data_none_key,
+    reduced_data_none_key,
+    'Test Gravity Spy Subject reducer none of the above',
+    network_kwargs=kwargs_extra_data_no_rr,
+    kwargs={'none_key': 'NONE'}
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
@@ -1,0 +1,192 @@
+from panoptes_aggregation.running_reducers.gravity_spy_subject_reducer import gravity_spy_subject_reducer
+from .base_test_class import RunningReducerTestNoProcessing
+
+extracted_data = [{
+    'user_label': 'BLIP',
+    'ml_weights': {
+        'BLIP': 0.1,
+        'WHISTLE': 0.9
+    }
+}]
+
+kwargs_extra_data = {
+    'relevant_reduction': [
+        {'data': {
+            'alpha': {
+                'BLIP': 0.75,
+                'WHISTLE': 8 / 11
+            },
+            'alpha_min': 8 / 11,
+            'alpha_length': 2,
+            'normalized_confusion_matrix': {
+                'BLIP': {
+                    'BLIP': 0.75,
+                    'WHISTLE': 0.25
+                },
+                'WHISTLE': {
+                    'BLIP': 3 / 11,
+                    'WHISTLE': 8 / 11
+                }
+            }
+        }}
+    ],
+    'store': {
+        'number_views': 3,
+        'catagory_weights_sum': {
+            'BLIP': 2.4,
+            'WHISTLE': 0.6
+        }
+    }
+}
+
+reduced_data = {
+    'number_views': 4,
+    'catagory_weights': {
+        'BLIP': 0.7875,
+        'WHISTLE': 0.2125
+    },
+    'max_catagory_weight': 0.7875,
+    '_store': {
+        'number_views': 4,
+        'catagory_weights_sum': {
+            'BLIP': 3.15,
+            'WHISTLE': 0.85
+        }
+    }
+}
+
+TestGravitySpySubjectReducer = RunningReducerTestNoProcessing(
+    gravity_spy_subject_reducer,
+    extracted_data,
+    reduced_data,
+    'Test Gravity Spy Subject reducer',
+    network_kwargs=kwargs_extra_data
+)
+
+kwargs_extra_data_no_store = {
+    'relevant_reduction': [
+        {'data': {
+            'alpha': {
+                'BLIP': 0.75,
+                'WHISTLE': 8 / 11
+            },
+            'alpha_min': 8 / 11,
+            'alpha_length': 2,
+            'normalized_confusion_matrix': {
+                'BLIP': {
+                    'BLIP': 0.75,
+                    'WHISTLE': 0.25
+                },
+                'WHISTLE': {
+                    'BLIP': 3 / 11,
+                    'WHISTLE': 8 / 11
+                }
+            }
+        }}
+    ],
+    'store': {}
+}
+
+reduced_data_no_store = {
+    'number_views': 2,
+    'catagory_weights': {
+        'BLIP': 0.425,
+        'WHISTLE': 0.575
+    },
+    'max_catagory_weight': 0.575,
+    '_store': {
+        'number_views': 2,
+        'catagory_weights_sum': {
+            'BLIP': 0.85,
+            'WHISTLE': 1.15
+        }
+    }
+}
+
+TestGravitySpySubjectReducerNoStore = RunningReducerTestNoProcessing(
+    gravity_spy_subject_reducer,
+    extracted_data,
+    reduced_data_no_store,
+    'Test Gravity Spy Subject reducer no store',
+    network_kwargs=kwargs_extra_data_no_store
+)
+
+kwargs_extra_data_no_rr = {
+    'relevant_reduction': [
+        None
+    ],
+    'store': {}
+}
+
+reduced_data_no_rr = {
+    'number_views': 1,
+    'catagory_weights': {
+        'BLIP': 0.1,
+        'WHISTLE': 0.9
+    },
+    'max_catagory_weight': 0.9,
+    '_store': {
+        'number_views': 1,
+        'catagory_weights_sum': {
+            'BLIP': 0.1,
+            'WHISTLE': 0.9
+        }
+    }
+}
+
+TestGravitySpySubjectReducerNoRR = RunningReducerTestNoProcessing(
+    gravity_spy_subject_reducer,
+    extracted_data,
+    reduced_data_no_rr,
+    'Test Gravity Spy Subject reducer no confusion matrix',
+    network_kwargs=kwargs_extra_data_no_rr
+)
+
+kwargs_extra_data_no_column = {
+    'relevant_reduction': [
+        {'data': {
+            'alpha': {
+                'WHISTLE': 8 / 11
+            },
+            'alpha_min': 8 / 11,
+            'alpha_length': 1,
+            'normalized_confusion_matrix': {
+                'WHISTLE': {
+                    'BLIP': 3 / 11,
+                    'WHISTLE': 8 / 11
+                }
+            }
+        }}
+    ],
+    'store': {
+        'number_views': 1,
+        'catagory_weights_sum': {
+            'BLIP': 0.1,
+            'WHISTLE': 0.9
+        }
+    }
+}
+
+reduced_data_no_column = {
+    'number_views': 1,
+    'catagory_weights': {
+        'BLIP': 0.1,
+        'WHISTLE': 0.9
+    },
+    'max_catagory_weight': 0.9,
+    '_store': {
+        'number_views': 1,
+        'catagory_weights_sum': {
+            'BLIP': 0.1,
+            'WHISTLE': 0.9
+        }
+    }
+}
+
+TestGravitySpySubjectReducerNoColumn = RunningReducerTestNoProcessing(
+    gravity_spy_subject_reducer,
+    extracted_data,
+    reduced_data_no_column,
+    'Test Gravity Spy Subject reducer no confusion matrix',
+    network_kwargs=kwargs_extra_data_no_column
+)

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_subject_reducer.py
@@ -63,7 +63,8 @@ TestGravitySpySubjectReducer = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test Gravity Spy Subject reducer',
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestGravitySpySubjectReducer'
 )
 
 kwargs_extra_data_no_store = {
@@ -113,7 +114,8 @@ TestGravitySpySubjectReducerNoStore = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_store,
     'Test Gravity Spy Subject reducer no store',
-    network_kwargs=kwargs_extra_data_no_store
+    network_kwargs=kwargs_extra_data_no_store,
+    test_name='TestGravitySpySubjectReducerNoStore'
 )
 
 kwargs_extra_data_no_rr = {
@@ -146,7 +148,8 @@ TestGravitySpySubjectReducerNoRR = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_rr,
     'Test Gravity Spy Subject reducer no confusion matrix',
-    network_kwargs=kwargs_extra_data_no_rr
+    network_kwargs=kwargs_extra_data_no_rr,
+    test_name='TestGravitySpySubjectReducerNoRR'
 )
 
 kwargs_extra_data_no_column = {
@@ -197,8 +200,9 @@ TestGravitySpySubjectReducerNoColumn = RunningReducerTestNoProcessing(
     gravity_spy_subject_reducer,
     extracted_data,
     reduced_data_no_column,
-    'Test Gravity Spy Subject reducer no confusion matrix',
-    network_kwargs=kwargs_extra_data_no_column
+    'Test Gravity Spy Subject reducer no confusion matrix column',
+    network_kwargs=kwargs_extra_data_no_column,
+    test_name='TestGravitySpySubjectReducerNoColumn'
 )
 
 extracted_data_none_key = [{
@@ -233,5 +237,6 @@ TestGravitySpySubjectReducerNoneKey = RunningReducerTestNoProcessing(
     reduced_data_none_key,
     'Test Gravity Spy Subject reducer none of the above',
     network_kwargs=kwargs_extra_data_no_rr,
-    kwargs={'none_key': 'NONE'}
+    kwargs={'none_key': 'NONE'},
+    test_name='TestGravitySpySubjectReducerNoneKey'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -34,6 +34,7 @@ reduced_data = {
     'level_up': True,
     'max_workflow_id': 2,
     'max_level': 'level_2',
+    'most_useful_category': None,
     'normalized_confusion_matrix': {
         'BLIP': {
             'BLIP': 6 / 8,
@@ -100,6 +101,7 @@ reduced_data_no_store = {
     'level_up': False,
     'max_workflow_id': 1,
     'max_level': 'level_1',
+    'most_useful_category': 'WHISTLE',
     'normalized_confusion_matrix': {
         'BLIP': {
             'BLIP': 1.0

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -27,10 +27,10 @@ kwargs_extra_data = {
 
 reduced_data = {
     'alpha': {
-        'BLIP': 6/8,
-        'WHISTLE': 8/11
+        'BLIP': 6 / 8,
+        'WHISTLE': 8 / 11
     },
-    'alpha_min': 8/11,
+    'alpha_min': 8 / 11,
     'alpha_length': 2,
     '_store': {
         'confusion_matrix': {

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -32,6 +32,16 @@ reduced_data = {
     },
     'alpha_min': 8 / 11,
     'alpha_length': 2,
+    'normalized_confusion_matrix': {
+        'BLIP': {
+            'BLIP': 6 / 8,
+            'WHISTLE': 2 / 8
+        },
+        'WHISTLE': {
+            'BLIP': 3 / 11,
+            'WHISTLE': 8 / 11
+        }
+    },
     '_store': {
         'confusion_matrix': {
             'BLIP': {
@@ -68,6 +78,11 @@ reduced_data_no_store = {
     },
     'alpha_min': 1.0,
     'alpha_length': 1,
+    'normalized_confusion_matrix': {
+        'BLIP': {
+            'BLIP': 1
+        }
+    },
     '_store': {
         'confusion_matrix': {
             'BLIP': {

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -1,0 +1,90 @@
+from panoptes_aggregation.running_reducers.gravity_spy_user_reducer import gravity_spy_user_reducer
+from .base_test_class import RunningReducerTestNoProcessing
+
+extracted_data = [{
+    'user_label': 'BLIP',
+    'gold_label': 'BLIP'
+}]
+
+kwargs_extra_data = {
+    'store': {
+        'confusion_matrix': {
+            'BLIP': {
+                'BLIP': 5,
+                'WHISTLE': 2
+            },
+            'WHISTLE': {
+                'BLIP': 3,
+                'WHISTLE': 8
+            }
+        },
+        'column_normalization': {
+            'BLIP': 7,
+            'WHISTLE': 11
+        }
+    }
+}
+
+reduced_data = {
+    'alpha': {
+        'BLIP': 6/8,
+        'WHISTLE': 8/11
+    },
+    'alpha_min': 8/11,
+    'alpha_length': 2,
+    '_store': {
+        'confusion_matrix': {
+            'BLIP': {
+                'BLIP': 6,
+                'WHISTLE': 2
+            },
+            'WHISTLE': {
+                'BLIP': 3,
+                'WHISTLE': 8
+            }
+        },
+        'column_normalization': {
+            'BLIP': 8,
+            'WHISTLE': 11
+        }
+    }
+}
+
+TestGravitySpyUserReducer = RunningReducerTestNoProcessing(
+    gravity_spy_user_reducer,
+    extracted_data,
+    reduced_data,
+    'Test Gravity Spy User reducer',
+    network_kwargs=kwargs_extra_data
+)
+
+kwargs_extra_data_no_store = {
+    'store': {}
+}
+
+reduced_data_no_store = {
+    'alpha': {
+        'BLIP': 1
+    },
+    'alpha_min': 1.0,
+    'alpha_length': 1,
+    '_store': {
+        'confusion_matrix': {
+            'BLIP': {
+                'BLIP': 1
+            }
+        },
+        'column_normalization': {
+            'BLIP': 1
+        }
+    }
+}
+
+
+TestGravitySpyUserReducerNoStore = RunningReducerTestNoProcessing(
+    gravity_spy_user_reducer,
+    extracted_data,
+    reduced_data_no_store,
+    'Test Gravity Spy User reducer with no store',
+    network_kwargs=kwargs_extra_data_no_store
+)

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -22,7 +22,7 @@ kwargs_extra_data = {
             'BLIP': 7,
             'WHISTLE': 11
         },
-        'level': 1
+        'max_level': 'level_1'
     }
 }
 
@@ -33,6 +33,7 @@ reduced_data = {
     },
     'level_up': True,
     'max_workflow_id': 2,
+    'max_level': 'level_2',
     'normalized_confusion_matrix': {
         'BLIP': {
             'BLIP': 6 / 8,
@@ -58,7 +59,7 @@ reduced_data = {
             'BLIP': 8,
             'WHISTLE': 11
         },
-        'level': 2
+        'max_level': 'level_2'
     }
 }
 
@@ -68,16 +69,18 @@ TestGravitySpyUserReducer = RunningReducerTestNoProcessing(
     reduced_data,
     'Test Gravity Spy User reducer',
     kwargs={
+        'first_level': 'level_1',
         'level_config': {
-            1: {
+            'level_1': {
                 'workflow_id': 1,
                 'new_categories': [
                     'BLIP',
                     'WHISTLE'
                 ],
-                'threshold': 0.7
+                'threshold': 0.7,
+                'next_level': 'level_2'
             },
-            2: {
+            'level_2': {
                 'workflow_id': 2
             }
         }
@@ -96,6 +99,7 @@ reduced_data_no_store = {
     },
     'level_up': False,
     'max_workflow_id': 1,
+    'max_level': 'level_1',
     'normalized_confusion_matrix': {
         'BLIP': {
             'BLIP': 1.0
@@ -110,7 +114,7 @@ reduced_data_no_store = {
         'column_normalization': {
             'BLIP': 1
         },
-        'level': 1
+        'max_level': 'level_1'
     }
 }
 
@@ -122,15 +126,16 @@ TestGravitySpyUserReducerNoStore = RunningReducerTestNoProcessing(
     'Test Gravity Spy User reducer with no store',
     kwargs={
         'level_config': {
-            1: {
+            'level_1': {
                 'workflow_id': 1,
                 'new_categories': [
                     'BLIP',
                     'WHISTLE'
                 ],
-                'threshold': 0.7
+                'threshold': 0.7,
+                'next_level': 'level_2'
             },
-            2: {
+            'level_2': {
                 'workflow_id': 2
             }
         }

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -21,7 +21,8 @@ kwargs_extra_data = {
         'column_normalization': {
             'BLIP': 7,
             'WHISTLE': 11
-        }
+        },
+        'level': 1
     }
 }
 
@@ -30,8 +31,8 @@ reduced_data = {
         'BLIP': 6 / 8,
         'WHISTLE': 8 / 11
     },
-    'alpha_min': 8 / 11,
-    'alpha_length': 2,
+    'level_up': True,
+    'max_workflow_id': 2,
     'normalized_confusion_matrix': {
         'BLIP': {
             'BLIP': 6 / 8,
@@ -56,7 +57,8 @@ reduced_data = {
         'column_normalization': {
             'BLIP': 8,
             'WHISTLE': 11
-        }
+        },
+        'level': 2
     }
 }
 
@@ -65,6 +67,21 @@ TestGravitySpyUserReducer = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test Gravity Spy User reducer',
+    kwargs={
+        'level_config': {
+            1: {
+                'workflow_id': 1,
+                'new_categories': [
+                    'BLIP',
+                    'WHISTLE'
+                ],
+                'threshold': 0.7
+            },
+            2: {
+                'workflow_id': 2
+            }
+        }
+    },
     network_kwargs=kwargs_extra_data,
     test_name='TestGravitySpyUserReducer'
 )
@@ -75,13 +92,13 @@ kwargs_extra_data_no_store = {
 
 reduced_data_no_store = {
     'alpha': {
-        'BLIP': 1
+        'BLIP': 1.0
     },
-    'alpha_min': 1.0,
-    'alpha_length': 1,
+    'level_up': False,
+    'max_workflow_id': 1,
     'normalized_confusion_matrix': {
         'BLIP': {
-            'BLIP': 1
+            'BLIP': 1.0
         }
     },
     '_store': {
@@ -92,7 +109,8 @@ reduced_data_no_store = {
         },
         'column_normalization': {
             'BLIP': 1
-        }
+        },
+        'level': 1
     }
 }
 
@@ -102,6 +120,21 @@ TestGravitySpyUserReducerNoStore = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_store,
     'Test Gravity Spy User reducer with no store',
+    kwargs={
+        'level_config': {
+            1: {
+                'workflow_id': 1,
+                'new_categories': [
+                    'BLIP',
+                    'WHISTLE'
+                ],
+                'threshold': 0.7
+            },
+            2: {
+                'workflow_id': 2
+            }
+        }
+    },
     network_kwargs=kwargs_extra_data_no_store,
     test_name='TestGravitySpyUserReducerNoStore'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_gravity_spy_user_reducer.py
@@ -65,7 +65,8 @@ TestGravitySpyUserReducer = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test Gravity Spy User reducer',
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestGravitySpyUserReducer'
 )
 
 kwargs_extra_data_no_store = {
@@ -101,5 +102,6 @@ TestGravitySpyUserReducerNoStore = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_store,
     'Test Gravity Spy User reducer with no store',
-    network_kwargs=kwargs_extra_data_no_store
+    network_kwargs=kwargs_extra_data_no_store,
+    test_name='TestGravitySpyUserReducerNoStore'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_tess_gold_standard_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_tess_gold_standard_reducer.py
@@ -37,7 +37,8 @@ TestTESSGoldStandardRunningReducer = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test TESS gold standard reducer in running mode',
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSGoldStandardRunningReducer'
 )
 
 kwargs_extra_data_no_store = {
@@ -57,7 +58,8 @@ TestTESSGoldStandardRunningReducerNoStore = RunningReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_store,
     'Test TESS gold standard reducer in running mode with no store',
-    network_kwargs=kwargs_extra_data_no_store
+    network_kwargs=kwargs_extra_data_no_store,
+    test_name='TestTESSGoldStandardRunningReducerNoStore'
 )
 
 extracted_data_empty = []
@@ -75,7 +77,8 @@ TestTESSGoldStandardRunningReducerEmptyExtract = RunningReducerTestNoProcessing(
     extracted_data_empty,
     reduced_data_empty,
     'Test TESS gold standard reducer in running mode with empty extract',
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSGoldStandardRunningReducerEmptyExtract'
 )
 
 reduced_data_empty_no_store = {
@@ -87,5 +90,6 @@ TestTESSGoldStandardRunningReducerEmptyExtractNoStore = RunningReducerTestNoProc
     extracted_data_empty,
     reduced_data_empty_no_store,
     'Test TESS gold standard reducer in running mode with empty extract and no store',
-    network_kwargs=kwargs_extra_data_no_store
+    network_kwargs=kwargs_extra_data_no_store,
+    test_name='TestTESSGoldStandardRunningReducerEmptyExtractNoStore'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_tess_reducer_column.py
@@ -124,7 +124,8 @@ TestTESSReducerColumnLeft = RunningReducerTestNoProcessing(
         'eps': 50,
         'min_samples': 2
     },
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSReducerColumnLeft'
 )
 
 kwargs_extra_data_no_store = {
@@ -165,5 +166,6 @@ TestTESSReducerColumnNoStore = RunningReducerTestNoProcessing(
         'eps': 50,
         'min_samples': 2
     },
-    network_kwargs=kwargs_extra_data_no_store
+    network_kwargs=kwargs_extra_data_no_store,
+    test_name='TestTESSReducerColumnNoStore'
 )

--- a/panoptes_aggregation/tests/running_reducer_tests/test_tess_user_reducer.py
+++ b/panoptes_aggregation/tests/running_reducer_tests/test_tess_user_reducer.py
@@ -38,12 +38,13 @@ reduced_data = {
     }
 }
 
-TestTESSUserReduer = RunningReducerTestNoProcessing(
+TestTESSUserReducer = RunningReducerTestNoProcessing(
     tess_user_reducer,
     extracted_data,
     reduced_data,
     'Test TESS User reducer',
-    network_kwargs=kwargs_extra_data
+    network_kwargs=kwargs_extra_data,
+    test_name='TestTESSUserReducer'
 )
 
 kwargs_extra_data_no_rr = {
@@ -61,12 +62,13 @@ reduced_data_no_rr = {
     }
 }
 
-TestTESSUserReduerNoRR = RunningReducerTestNoProcessing(
+TestTESSUserReducerNoRR = RunningReducerTestNoProcessing(
     tess_user_reducer,
     extracted_data,
     reduced_data_no_rr,
     'Test TESS User reducer with no relevant reduction',
-    network_kwargs=kwargs_extra_data_no_rr
+    network_kwargs=kwargs_extra_data_no_rr,
+    test_name='TestTESSUserReducerNoRR'
 )
 
 kwargs_extra_data_no_gs_extract = {
@@ -78,10 +80,11 @@ kwargs_extra_data_no_gs_extract = {
     'store': {}
 }
 
-TestTESSUserReduerNoGSExtract = RunningReducerTestNoProcessing(
+TestTESSUserReducerNoGSExtract = RunningReducerTestNoProcessing(
     tess_user_reducer,
     extracted_data,
     reduced_data_no_rr,
     'Test TESS User reducer with no GS extract',
-    network_kwargs=kwargs_extra_data_no_gs_extract
+    network_kwargs=kwargs_extra_data_no_gs_extract,
+    test_name='TestTESSUserReducerNoGSExtract'
 )

--- a/panoptes_aggregation/tests/scripts_tests/test_extract_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_extract_csv.py
@@ -5,6 +5,12 @@ import os
 import pandas
 from pandas.testing import assert_frame_equal
 import panoptes_aggregation.scripts.extract_panoptes_csv as extract_panoptes_csv
+import platform
+
+if platform.system() == 'Windows':
+    WINDOWS = True
+else:
+    WINDOWS = False
 
 classification_data_dump_two_tasks = '''classification_id,user_name,user_id,workflow_id,workflow_version,created_at,annotations,subject_ids
 1,1,1,4249,14.18,2017-05-31 12:33:46 UTC,"[{""task"":""T0""},{""task"":""T1""}]",1
@@ -167,6 +173,7 @@ class TestExtractCSV(unittest.TestCase):
         assert_frame_equal(result_dataframe, self.extracts_dataframe_question, check_like=True)
         mock_to_csv.assert_called_once_with(output_path, index=False, encoding='utf-8')
 
+    @unittest.skipIf(WINDOWS, 'Installed on windows, skipping multi core test')
     @patch('panoptes_aggregation.scripts.extract_panoptes_csv.progressbar.ProgressBar')
     @patch('panoptes_aggregation.scripts.extract_panoptes_csv.pandas.DataFrame.to_csv')
     @patch.dict('panoptes_aggregation.scripts.extract_panoptes_csv.extractors.extractors', mock_extractors_dict)


### PR DESCRIPTION
This PR adds the components that will be needed to move Gravity Spy over to Caesar.

Some notes about the way this will be set up in Caesar (this section will update as more code is written):

# Extractor setup
## Gold standard subject
User Caesar's `PluckFieldExtractor` with
```json
{
    "field_map" : {
        "user_label": "$.annotations[0].value[0].choice",
        "gold_label": "$.subject.metadata.#Label"
    }
}
```

`"$.subject.metadata.#Label"` is the gold standard label stored on the subject's metadata.

## Research subject
User Caesar's `PluckFieldExtractor` with (metadata field name subject to change)
```json
{
    "field_map" : {
        "user_label": "$.annotations[0].value[0].choice",
        "ml_weights": "$.subject.metadata.#ML_weights"
    }
}
```

`"$.subject.metadata.#ML_weights"` is a dictionary with keys equal to category names and values equal to the machine learning code's probability that the subject belongs to the category (all subject metadata will be updated with this dictionary).  This is equivalent to taking the column of a volunteer's normalized confusion matrix.  In the reduction the ML weights will be treated the same as a volunteer.

# Reducer setup
## Gold standard subject
Use `running_reducer/gravity_spy_user_reducer.py`

## Research subject
User `running_reducer/gravity_spy_subject_reducer.py`