### PR TITLE
Optics fix

### DIFF
--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -17,7 +17,7 @@ import warnings
 
 DEFAULTS = {
     'min_samples': {'default': 'auto', 'type': int},
-    'max_eps': {'default': np.inf, 'type': float},
+    'max_eps': {'default': None, 'type': float},
     'xi': {'default': 0.05, 'type': float},
     'angle_eps': {'default': 30, 'type': float},
     'gutter_eps': {'default': 150, 'type': float},
@@ -136,6 +136,9 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
     min_samples_orig = kwargs_optics.pop('min_samples')
     angle_eps = kwargs_optics.pop('angle_eps')
     gutter_eps = kwargs_optics.pop('gutter_eps')
+    max_eps = kwargs_optics.pop('max_eps', np.inf)
+    if max_eps is None:
+        max_eps = np.inf
     low_consensus_lines = 0
     number_of_lines = 0
     for frame, value in data_by_frame.items():

--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -128,7 +128,7 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
         * `low_consensus_lines` : The number of lines with low consensus
         * `transcribed_lines` : The total number of lines transcribed on the subject
 
-        Note: the image coordiate system has y increasing downward.
+        Note: the image coordinate system has y increasing downward.
     '''
     user_ids_input = np.array(kwargs_optics.pop('user_id'))
     low_consensus_threshold = kwargs_optics.pop('low_consensus_threshold')

--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -3,7 +3,7 @@ Line Tool with Text Subtask Reducer using OPTICS
 ------------------------------------------------
 This module provides functions to reduce the polygon-text extractions from
 :mod:`panoptes_aggregation.extractors.poly_line_text_extractor` using the
-density indipended clustering algorithm OPTICS.  It is assumed that all
+density independent clustering algorithm OPTICS.  It is assumed that all
 extracts are full lines of text in the document.
 '''
 from sklearn.cluster import OPTICS
@@ -33,7 +33,7 @@ col.core_classes.WordPunctuationTokenizer.tokenize = tokenize
 
 
 def process_data(data_list, min_line_length=0.0):
-    '''Process a list of extractions into a dictinary organized by `frame`
+    '''Process a list of extractions into a dictionary organized by `frame`
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def process_data(data_list, min_line_length=0.0):
     processed_data : dict
         A dictionary with one key for each frame of the subject. The value for each key
         is a dictionary with two keys `X` and `data`. `X` is a 2D array with each row
-        mapping to the data held in `data`.  The first column contains row indicies
+        mapping to the data held in `data`.  The first column contains row indices
         and the second column is an index assigned to each user. `data` is a list of
         dictionaries of the form `{'x': [start_x, end_x], 'y': [start_y, end_y],
         'text': ['text for line'], 'gold_standard': bool}`.

--- a/panoptes_aggregation/reducers/optics_text_utils.py
+++ b/panoptes_aggregation/reducers/optics_text_utils.py
@@ -147,11 +147,6 @@ def remove_user_duplication(labels_, core_distances_, users):
     return clean_labels
 
 
-def remove_nans(input):
-    '''Remove numpy nan's from a list and replace them with `None`'''
-    return [i if np.isfinite(i) else None for i in input]
-
-
 def cluster_of_one(X, data, user_ids, extract_index):
     '''Create "clusters of one" out of the data passed in. Lines of text
     identified as noise are kept around as clusters of one so they can be
@@ -190,7 +185,7 @@ def cluster_of_one(X, data, user_ids, extract_index):
             'line_slope': slope,
             'consensus_score': 1.0,
             'consensus_text': ' '.join(line['text'][0].split()),
-            'user_ids': remove_nans([user_ids[user_index]]),
+            'user_ids': [user_ids[user_index]],
             'extract_index': [extract_index[rdx]],
             'gold_standard': [line['gold_standard']],
             'low_consensus': True

--- a/panoptes_aggregation/reducers/optics_text_utils.py
+++ b/panoptes_aggregation/reducers/optics_text_utils.py
@@ -36,7 +36,7 @@ def metric(a, b, data_in=[]):
     '''Calculate the distance between two drawn lines that have text
     associated with them.  This distance is found by summing the euclidean
     distance between the start points of each line, the euclidean distance
-    between the end poitns of each line, and the Levenshtein distance
+    between the end points of each line, and the Levenshtein distance
     of the text for each line.  The Levenshtein distance is done after
     stripping text tags and consolidating whitespace.
 
@@ -167,7 +167,7 @@ def cluster_of_one(X, data, user_ids, extract_index):
     Returns
     -------
     clusters: list
-        A list with n clusters each containing only one calssification
+        A list with n clusters each containing only one classification
     '''
     clusters = []
     for rdx, row in enumerate(X):

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -1,6 +1,5 @@
 from panoptes_aggregation.reducers.optics_line_text_reducer import process_data, optics_line_text_reducer
 from .base_test_class import ReducerTest
-import numpy as np
 import copy
 
 extracted_data = [

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -179,7 +179,7 @@ kwargs_extra_data = {
         1,
         2,
         3,
-        4,
+        None,
         5
     ]
 }
@@ -432,7 +432,7 @@ reduced_data = {
             'consensus_text': 'not in a cluster',
             'line_slope': 214.875,
             'number_views': 1,
-            'user_ids': [4],
+            'user_ids': [None],
             'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 2,
@@ -472,7 +472,7 @@ reduced_data = {
             'consensus_text': 'some words',
             'line_slope': 0.0,
             'number_views': 1,
-            'user_ids': [4],
+            'user_ids': [None],
             'extract_index': [0],
             'gold_standard': [False],
             'slope_label': 0,
@@ -482,7 +482,7 @@ reduced_data = {
     ],
     'parameters': {
         'min_samples': 'auto',
-        'max_eps': np.inf,
+        'max_eps': None,
         'xi': 0.05,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
@@ -672,7 +672,7 @@ reduced_data_with_dollar_sign = {
     }],
     'parameters': {
         'min_samples': 'auto',
-        'max_eps': np.inf,
+        'max_eps': None,
         'xi': 0.05,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
@@ -739,7 +739,7 @@ reduced_data_no_length = {
     'frame5': [],
     'parameters': {
         'min_samples': 'auto',
-        'max_eps': np.inf,
+        'max_eps': None,
         'xi': 0.05,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,

--- a/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_optics_text_utils.py
@@ -164,13 +164,6 @@ class TextOpticsTextUtils(unittest.TestCase):
         result = optics_text_utils.order_lines(frame)
         self.assertIsInstance(result, list)
 
-    def test_remove_nans(self):
-        '''Test remove nans'''
-        input = [np.nan, 1, 2, 3, np.nan]
-        expected = [None, 1, 2, 3, None]
-        result = optics_text_utils.remove_nans(input)
-        self.assertEqual(result, expected)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes two sentry errors:

https://sentry.io/organizations/zooniverse-27/issues/1508932644/?project=1760084&referrer=alert_email

The `isfinite` bug was caused by code that should have been removed, but still stuck around in the `cluster_of_one` sub-function.  Not logged in users are passed along as `None` (even when converted to a numpy array), not `np.nan`.

https://sentry.io/organizations/zooniverse-27/issues/1509795280/?environment=production&referrer=alert_email

The old default for `max_eps` as `np.inf` but this does not pass along in JSON very well, so instead the new default is `None` and the optics reducer converts this to `np.inf` when run.