### PR TITLE
Fix pandas eval

### DIFF
--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -207,8 +207,8 @@ def reduce_csv(
         if 'data' in reduced_csv:
             def eval_func(a):
                 # pandas uses a local namespace, make sure it has the correct imports
-                from collections import OrderedDict
-                from numpy import nan
+                from collections import OrderedDict  # noqa
+                from numpy import nan  # noqa
                 return eval(a)
             reduced_csv.data = reduced_csv.data.apply(eval_func)
             flat_reduced_data = flatten_data(reduced_csv)

--- a/panoptes_aggregation/scripts/reduce_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/reduce_panoptes_csv.py
@@ -205,7 +205,12 @@ def reduce_csv(
     if stream:
         reduced_csv = pandas.read_csv(output_path, encoding='utf-8')
         if 'data' in reduced_csv:
-            reduced_csv.data = reduced_csv.data.apply(eval)
+            def eval_func(a):
+                # pandas uses a local namespace, make sure it has the correct imports
+                from collections import OrderedDict
+                from numpy import nan
+                return eval(a)
+            reduced_csv.data = reduced_csv.data.apply(eval_func)
             flat_reduced_data = flatten_data(reduced_csv)
         else:
             return output_path


### PR DESCRIPTION
Panda's`apply` function does not use the same namespace as the rest of the code.  As a result some data structures (e.g. `OrderedDict`) are not defined.  This PR ensures the namespace has the correct imports.