### PR TITLE
Fix #297

### DIFF
--- a/panoptes_aggregation/csv_utils.py
+++ b/panoptes_aggregation/csv_utils.py
@@ -18,13 +18,16 @@ def unflatten_data(data, json_column='data', renest=True):
     for name, value in data.items():
         if ('{0}.'.format(json_column) in name) and (pandas.notnull(value)):
             key = name.split('{0}.'.format(json_column))[1]
-            try:
-                nan = None  # noqa
-                false = False  # noqa
-                true = True  # noqa
-                null = None  # noqa
-                data_dict[key] = eval(value)
-            except:
+            if isinstance(value, str) and (('{' in value) or ('[' in value)):
+                try:
+                    nan = None  # noqa
+                    false = False  # noqa
+                    true = True  # noqa
+                    null = None  # noqa
+                    data_dict[key] = eval(value)
+                except:
+                    data_dict[key] = value
+            else:
                 data_dict[key] = value
     if renest:
         return renest_dict(data_dict)

--- a/panoptes_aggregation/reducers/text_reducer.py
+++ b/panoptes_aggregation/reducers/text_reducer.py
@@ -16,7 +16,7 @@ def process_data(data_list):
     '''Flatten list of extracts into a list of strings.  Empty strings
     are not returned'''
     return [
-        [idx, d.get('text', ''), d.get('gold_standard', False)]
+        [idx, str(d.get('text', '')), d.get('gold_standard', False)]
         for idx, d in enumerate(data_list)
         if str(d.get('text', '')).strip() != ''
     ]

--- a/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
@@ -30,13 +30,23 @@ expected_unflatten_renest = {'a': 1, 'b': 0, 'c': {'d': 0, 'e': 1}}
 expected_unflatten = {'a': 1, 'b': 0, 'c.d': 0, 'c.e': 1}
 
 flat_data_text = pandas.DataFrame({
-    'classification_id': [1, 2, 3],
-    'user_id': [1, 2, 3],
-    'data.text': ['1', '10', '10-12']
+    'classification_id': [3, 4],
+    'user_id': [3, 4],
+    'data.text': ['10-12', '5 bags [blue]']
 })
-
-flat_row_text = flat_data_text.iloc[2]
+flat_row_text = flat_data_text.iloc[0]
 expected_unflatten_text = {'text': '10-12'}
+
+flat_row_text_2 = flat_data_text.iloc[1]
+expected_unflatten_text_2 = {'text': '5 bags [blue]'}
+
+flat_data_array = pandas.DataFrame({
+    'classification_id': [1],
+    'user_id': [1],
+    'data.array': ['[[137, 592]]']
+})
+flat_row_array = flat_data_array.iloc[0]
+expected_unflatten_array = {'array': [[137, 592]]}
 
 json_data = pandas.DataFrame({
     'classification_id': [1, 2, 3, 4],
@@ -92,6 +102,16 @@ class TestCSVUtils(unittest.TestCase):
         '''Test unflattening of data with numbers as text'''
         result = csv_utils.unflatten_data(flat_row_text)
         self.assertDictEqual(result, expected_unflatten_text)
+
+    def test_unflatten_text_2(self):
+        '''Test unflattening of data with text containing brackets'''
+        result = csv_utils.unflatten_data(flat_row_text_2)
+        self.assertDictEqual(result, expected_unflatten_text_2)
+
+    def test_unflatten_array(self):
+        '''Test unflattening of data with array as a string'''
+        result = csv_utils.unflatten_data(flat_row_array)
+        self.assertDictEqual(result, expected_unflatten_array)
 
     def test_unflatten_data(self):
         '''Test unflattening of data with out the renest keyword'''

--- a/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
+++ b/panoptes_aggregation/tests/utility_tests/test_csv_utils.py
@@ -29,6 +29,15 @@ flat_row = flat_data.iloc[0]
 expected_unflatten_renest = {'a': 1, 'b': 0, 'c': {'d': 0, 'e': 1}}
 expected_unflatten = {'a': 1, 'b': 0, 'c.d': 0, 'c.e': 1}
 
+flat_data_text = pandas.DataFrame({
+    'classification_id': [1, 2, 3],
+    'user_id': [1, 2, 3],
+    'data.text': ['1', '10', '10-12']
+})
+
+flat_row_text = flat_data_text.iloc[2]
+expected_unflatten_text = {'text': '10-12'}
+
 json_data = pandas.DataFrame({
     'classification_id': [1, 2, 3, 4],
     'data.points': [
@@ -78,6 +87,11 @@ class TestCSVUtils(unittest.TestCase):
         '''Test unflattening of data with the renest keyword'''
         result = csv_utils.unflatten_data(flat_row, renest=True)
         self.assertDictEqual(result, expected_unflatten_renest)
+
+    def test_unflatten_text(self):
+        '''Test unflattening of data with numbers as text'''
+        result = csv_utils.unflatten_data(flat_row_text)
+        self.assertDictEqual(result, expected_unflatten_text)
 
     def test_unflatten_data(self):
         '''Test unflattening of data with out the renest keyword'''


### PR DESCRIPTION
This change will only try to `eval` data columns is they are strings and they contain `{` or `[`.  This will only effect the offline version of the reducers.

Before this fix strings like `"10-12"` were being converted to `-2` when they should have been kept as a string.

More test needs to be done to make sure this does not break anything.