### PR TITLE
Fix TESS column reducer

### DIFF
--- a/panoptes_aggregation/reducers/tess_reducer_column.py
+++ b/panoptes_aggregation/reducers/tess_reducer_column.py
@@ -49,7 +49,7 @@ def process_data(data, **kwargs_extra_data):
         * `index`: A list of lenght N indicating the extract index for each drawn column
     '''
     shape_params = SHAPE_LUT['column']
-    unique_frames = set(sum([list(d.keys()) for d in data], []))
+    unique_frames = set(sum([[k for k in d.keys() if k.startswith('frame')] for d in data], []))
     data_by_tool = []
     index_by_tool = []
     for frame in unique_frames:

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
@@ -203,3 +203,33 @@ TestSubtaskReducerV2 = ReducerTestNoProcessing(
     },
     test_name='TestSubtaskReducerV2'
 )
+
+reduced_data_no_details = {
+    'frame0': {
+        'T0_tool0_point_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_point_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_cluster_labels': [0, 1, 0, 1],
+        'T0_tool0_clusters_count': [2, 2],
+        'T0_tool0_clusters_x': [0.0, 100.0],
+        'T0_tool0_clusters_y': [0.0, 100.0],
+        'T0_tool1_point_x': [500.0, 500.0, 500.0],
+        'T0_tool1_point_y': [500.0, 500.0, 500.0],
+        'T0_tool1_cluster_labels': [0, 0, 0],
+        'T0_tool1_clusters_count': [3],
+        'T0_tool1_clusters_x': [500.0],
+        'T0_tool1_clusters_y': [500.0],
+    }
+}
+
+TestSubtaskReducerV2NoDetails = ReducerTestNoProcessing(
+    reducers.shape_reducer_dbscan,
+    extracted_data,
+    reduced_data_no_details,
+    'Test subtask reducer with classifier v2 extracts',
+    kwargs={
+        'shape': 'point',
+        'eps': 5,
+        'min_samples': 2
+    },
+    test_name='TestSubtaskReducerV2NoDetails'
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_tess_reducer_column.py
@@ -4,6 +4,7 @@ import copy
 
 extracted_data = [
     {
+        'classifier': '2.0',
         'frame0': {
             'T0_tool0_x': [
                 0.0,
@@ -20,6 +21,7 @@ extracted_data = [
         }
     },
     {
+        'classifier': '2.0',
         'frame0': {
             'T0_tool0_x': [
                 0.0,


### PR DESCRIPTION
The column reducer does not use the stardard shape process data fuction, this adds the fix for skipping the 'classifier: 2.0' key in the extract.