### PR TITLE
Fix Future Warnings coming from pandas 1.0

### DIFF
--- a/panoptes_aggregation/csv_utils.py
+++ b/panoptes_aggregation/csv_utils.py
@@ -1,6 +1,6 @@
 import ast
 import pandas
-from pandas.io.json import json_normalize
+from pandas import json_normalize
 
 
 def flatten_data(data, json_column='data'):

--- a/panoptes_aggregation/tests/scripts_tests/test_extract_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_extract_csv.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock, call
 from io import StringIO
 import os
 import pandas
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import panoptes_aggregation.scripts.extract_panoptes_csv as extract_panoptes_csv
 
 classification_data_dump_two_tasks = '''classification_id,user_name,user_id,workflow_id,workflow_version,created_at,annotations,subject_ids

--- a/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
+++ b/panoptes_aggregation/tests/scripts_tests/test_reduce_csv.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock, call
 from io import StringIO
 import os
 import pandas
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import panoptes_aggregation.scripts.reduce_panoptes_csv as reduce_panoptes_csv
 
 extracted_csv_question = '''classification_id,user_name,user_id,workflow_id,task,created_at,subject_id,extractor,data.blue,data.green,data.no,data.yes

--- a/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
@@ -1,7 +1,8 @@
 import unittest
 from collections import OrderedDict
+import numpy as np
 import pandas
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import panoptes_aggregation.csv_utils as csv_utils
 
 nested_data = {
@@ -34,9 +35,9 @@ json_data = pandas.DataFrame({
         '{"x": 1, "y": 1}',
         '{"x": 2, "y": 2}',
         '{"x": 3, "y": 3}',
-        pandas.np.nan
+        np.nan
     ],
-    'data.text': ['how', 'are', 'you', pandas.np.nan]
+    'data.text': ['how', 'are', 'you', np.nan]
 })
 
 unjson_data = pandas.DataFrame({
@@ -45,9 +46,9 @@ unjson_data = pandas.DataFrame({
         {"x": 1, "y": 1},
         {"x": 2, "y": 2},
         {"x": 3, "y": 3},
-        pandas.np.nan
+        np.nan
     ],
-    'data.text': ['how', 'are', 'you', pandas.np.nan]
+    'data.text': ['how', 'are', 'you', np.nan]
 })
 
 unordered_data = pandas.DataFrame(OrderedDict((


### PR DESCRIPTION
Pandas 1.0 changed some of the testing API and moved `json_normalize`.  This PR cleans up all the `FutureWarning`s.