### PR TITLE
Add tests for TESS v2.0 extracts

### DIFF
--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -16,7 +16,7 @@ def subtask_wrapper(func):
             data_subtask = {}
             for annotation in data['annotations']:
                 # TESS does not have taskType defined on the column task
-                if annotation.get('taskType', 'drawing') == 'drawing':
+                if annotation.get('taskType', 'drawing') in ['drawing', 'dataVisAnnotation']:
                     data_drawing['annotations'].append(annotation)
                 else:
                     subtask_key = annotation['task']

--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -15,7 +15,7 @@ def subtask_wrapper(func):
             data_drawing = {'annotations': []}
             data_subtask = {}
             for annotation in data['annotations']:
-                # TESS does not have taskType defined on the column task
+                # `dataVisAnnotation` is used for graph subjects
                 if annotation.get('taskType', 'drawing') in ['drawing', 'dataVisAnnotation']:
                     data_drawing['annotations'].append(annotation)
                 else:

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2_tess.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2_tess.py
@@ -1,0 +1,51 @@
+# Tess uses classifier v2.0 with a shape_extractor and no subtasks
+# it is also does not have `taskType: drawing`
+# ensure the subtask wrapper passes it along correctly
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    'annotations': [{
+        'task': 'T1',
+        'value': [{
+            'x': 15,
+            'tool': 0,
+            'width': 0.92,
+            'toolType': 'graph2dRangeX',
+            'zoomLevelOnCreation': 1
+        }],
+        'taskType': 'dataVisAnnotation'
+    }],
+    'metadata': {
+        'classifier_version': '2.0'
+    }
+}
+
+expected = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T1_tool0_x': [15],
+        'T1_tool0_width': [0.92],
+    }
+}
+
+TestShapeColumnTess = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected,
+    'Test shape column for TESS v2.0 classification',
+    kwargs={'shape': 'column'},
+    test_name='TestShapeColumnTess'
+)
+
+TestShapeColumnTaskTess = ExtractorTest(
+    extractors.shape_extractor,
+    classification,
+    expected,
+    'Test shape column with task specified for TESS v2.0 classification',
+    kwargs={
+        'shape': 'column',
+        'task': 'T1'
+    },
+    test_name='TestShapeColumnTaskTess'
+)


### PR DESCRIPTION
These tests ensure that the TESS classification format makes it through the new subtask wrapper update without issue.