### PR TITLE
Allow `toolIndex` to be used instead of `tool`

### DIFF
--- a/panoptes_aggregation/extractors/shape_extractor.py
+++ b/panoptes_aggregation/extractors/shape_extractor.py
@@ -43,7 +43,15 @@ def shape_extractor(classification, **kwargs):
     for annotation in classification['annotations']:
         task_key = annotation['task']
         for value in annotation['value']:
-            key = '{0}_tool{1}'.format(task_key, value['tool'])
+            if 'tool' in value:
+                # classifier v1.0
+                tool_index = value['tool']
+            elif 'toolIndex' in value:
+                # classifier v2.0
+                tool_index = value['toolIndex']
+            else:
+                raise KeyError('Neither `tool` or `toolIndex` are in the annotation')
+            key = '{0}_tool{1}'.format(task_key, tool_index)
             frame = 'frame{0}'.format(value.get('frame', 0))
             if all(param in value for param in shape_params):
                 extract.setdefault(frame, {})

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -9,7 +9,7 @@ classification = {
             'value': [
                 {
                     'frame': 0,
-                    'tool': 0,
+                    'toolIndex': 0,
                     'toolType': 'point',
                     'x': 452.18341064453125,
                     'y': 202.87478637695312,
@@ -20,7 +20,7 @@ classification = {
                 },
                 {
                     'frame': 0,
-                    'tool': 0,
+                    'toolIndex': 0,
                     'toolType': 'point',
                     'x': 374.23454574576868,
                     'y': 455.23453656547428,
@@ -31,7 +31,7 @@ classification = {
                 },
                 {
                     'frame': 0,
-                    'tool': 1,
+                    'toolIndex': 1,
                     'toolType': 'point',
                     'x': 404.61279296875,
                     'y': 583.4398803710938,


### PR DESCRIPTION
Classifier 2.0 will change `tool` to `toolIndex` in drawing annotaitons.  This PR updates the shape extractor to use either key.  If neither key is located than a `KeyError` is raised.