### PR TITLE
Fix TESS extracts

### DIFF
--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -15,7 +15,8 @@ def subtask_wrapper(func):
             data_drawing = {'annotations': []}
             data_subtask = {}
             for annotation in data['annotations']:
-                if annotation['taskType'] == 'drawing':
+                # TESS does not have taskType defined on the column task
+                if annotation.get('taskType', 'drawing') == 'drawing':
                     data_drawing['annotations'].append(annotation)
                 else:
                     subtask_key = annotation['task']


### PR DESCRIPTION
TESS uses the classifier v2.0 metadata but does not have `taskType` defined the column task.  This makes the default correct for TESS.