### PR TITLE
Define structure of new subtask extractor

### DIFF
--- a/panoptes_aggregation/extractors/extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/extractor_wrapper.py
@@ -4,12 +4,11 @@ from ..append_version import append_version
 
 
 def unpack_annotations(annotations, task):
-    if task == 'all':
-        annotations_list = []
-        for value in annotations.values():
+    annotations_list = []
+    for key, value in annotations.items():
+        # subtasks are stored as 'T0.0.0' and need to be pulled out with 'T0'
+        if (task == 'all') or (key.split('.')[0] == task):
             annotations_list += value
-    else:
-        annotations_list = annotations.get(task, [])
     return annotations_list
 
 

--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -1,31 +1,67 @@
 from functools import wraps
 import copy
 from panoptes_aggregation import extractors
+from packaging import version
 
 
 def subtask_wrapper(func):
     @wraps(func)
     def wrapper(data, **kwargs):
+        classification_metadata = data.get('metadata', {})
+        classifier_version = version.parse(classification_metadata.get('classifier_version', '1.0'))
         details_functions = kwargs.pop('details', None)
-        output = func(data, **kwargs)
-        if details_functions is not None:
-            blank_annotation = {'annotations': {'ST': []}}
+        if classifier_version >= version.parse('2.0'):
+            # split drawing annotaitons from subtask annotations
+            data_drawing = {'annotations': []}
+            data_subtask = {}
             for annotation in data['annotations']:
-                task_key = annotation['task']
-                for value in annotation['value']:
-                    key_prefix = '{0}_tool{1}'.format(task_key, value['tool'])
-                    key = '{0}_details'.format(key_prefix)
-                    frame = 'frame{0}'.format(value['frame'])
-                    if key_prefix in details_functions:
-                        output[frame].setdefault(key, []).append([])
-                        for ddx, detail in enumerate(value['details']):
-                            mock_annotation = copy.deepcopy(blank_annotation)
-                            mock_annotation['annotations']['ST'].append(detail)
-                            if details_functions[key_prefix][ddx] in extractors.extractors:
-                                extractor = extractors.extractors[details_functions[key_prefix][ddx]]
-                                detail_extract = extractor(mock_annotation, no_version=True)
-                                output[frame][key][-1].append(detail_extract)
-                            else:
-                                output[frame][key][-1].append('No extractor for this subtask type')
+                if annotation['taskType'] == 'drawing':
+                    data_drawing['annotations'].append(annotation)
+                else:
+                    subtask_key = annotation['task']
+                    subtask_mark = annotation['markIndex']
+                    data_subtask[(subtask_key, subtask_mark)] = annotation
+            output = func(data_drawing, **kwargs)
+        else:
+            output = func(data, **kwargs)
+        if details_functions is not None:
+            if classifier_version < version.parse('2.0'):
+                # old classifier version
+                blank_annotation = {'annotations': {'ST': []}}
+                for annotation in data['annotations']:
+                    task_key = annotation['task']
+                    for value in annotation['value']:
+                        key_prefix = '{0}_tool{1}'.format(task_key, value['tool'])
+                        key = '{0}_details'.format(key_prefix)
+                        frame = 'frame{0}'.format(value['frame'])
+                        if key_prefix in details_functions:
+                            output[frame].setdefault(key, []).append([])
+                            for ddx, detail in enumerate(value['details']):
+                                mock_annotation = copy.deepcopy(blank_annotation)
+                                mock_annotation['annotations']['ST'].append(detail)
+                                if details_functions[key_prefix][ddx] in extractors.extractors:
+                                    extractor = extractors.extractors[details_functions[key_prefix][ddx]]
+                                    detail_extract = extractor(mock_annotation, no_version=True)
+                                    output[frame][key][-1].append(detail_extract)
+                                else:
+                                    output[frame][key][-1].append('No extractor for this subtask type')
+            else:
+                # new classifier version
+                output['classifier_version'] = str(classifier_version)
+                for annotation in data_drawing['annotations']:
+                    task_key = annotation['task']
+                    for vdx, value in enumerate(annotation['value']):
+                        frame = 'frame{0}'.format(value['frame'])
+                        for detail in value['details']:
+                            subtask = detail['task']
+                            subtask_key = '{0}_tool{1}_subtask{2}'.format(*subtask.split('.'))
+                            if subtask_key in details_functions:
+                                output[frame].setdefault(subtask_key, [])
+                                extractor = extractors.extractors[details_functions[subtask_key]]
+                                subtask_annotation = {'annotations': {
+                                    subtask_key: [data_subtask[(subtask, vdx)]]
+                                }}
+                                detail_extract = extractor(subtask_annotation, no_version=True)
+                                output[frame][subtask_key].append(detail_extract)
         return output
     return wrapper

