### PR TITLE
Add `minimum_views` as a prameter to text reducers

### DIFF
--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -21,7 +21,8 @@ DEFAULTS = {
     'xi': {'default': 0.05, 'type': float},
     'angle_eps': {'default': 30, 'type': float},
     'gutter_eps': {'default': 150, 'type': float},
-    'low_consensus_threshold': {'default': 3, 'type': float}
+    'low_consensus_threshold': {'default': 3, 'type': float},
+    'minimum_views': {'default': 5, 'type': int}
 }
 
 DEFAULTS_PROCESS = {
@@ -132,6 +133,7 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
     '''
     user_ids_input = np.array(kwargs_optics.pop('user_id'))
     low_consensus_threshold = kwargs_optics.pop('low_consensus_threshold')
+    _ = kwargs_optics.pop('minimum_views')
     output = defaultdict(list)
     min_samples_orig = kwargs_optics.pop('min_samples')
     angle_eps = kwargs_optics.pop('angle_eps')

--- a/panoptes_aggregation/reducers/poly_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/poly_line_text_reducer.py
@@ -15,7 +15,8 @@ DEFAULTS = {
     'min_word_count': {'default': 1, 'type': int},
     'dot_freq': {'default': 'line', 'type': str},
     'min_samples': {'default': 1, 'type': int},
-    'low_consensus_threshold': {'default': 3, 'type': float}
+    'low_consensus_threshold': {'default': 3, 'type': float},
+    'minimum_views': {'default': 5, 'type': int}
 }
 
 DEFAULTS_PROCESS = {
@@ -130,4 +131,5 @@ def poly_line_text_reducer(data_by_frame, **kwargs_dbscan):
     kwargs_cluster['gutter_tol'] = kwargs_dbscan.pop('gutter_tol')
     kwargs_cluster['dot_freq'] = kwargs_dbscan.pop('dot_freq')
     kwargs_cluster['min_word_count'] = kwargs_dbscan.pop('min_word_count')
+    _ = kwargs_dbscan.pop('minimum_views')
     return cluster_by_frame(data_by_frame, kwargs_cluster, kwargs_dbscan, user_ids_input, low_consensus_threshold)

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -486,7 +486,8 @@ reduced_data = {
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
-        'min_line_length': 0.0
+        'min_line_length': 0.0,
+        'minimum_views': 5
     }
 }
 
@@ -500,7 +501,8 @@ TestOpticsLTReducer = ReducerTest(
     kwargs={
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     okwargs={
         'min_samples': 'auto'
@@ -523,7 +525,8 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
         'min_samples': 2,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -678,7 +681,8 @@ reduced_data_with_dollar_sign = {
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
-        'min_line_length': 0.0
+        'min_line_length': 0.0,
+        'minimum_views': 5
     }
 }
 
@@ -692,7 +696,8 @@ TestOpticsLTReducerWithDollarSign = ReducerTest(
     kwargs={
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     okwargs={'min_samples': 'auto'},
     network_kwargs=kwargs_extra_data_with_dollar_sign,
@@ -746,7 +751,8 @@ reduced_data_no_length = {
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
-        'min_line_length': 0.0
+        'min_line_length': 0.0,
+        'minimum_views': 5
     }
 }
 
@@ -761,7 +767,8 @@ TestOpticsLTReducerNoLengthLine = ReducerTest(
         'min_samples': 'auto',
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data_no_length,
     output_kwargs=True,

--- a/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_poly_line_text_reducer.py
@@ -914,7 +914,8 @@ reduced_data = {
         'dot_freq': 'word',
         'min_word_count': 1,
         'low_consensus_threshold': 4.0,
-        'process_by_line': False
+        'process_by_line': False,
+        'minimum_views': 5
     }
 }
 
@@ -935,7 +936,8 @@ TestPLTReducer = ReducerTest(
         'min_samples': 1,
         'dot_freq': 'word',
         'min_word_count': 1,
-        'low_consensus_threshold': 4.0
+        'low_consensus_threshold': 4.0,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -1520,7 +1522,8 @@ reduced_data_by_line = {
         'dot_freq': 'line',
         'min_word_count': 1,
         'low_consensus_threshold': 4.0,
-        'process_by_line': True
+        'process_by_line': True,
+        'minimum_views': 5
     }
 }
 
@@ -1544,7 +1547,8 @@ TestPLTReducerByLine = ReducerTest(
         'min_samples': 1,
         'dot_freq': 'line',
         'min_word_count': 1,
-        'low_consensus_threshold': 4.0
+        'low_consensus_threshold': 4.0,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -1814,7 +1818,8 @@ reduced_data_min_word = {
         'dot_freq': 'line',
         'min_word_count': 4,
         'low_consensus_threshold': 4.0,
-        'process_by_line': True
+        'process_by_line': True,
+        'minimum_views': 5
     }
 }
 
@@ -1838,7 +1843,8 @@ TestPLTReducerWithMinWordCount = ReducerTest(
         'min_samples': 1,
         'dot_freq': 'line',
         'min_word_count': 4,
-        'low_consensus_threshold': 4
+        'low_consensus_threshold': 4,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -1897,7 +1903,8 @@ reduced_data_no_length = {
         'dot_freq': 'line',
         'min_word_count': 1,
         'low_consensus_threshold': 4.0,
-        'process_by_line': True
+        'process_by_line': True,
+        'minimum_views': 5
     }
 }
 
@@ -1921,7 +1928,8 @@ TestPolyLTReducerNoLengthLine = ReducerTest(
         'min_samples': 1,
         'dot_freq': 'line',
         'min_word_count': 1,
-        'low_consensus_threshold': 4.0
+        'low_consensus_threshold': 4.0,
+        'minimum_views': 5
     },
     network_kwargs=kwargs_extra_data_no_length,
     output_kwargs=True,

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer.py
@@ -1187,7 +1187,8 @@ reduced_data = {
         'dot_freq': 'line',
         'min_word_count': 1,
         'low_consensus_threshold': 3.0,
-        'process_by_line': False
+        'process_by_line': False,
+        'minimum_views': 5
     }
 }
 
@@ -1201,7 +1202,8 @@ TestSWReducer = ReducerTest(
     okwargs={
         'gutter_tol': 0.0,
         'min_word_count': 1,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     kwargs={
         'eps_slope': 0.5,
@@ -1281,7 +1283,8 @@ reduced_data_all_blank = {
         'dot_freq': 'line',
         'min_word_count': 1,
         'low_consensus_threshold': 3.0,
-        'process_by_line': False
+        'process_by_line': False,
+        'minimum_views': 5
     }
 }
 
@@ -1295,7 +1298,8 @@ TestSWReducerAllBlank = ReducerTest(
     okwargs={
         'gutter_tol': 0.0,
         'min_word_count': 1,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     kwargs={
         'eps_slope': 0.5,

--- a/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_sw_reducer_min_samples_1.py
@@ -87,7 +87,8 @@ reduced_data = {
         'dot_freq': 'line',
         'min_word_count': 1,
         'low_consensus_threshold': 3.0,
-        'process_by_line': False
+        'process_by_line': False,
+        'minimum_views': 5
     }
 }
 
@@ -101,7 +102,8 @@ TestSWReducerMinSample = ReducerTest(
     okwargs={
         'gutter_tol': 0.0,
         'min_word_count': 1,
-        'low_consensus_threshold': 3.0
+        'low_consensus_threshold': 3.0,
+        'minimum_views': 5
     },
     kwargs={
         'eps_slope': 0.5,


### PR DESCRIPTION
This implements "Option 2" of issue #259

The new keyword is added so the value shows up in the `parameters` section of the reduction.  The reducers don't act on this value, they just pass it along to the front-end.