--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -22,6 +22,7 @@ def subtask_wrapper(func):
                     subtask_mark = annotation['markIndex']
                     data_subtask[(subtask_key, subtask_mark)] = annotation
             output = func(data_drawing, **kwargs)
+            output['classifier_version'] = str(classifier_version)
         else:
             output = func(data, **kwargs)
         if details_functions is not None:
@@ -47,7 +48,6 @@ def subtask_wrapper(func):
                                     output[frame][key][-1].append('No extractor for this subtask type')
             else:
                 # new classifier version
-                output['classifier_version'] = str(classifier_version)
                 for annotation in data_drawing['annotations']:
                     task_key = annotation['task']
                     for vdx, value in enumerate(annotation['value']):

--- a/panoptes_aggregation/extractors/tool_wrapper.py
+++ b/panoptes_aggregation/extractors/tool_wrapper.py
@@ -7,10 +7,15 @@ def tool_wrapper(func):
         if 'tools' in kwargs:
             tools = kwargs.pop('tools')
             for annotation in data['annotations']:
-                new_value = []
-                for v in annotation['value']:
-                    if v['tool'] in tools:
-                        new_value.append(v)
-                annotation['value'] = new_value
+                # v1 drawing tasks don't have a `taskType` key
+                # default it to `drawing` as there will be only
+                # drawing tasks in it
+                task_type = annotation.get('taskType', 'drawing')
+                if task_type == 'drawing':
+                    new_value = []
+                    for v in annotation['value']:
+                        if v['tool'] in tools:
+                            new_value.append(v)
+                    annotation['value'] = new_value
         return func(data, **kwargs)
     return wrapper

--- a/panoptes_aggregation/reducers/shape_process_data.py
+++ b/panoptes_aggregation/reducers/shape_process_data.py
@@ -29,14 +29,14 @@ def process_data(data, shape=None, symmetric=False):
     -------
     processed_data : dict
         A dictionary with each key being a `tool` with a list of (`x`, `y`, ...)
-        tuples as a vlaue. Each shape parameter shows up in this list.
+        tuples as a value. Each shape parameter shows up in this list.
     '''
     if shape is None:
         raise KeyError('`shape` must be provided as a keyword')
     if shape not in SHAPE_LUT:
         raise KeyError('`shape` must be one of {0}'.format(list(SHAPE_LUT.keys())))
     shape_params = SHAPE_LUT[shape]
-    unique_frames = set(sum([list(d.keys()) for d in data], []))
+    unique_frames = set(sum([[k for k in d.keys() if k.startswith('frame')] for d in data], []))
     data_by_tool = {
         'shape': shape,
         'symmetric': symmetric

--- a/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
@@ -1,39 +1,75 @@
 from functools import wraps
 import numpy as np
 from panoptes_aggregation import reducers
+from packaging import version
 
 
 def subtask_wrapper(func):
     @wraps(func)
     def wrapper(data, **kwargs):
         details_functions = kwargs.pop('details', None)
+        # data_in is the list of original extracts
+        # data is the `processed` data_in
         data_in = kwargs.pop('data_in', None)
         output = func(data, **kwargs)
         if details_functions is not None:
-            keys_details = ['{0}_details'.format(k) for k in details_functions.keys()]
-            keys_labels = ['{0}_cluster_labels'.format(k) for k in details_functions.keys()]
-            keys_clusters = ['{0}_clusters_details'.format(k) for k in details_functions.keys()]
-            for extract in data_in:
-                for frame_key, frame in extract.items():
-                    for k in keys_details:
-                        output[frame_key].setdefault(k, [])
-                        if k in frame:
-                            output[frame_key][k] += frame[k]
-            for frame_key, _frame in output.items():
-                for kd, kl, kc, df in zip(keys_details, keys_labels, keys_clusters, details_functions.keys()):
-                    detail_array = np.array(output[frame_key][kd])
-                    if kl in output[frame_key]:
-                        cluster_labels = np.array(output[frame_key][kl])
-                        for label in np.unique(cluster_labels):
-                            if label > -1:
-                                detail_cluster = detail_array[cluster_labels == label]
-                                detail_reduced = []
-                                for ddx, detail in enumerate(detail_cluster.T):
-                                    if details_functions[df][ddx] is None:
-                                        detail_reduced.append('No reducer for this subtask type')
-                                    else:
-                                        reducer = reducers.reducers[details_functions[df][ddx]]
-                                        detail_reduced.append(reducer(detail, no_version=True))
-                                output[frame_key].setdefault(kc, []).append(detail_reduced)
+            classifier_versions = np.array([version.parse(d.pop('classifier_version', '1.0')) for d in data_in])
+            if all(classifier_versions == version.parse('1.0')):
+                # classifier version 1.0
+                keys_details = ['{0}_details'.format(k) for k in details_functions.keys()]
+                keys_labels = ['{0}_cluster_labels'.format(k) for k in details_functions.keys()]
+                keys_clusters = ['{0}_clusters_details'.format(k) for k in details_functions.keys()]
+                for extract in data_in:
+                    for frame_key, frame in extract.items():
+                        for k in keys_details:
+                            output[frame_key].setdefault(k, [])
+                            if k in frame:
+                                output[frame_key][k] += frame[k]
+                for frame_key, _frame in output.items():
+                    for kd, kl, kc, df in zip(keys_details, keys_labels, keys_clusters, details_functions.keys()):
+                        detail_array = np.array(output[frame_key][kd])
+                        if kl in output[frame_key]:
+                            cluster_labels = np.array(output[frame_key][kl])
+                            for label in np.unique(cluster_labels):
+                                if label > -1:
+                                    detail_cluster = detail_array[cluster_labels == label]
+                                    detail_reduced = []
+                                    for ddx, detail in enumerate(detail_cluster.T):
+                                        if details_functions[df][ddx] is None:
+                                            detail_reduced.append('No reducer for this subtask type')
+                                        else:
+                                            reducer = reducers.reducers[details_functions[df][ddx]]
+                                            detail_reduced.append(reducer(detail, no_version=True))
+                                    output[frame_key].setdefault(kc, []).append(detail_reduced)
+            elif all(classifier_versions >= version.parse('2.0')):
+                # classifier version 2.0 and up
+                for extract in data_in:
+                    for frame_key, frame in extract.items():
+                        for k in details_functions.keys():
+                            output[frame_key].setdefault(k, [])
+                            if k in frame:
+                                output[frame_key][k] += frame[k]
+                for frame in output.values():
+                    unique_tools = set(['_'.join(k.split('_')[:2]) for k in frame.keys()])
+                    for tool in unique_tools:
+                        subtasks = [k for k in details_functions.keys() if k.startswith(tool)]
+                        for subtask in subtasks:
+                            cluster_labels = np.array(frame['{0}_cluster_labels'.format(tool)])
+                            subtask_array = np.array(frame[subtask])
+                            subtask_reduced = []
+                            for label in np.unique(cluster_labels):
+                                if label > -1:
+                                    subtask_cluster = subtask_array[cluster_labels == label]
+                                    reducer = reducers.reducers[details_functions[subtask]]
+                                    subtask_reduced.append(reducer(subtask_cluster, no_version=True))
+                            frame['{0}_clusters'.format(subtask)] = subtask_reduced
+                output['classifier_version'] = str(classifier_versions.max())
+            else:
+                # mix of classifier version 1.0 and 2.0
+                # this should never happen
+                # chances are this check will need to be done
+                # at the reducer wrapper level to prevent the
+                # reducer from running in the first place
+                pass
         return output
     return wrapper

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -1,0 +1,133 @@
+classification = {
+    'annotations': [
+        {
+            'task': 'T0',
+            'taskType': 'drawing',
+            'value': [
+                {
+                    'frame': 0,
+                    'tool': 0,
+                    'toolType': 'point',
+                    'x': 452.18341064453125,
+                    'y': 202.87478637695312,
+                    'details': [
+                        {'task': 'T0.0.0'},
+                        {'task': 'T0.0.1'}
+                    ]
+                },
+                {
+                    'frame': 0,
+                    'tool': 0,
+                    'toolType': 'point',
+                    'x': 374.23454574576868,
+                    'y': 455.23453656547428,
+                    'details': [
+                        {'task': 'T0.0.0'},
+                        {'task': 'T0.0.1'}
+                    ]
+                },
+                {
+                    'frame': 0,
+                    'tool': 1,
+                    'toolType': 'point',
+                    'x': 404.61279296875,
+                    'y': 583.4398803710938,
+                    'details': [
+                        {'task': 'T0.1.0'},
+                        {'task': 'T0.1.1'}
+                    ]
+                }
+            ]
+        },
+        {
+            'task': 'T0.0.0',
+            'taskType': 'single',
+            'markIndex': 0,
+            'value': 0
+        },
+        {
+            'task': 'T0.0.1',
+            'taskType': 'dropdown',
+            'markIndex': 0,
+            'value': [
+                {'value': 'option-1'},
+                {'value': 'option-2'},
+                {'value': None}
+            ]
+        },
+        {
+            'task': 'T0.0.0',
+            'taskType': 'single',
+            'markIndex': 1,
+            'value': 1
+        },
+        {
+            'task': 'T0.0.1',
+            'taskType': 'dropdown',
+            'markIndex': 1,
+            'value': [
+                {'value': 'option-3'},
+                {'value': 'option-4'},
+                {'value': 'option-5'}
+            ]
+        },
+        {
+            'task': 'T0.1.0',
+            'markIndex': 2,
+            'taskType': 'single',
+            'value': 1
+        },
+        {
+            'task': 'T0.1.1',
+            'markIndex': 2,
+            'taskType': 'dropdown',
+            'value': [
+                {'value': 'option-3'},
+                {'value': 'option-4'},
+                {'value': 'option-5'}
+            ]
+        }
+    ],
+    'metadata': {
+        'classifier_version': 2.0
+    }
+}
+
+expected = {
+    'T0_tool0_x': [
+        452.18341064453125,
+        374.23454574576868
+    ],
+    'T0_tool0_y': [
+        202.87478637695312,
+        455.23453656547428
+    ],
+    'T0_tool0_subtask0': [
+        {'0': 1},
+        {'1': 1}
+    ],
+    'T0_tool0_subtask1': [
+        {'value': [
+            {'option-1': 1},
+            {'option-2': 1},
+            {'None': 1}
+        ]},
+        {'value': [
+            {'option-3': 1},
+            {'option-4': 1},
+            {'option-5': 1}
+        ]}
+    ],
+    'T0_tool1_x': [404.61279296875],
+    'T0_tool1_y': [583.4398803710938],
+    'T0_tool1_subtask0': [
+        {'1': 1}
+    ],
+    'T0_tool1_subtask1': [
+        {'value': [
+            {'option-3': 1},
+            {'option-4': 1},
+            {'option-5': 1}
+        ]}
+    ]
+}

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -172,3 +172,139 @@ TestSubtaskV2Task = ExtractorTest(
     },
     test_name='TestSubtaskV2Task'
 )
+
+TestSubtaskV2AllTools = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected,
+    'Test subtask v2.0 extraction with all tools specified',
+    kwargs={
+        'tools': [0, 1],
+        'shape': 'point',
+        'details': {
+            'T0_tool0_subtask0': 'question_extractor',
+            'T0_tool0_subtask1': 'dropdown_extractor',
+            'T0_tool1_subtask0': 'question_extractor',
+            'T0_tool1_subtask1': 'dropdown_extractor'
+        }
+    },
+    test_name='TestSubtaskV2AllTools'
+)
+
+expected_0 = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T0_tool0_x': [
+            452.18341064453125,
+            374.23454574576868
+        ],
+        'T0_tool0_y': [
+            202.87478637695312,
+            455.23453656547428
+        ],
+        'T0_tool0_subtask0': [
+            {'0': 1},
+            {'1': 1}
+        ],
+        'T0_tool0_subtask1': [
+            {'value': [
+                {'option-1': 1},
+                {'option-2': 1},
+                {'None': 1}
+            ]},
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]}
+        ]
+    }
+}
+
+TestSubtaskV2OneTool = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected_0,
+    'Test subtask v2.0 extraction with one tool specified',
+    kwargs={
+        'tools': [0],
+        'shape': 'point',
+        'details': {
+            'T0_tool0_subtask0': 'question_extractor',
+            'T0_tool0_subtask1': 'dropdown_extractor'
+        }
+    },
+    test_name='TestSubtaskV2OneTool'
+)
+
+expected_no_sub = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T0_tool0_x': [
+            452.18341064453125,
+            374.23454574576868
+        ],
+        'T0_tool0_y': [
+            202.87478637695312,
+            455.23453656547428
+        ],
+        'T0_tool1_x': [404.61279296875],
+        'T0_tool1_y': [583.4398803710938],
+    }
+}
+
+TestSubtaskV2NoSub = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected_no_sub,
+    'Test subtask v2.0 extraction with no subtask extractors configured',
+    kwargs={'shape': 'point'},
+    test_name='TestSubtaskV2NoSub'
+)
+
+expected_one_sub = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T0_tool0_x': [
+            452.18341064453125,
+            374.23454574576868
+        ],
+        'T0_tool0_y': [
+            202.87478637695312,
+            455.23453656547428
+        ],
+        'T0_tool0_subtask0': [
+            {'0': 1},
+            {'1': 1}
+        ],
+        'T0_tool0_subtask1': [
+            {'value': [
+                {'option-1': 1},
+                {'option-2': 1},
+                {'None': 1}
+            ]},
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]}
+        ],
+        'T0_tool1_x': [404.61279296875],
+        'T0_tool1_y': [583.4398803710938],
+    }
+}
+
+TestSubtaskV2OneSub = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected_one_sub,
+    'Test subtask v2.0 extraction with one subtask extractors configured',
+    kwargs={
+        'shape': 'point',
+        'details': {
+            'T0_tool0_subtask0': 'question_extractor',
+            'T0_tool0_subtask1': 'dropdown_extractor'
+        }
+    },
+    test_name='TestSubtaskV2OneSub'
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -1,3 +1,6 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
 classification = {
     'annotations': [
         {
@@ -94,40 +97,60 @@ classification = {
 }
 
 expected = {
-    'T0_tool0_x': [
-        452.18341064453125,
-        374.23454574576868
-    ],
-    'T0_tool0_y': [
-        202.87478637695312,
-        455.23453656547428
-    ],
-    'T0_tool0_subtask0': [
-        {'0': 1},
-        {'1': 1}
-    ],
-    'T0_tool0_subtask1': [
-        {'value': [
-            {'option-1': 1},
-            {'option-2': 1},
-            {'None': 1}
-        ]},
-        {'value': [
-            {'option-3': 1},
-            {'option-4': 1},
-            {'option-5': 1}
-        ]}
-    ],
-    'T0_tool1_x': [404.61279296875],
-    'T0_tool1_y': [583.4398803710938],
-    'T0_tool1_subtask0': [
-        {'1': 1}
-    ],
-    'T0_tool1_subtask1': [
-        {'value': [
-            {'option-3': 1},
-            {'option-4': 1},
-            {'option-5': 1}
-        ]}
-    ]
+    'classifier_version': 2.0,
+    'frame0': {
+        'T0_tool0_x': [
+            452.18341064453125,
+            374.23454574576868
+        ],
+        'T0_tool0_y': [
+            202.87478637695312,
+            455.23453656547428
+        ],
+        'T0_tool0_subtask0': [
+            {'0': 1},
+            {'1': 1}
+        ],
+        'T0_tool0_subtask1': [
+            {'value': [
+                {'option-1': 1},
+                {'option-2': 1},
+                {'None': 1}
+            ]},
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]}
+        ],
+        'T0_tool1_x': [404.61279296875],
+        'T0_tool1_y': [583.4398803710938],
+        'T0_tool1_subtask0': [
+            {'1': 1}
+        ],
+        'T0_tool1_subtask1': [
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]}
+        ]
+    }
 }
+
+TestSubtaskV2 = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected,
+    'Test subtask v2.0 extraction',
+    kwargs={
+        'shape': 'point',
+        'details': {
+            'T0_tool0_subtask0': 'question_extractor',
+            'T0_tool0_subtask1': 'dropdown_extractor',
+            'T0_tool1_subtask0': 'question_extractor',
+            'T0_tool1_subtask1': 'dropdown_extractor'
+        }
+    },
+    test_name='TestSubtaskV2'
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -154,3 +154,21 @@ TestSubtaskV2 = ExtractorTest(
     },
     test_name='TestSubtaskV2'
 )
+
+TestSubtaskV2Task = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected,
+    'Test subtask v2.0 extraction with task specified',
+    kwargs={
+        'task': 'T0',
+        'shape': 'point',
+        'details': {
+            'T0_tool0_subtask0': 'question_extractor',
+            'T0_tool0_subtask1': 'dropdown_extractor',
+            'T0_tool1_subtask0': 'question_extractor',
+            'T0_tool1_subtask1': 'dropdown_extractor'
+        }
+    },
+    test_name='TestSubtaskV2Task'
+)

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -92,12 +92,12 @@ classification = {
         }
     ],
     'metadata': {
-        'classifier_version': 2.0
+        'classifier_version': '2.0'
     }
 }
 
 expected = {
-    'classifier_version': 2.0,
+    'classifier_version': '2.0',
     'frame0': {
         'T0_tool0_x': [
             452.18341064453125,

--- a/panoptes_aggregation/tests/reducer_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/reducer_tests/base_test_class.py
@@ -129,7 +129,7 @@ def ReducerTestNoProcessing(
         def test_reducer(self):
             '''Test the offline reducer'''
             result = reducer(self.extracted_with_version, **kwargs)
-            self.assertDictEqual(result, self.reduced_with_version)
+            self.assertDictEqual(cast_to_dict(result), self.reduced_with_version)
 
         @unittest.skipIf(OFFLINE, 'Installed in offline mode')
         def test_request(self):
@@ -145,7 +145,7 @@ def ReducerTestNoProcessing(
                 url_params = ''
             with app.test_request_context(url_params, **request_kwargs):
                 result = reducer(flask.request)
-                self.assertDictEqual(result, self.reduced_with_version)
+                self.assertDictEqual(cast_to_dict(result), self.reduced_with_version)
 
     if test_name is None:
         test_name = '_'.join(name.split())

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
@@ -1,0 +1,205 @@
+from panoptes_aggregation import reducers
+from .base_test_class import ReducerTestNoProcessing
+
+extracted_data = [
+    {
+        'classifier_version': '2.0',
+        'frame0': {
+            'T0_tool0_x': [0.0, 100.0],
+            'T0_tool0_y': [0.0, 100.0],
+            'T0_tool0_subtask0': [
+                {'0': 1},
+                {'1': 1}
+            ],
+            'T0_tool0_subtask1': [
+                {'value': [
+                    {'option-1': 1},
+                    {'option-2': 1},
+                    {'None': 1}
+                ]},
+                {'value': [
+                    {'option-3': 1},
+                    {'option-4': 1},
+                    {'option-5': 1}
+                ]}
+            ],
+            'T0_tool1_x': [500.0],
+            'T0_tool1_y': [500.0],
+            'T0_tool1_subtask0': [
+                {'1': 1}
+            ],
+            'T0_tool1_subtask1': [
+                {'value': [
+                    {'option-3': 1},
+                    {'option-4': 1},
+                    {'option-5': 1}
+                ]}
+            ]
+        }
+    },
+    {
+        'classifier_version': '2.0',
+        'frame0': {
+            'T0_tool0_x': [0.0, 100.0],
+            'T0_tool0_y': [0.0, 100.0],
+            'T0_tool0_subtask0': [
+                {'1': 1},
+                {'1': 1}
+            ],
+            'T0_tool0_subtask1': [
+                {'value': [
+                    {'option-1': 1},
+                    {'option-2': 1},
+                    {'option-3': 1}
+                ]},
+                {'value': [
+                    {'option-1': 1},
+                    {'option-4': 1},
+                    {'option-5': 1}
+                ]}
+            ],
+            'T0_tool1_x': [500.0],
+            'T0_tool1_y': [500.0],
+            'T0_tool1_subtask0': [
+                {'1': 1}
+            ],
+            'T0_tool1_subtask1': [
+                {'value': [
+                    {'option-1': 1},
+                    {'option-3': 1},
+                    {'option-5': 1}
+                ]}
+            ]
+        }
+    },
+    {
+        'classifier_version': '2.0',
+        'frame0': {
+            'T0_tool1_x': [500.0],
+            'T0_tool1_y': [500.0],
+            'T0_tool1_subtask0': [
+                {'0': 1}
+            ],
+            'T0_tool1_subtask1': [
+                {'value': [
+                    {'option-1': 1},
+                    {'option-3': 1},
+                    {'option-5': 1}
+                ]}
+            ]
+        }
+    }
+]
+
+reduced_data = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T0_tool0_point_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_point_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_cluster_labels': [0, 1, 0, 1],
+        'T0_tool0_clusters_count': [2, 2],
+        'T0_tool0_clusters_x': [0.0, 100.0],
+        'T0_tool0_clusters_y': [0.0, 100.0],
+        'T0_tool0_subtask0': [
+            {'0': 1},
+            {'1': 1},
+            {'1': 1},
+            {'1': 1}
+        ],
+        'T0_tool0_subtask1': [
+            {'value': [
+                {'option-1': 1},
+                {'option-2': 1},
+                {'None': 1}
+            ]},
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]},
+            {'value': [
+                {'option-1': 1},
+                {'option-2': 1},
+                {'option-3': 1}
+            ]},
+            {'value': [
+                {'option-1': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]}
+        ],
+        'T0_tool0_clusters_subtask0': [
+            {'0': 1, '1': 1},
+            {'1': 2}
+        ],
+        'T0_tool0_clusters_subtask1': [
+            {'value': [
+                {'option-1': 2},
+                {'option-2': 2},
+                {'None': 1, 'option-3': 1}
+            ]},
+            {'value': [
+                {'option-3': 1, 'option-1': 1},
+                {'option-4': 2},
+                {'option-5': 2}
+            ]}
+        ],
+        'T0_tool1_point_x': [500.0, 500.0, 500.0],
+        'T0_tool1_point_y': [500.0, 500.0, 500.0],
+        'T0_tool1_cluster_labels': [0, 0, 0],
+        'T0_tool1_cluster_count': [3],
+        'T0_tool1_cluster_x': [500.0],
+        'T0_tool1_clusters_y': [500.0],
+        'T0_tool1_subtask0': [
+            {'1': 1},
+            {'1': 1},
+            {'0': 1}
+        ],
+        'T0_tool1_subtask1': [
+            {'value': [
+                {'option-3': 1},
+                {'option-4': 1},
+                {'option-5': 1}
+            ]},
+            {'value': [
+                {'option-1': 1},
+                {'option-3': 1},
+                {'option-5': 1}
+            ]},
+            {'value': [
+                {'option-1': 1},
+                {'option-3': 1},
+                {'option-5': 1}
+            ]}
+        ],
+        'T0_tool1_clusters_subtask0': [
+            {'0': 1, '1': 2}
+        ],
+        'T0_tool1_clusters_subtask1': [
+            {'value': [
+                {'option-1': 2, 'option-3': 1},
+                {'option-3': 2, 'option-4': 1},
+                {'option-5': 3}
+            ]}
+        ]
+    }
+}
+
+TestSubtaskReducerV2 = ReducerTestNoProcessing(
+    reducers.shape_reducer_dbscan,
+    extracted_data,
+    reduced_data,
+    'Test subtask reducer with classifier v2 extracts',
+    kwargs={
+        'shape': 'point',
+        'eps': 5,
+        'min_samples': 2,
+        'details': {
+            'T0_tool0_subtask0': 'question_reducer',
+            'T0_tool0_subtask1': 'dropdown_reducer',
+            'T0_tool1_subtask0': 'question_reducer',
+            'T0_tool1_subtask1': 'dropdown_reducer'
+        }
+    },
+    test_name='TestSubtaskReducerV2'
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
@@ -128,11 +128,11 @@ reduced_data = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool0_clusters_subtask0': [
+        'T0_tool0_subtask0_clusters': [
             {'0': 1, '1': 1},
             {'1': 2}
         ],
-        'T0_tool0_clusters_subtask1': [
+        'T0_tool0_subtask1_clusters': [
             {'value': [
                 {'option-1': 2},
                 {'option-2': 2},
@@ -147,8 +147,8 @@ reduced_data = {
         'T0_tool1_point_x': [500.0, 500.0, 500.0],
         'T0_tool1_point_y': [500.0, 500.0, 500.0],
         'T0_tool1_cluster_labels': [0, 0, 0],
-        'T0_tool1_cluster_count': [3],
-        'T0_tool1_cluster_x': [500.0],
+        'T0_tool1_clusters_count': [3],
+        'T0_tool1_clusters_x': [500.0],
         'T0_tool1_clusters_y': [500.0],
         'T0_tool1_subtask0': [
             {'1': 1},
@@ -172,10 +172,10 @@ reduced_data = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool1_clusters_subtask0': [
+        'T0_tool1_subtask0_clusters': [
             {'0': 1, '1': 2}
         ],
-        'T0_tool1_clusters_subtask1': [
+        'T0_tool1_subtask1_clusters': [
             {'value': [
                 {'option-1': 2, 'option-3': 1},
                 {'option-3': 2, 'option-4': 1},

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         'hdbscan>=0.8.20,<0.8.27',
         'lxml>=4.4,<4.6',
         'numpy>=1.16.3,<1.19',
+        'packaging>=20.1,<20.4',
         'pandas>=0.24.2,<1.0.4',
         'progressbar2>=3.39,<3.52',
         'python-levenshtein>=0.12.0,<0.13',


### PR DESCRIPTION
Taking the example classification from [ADR 25](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-25.md) of the monorepo this test defines what the extract should look like.

I am taking this opportunity to make the resulting extract a bit cleaner than the previous version.  Each subtask is split into its own key containing a list of extracts.  These lists can be indexed (by cluster ID number) and passed directly into a reducer without any reformatting.  Also subtasks without defined extractors no longer need a placeholder.

The `classifier_version: 2.0` in the `metadata` will act as the switch between the old method and the new.