### PR TITLE
Update classifier v2.0 to use `toolIndex`

### DIFF
--- a/panoptes_aggregation/extractors/shape_extractor.py
+++ b/panoptes_aggregation/extractors/shape_extractor.py
@@ -46,12 +46,13 @@ def shape_extractor(classification, **kwargs):
             if 'tool' in value:
                 # classifier v1.0
                 tool_index = value['tool']
+                key = '{0}_tool{1}'.format(task_key, tool_index)
             elif 'toolIndex' in value:
                 # classifier v2.0
                 tool_index = value['toolIndex']
+                key = '{0}_toolIndex{1}'.format(task_key, tool_index)
             else:
                 raise KeyError('Neither `tool` or `toolIndex` are in the annotation')
-            key = '{0}_tool{1}'.format(task_key, tool_index)
             frame = 'frame{0}'.format(value.get('frame', 0))
             if all(param in value for param in shape_params):
                 extract.setdefault(frame, {})

--- a/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
+++ b/panoptes_aggregation/extractors/subtask_extractor_wrapper.py
@@ -55,7 +55,7 @@ def subtask_wrapper(func):
                         frame = 'frame{0}'.format(value['frame'])
                         for detail in value['details']:
                             subtask = detail['task']
-                            subtask_key = '{0}_tool{1}_subtask{2}'.format(*subtask.split('.'))
+                            subtask_key = '{0}_toolIndex{1}_subtask{2}'.format(*subtask.split('.'))
                             if subtask_key in details_functions:
                                 output[frame].setdefault(subtask_key, [])
                                 extractor = extractors.extractors[details_functions[subtask_key]]

--- a/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_subtask_extractor_v2.py
@@ -99,19 +99,19 @@ classification = {
 expected = {
     'classifier_version': '2.0',
     'frame0': {
-        'T0_tool0_x': [
+        'T0_toolIndex0_x': [
             452.18341064453125,
             374.23454574576868
         ],
-        'T0_tool0_y': [
+        'T0_toolIndex0_y': [
             202.87478637695312,
             455.23453656547428
         ],
-        'T0_tool0_subtask0': [
+        'T0_toolIndex0_subtask0': [
             {'0': 1},
             {'1': 1}
         ],
-        'T0_tool0_subtask1': [
+        'T0_toolIndex0_subtask1': [
             {'value': [
                 {'option-1': 1},
                 {'option-2': 1},
@@ -123,12 +123,12 @@ expected = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool1_x': [404.61279296875],
-        'T0_tool1_y': [583.4398803710938],
-        'T0_tool1_subtask0': [
+        'T0_toolIndex1_x': [404.61279296875],
+        'T0_toolIndex1_y': [583.4398803710938],
+        'T0_toolIndex1_subtask0': [
             {'1': 1}
         ],
-        'T0_tool1_subtask1': [
+        'T0_toolIndex1_subtask1': [
             {'value': [
                 {'option-3': 1},
                 {'option-4': 1},
@@ -146,10 +146,10 @@ TestSubtaskV2 = ExtractorTest(
     kwargs={
         'shape': 'point',
         'details': {
-            'T0_tool0_subtask0': 'question_extractor',
-            'T0_tool0_subtask1': 'dropdown_extractor',
-            'T0_tool1_subtask0': 'question_extractor',
-            'T0_tool1_subtask1': 'dropdown_extractor'
+            'T0_toolIndex0_subtask0': 'question_extractor',
+            'T0_toolIndex0_subtask1': 'dropdown_extractor',
+            'T0_toolIndex1_subtask0': 'question_extractor',
+            'T0_toolIndex1_subtask1': 'dropdown_extractor'
         }
     },
     test_name='TestSubtaskV2'
@@ -164,10 +164,10 @@ TestSubtaskV2Task = ExtractorTest(
         'task': 'T0',
         'shape': 'point',
         'details': {
-            'T0_tool0_subtask0': 'question_extractor',
-            'T0_tool0_subtask1': 'dropdown_extractor',
-            'T0_tool1_subtask0': 'question_extractor',
-            'T0_tool1_subtask1': 'dropdown_extractor'
+            'T0_toolIndex0_subtask0': 'question_extractor',
+            'T0_toolIndex0_subtask1': 'dropdown_extractor',
+            'T0_toolIndex1_subtask0': 'question_extractor',
+            'T0_toolIndex1_subtask1': 'dropdown_extractor'
         }
     },
     test_name='TestSubtaskV2Task'
@@ -182,10 +182,10 @@ TestSubtaskV2AllTools = ExtractorTest(
         'tools': [0, 1],
         'shape': 'point',
         'details': {
-            'T0_tool0_subtask0': 'question_extractor',
-            'T0_tool0_subtask1': 'dropdown_extractor',
-            'T0_tool1_subtask0': 'question_extractor',
-            'T0_tool1_subtask1': 'dropdown_extractor'
+            'T0_toolIndex0_subtask0': 'question_extractor',
+            'T0_toolIndex0_subtask1': 'dropdown_extractor',
+            'T0_toolIndex1_subtask0': 'question_extractor',
+            'T0_toolIndex1_subtask1': 'dropdown_extractor'
         }
     },
     test_name='TestSubtaskV2AllTools'
@@ -194,19 +194,19 @@ TestSubtaskV2AllTools = ExtractorTest(
 expected_0 = {
     'classifier_version': '2.0',
     'frame0': {
-        'T0_tool0_x': [
+        'T0_toolIndex0_x': [
             452.18341064453125,
             374.23454574576868
         ],
-        'T0_tool0_y': [
+        'T0_toolIndex0_y': [
             202.87478637695312,
             455.23453656547428
         ],
-        'T0_tool0_subtask0': [
+        'T0_toolIndex0_subtask0': [
             {'0': 1},
             {'1': 1}
         ],
-        'T0_tool0_subtask1': [
+        'T0_toolIndex0_subtask1': [
             {'value': [
                 {'option-1': 1},
                 {'option-2': 1},
@@ -230,8 +230,8 @@ TestSubtaskV2OneTool = ExtractorTest(
         'tools': [0],
         'shape': 'point',
         'details': {
-            'T0_tool0_subtask0': 'question_extractor',
-            'T0_tool0_subtask1': 'dropdown_extractor'
+            'T0_toolIndex0_subtask0': 'question_extractor',
+            'T0_toolIndex0_subtask1': 'dropdown_extractor'
         }
     },
     test_name='TestSubtaskV2OneTool'
@@ -240,16 +240,16 @@ TestSubtaskV2OneTool = ExtractorTest(
 expected_no_sub = {
     'classifier_version': '2.0',
     'frame0': {
-        'T0_tool0_x': [
+        'T0_toolIndex0_x': [
             452.18341064453125,
             374.23454574576868
         ],
-        'T0_tool0_y': [
+        'T0_toolIndex0_y': [
             202.87478637695312,
             455.23453656547428
         ],
-        'T0_tool1_x': [404.61279296875],
-        'T0_tool1_y': [583.4398803710938],
+        'T0_toolIndex1_x': [404.61279296875],
+        'T0_toolIndex1_y': [583.4398803710938],
     }
 }
 
@@ -265,19 +265,19 @@ TestSubtaskV2NoSub = ExtractorTest(
 expected_one_sub = {
     'classifier_version': '2.0',
     'frame0': {
-        'T0_tool0_x': [
+        'T0_toolIndex0_x': [
             452.18341064453125,
             374.23454574576868
         ],
-        'T0_tool0_y': [
+        'T0_toolIndex0_y': [
             202.87478637695312,
             455.23453656547428
         ],
-        'T0_tool0_subtask0': [
+        'T0_toolIndex0_subtask0': [
             {'0': 1},
             {'1': 1}
         ],
-        'T0_tool0_subtask1': [
+        'T0_toolIndex0_subtask1': [
             {'value': [
                 {'option-1': 1},
                 {'option-2': 1},
@@ -289,8 +289,8 @@ expected_one_sub = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool1_x': [404.61279296875],
-        'T0_tool1_y': [583.4398803710938],
+        'T0_toolIndex1_x': [404.61279296875],
+        'T0_toolIndex1_y': [583.4398803710938],
     }
 }
 
@@ -302,8 +302,8 @@ TestSubtaskV2OneSub = ExtractorTest(
     kwargs={
         'shape': 'point',
         'details': {
-            'T0_tool0_subtask0': 'question_extractor',
-            'T0_tool0_subtask1': 'dropdown_extractor'
+            'T0_toolIndex0_subtask0': 'question_extractor',
+            'T0_toolIndex0_subtask1': 'dropdown_extractor'
         }
     },
     test_name='TestSubtaskV2OneSub'

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
@@ -5,13 +5,13 @@ extracted_data = [
     {
         'classifier_version': '2.0',
         'frame0': {
-            'T0_tool0_x': [0.0, 100.0],
-            'T0_tool0_y': [0.0, 100.0],
-            'T0_tool0_subtask0': [
+            'T0_toolIndex0_x': [0.0, 100.0],
+            'T0_toolIndex0_y': [0.0, 100.0],
+            'T0_toolIndex0_subtask0': [
                 {'0': 1},
                 {'1': 1}
             ],
-            'T0_tool0_subtask1': [
+            'T0_toolIndex0_subtask1': [
                 {'value': [
                     {'option-1': 1},
                     {'option-2': 1},
@@ -23,12 +23,12 @@ extracted_data = [
                     {'option-5': 1}
                 ]}
             ],
-            'T0_tool1_x': [500.0],
-            'T0_tool1_y': [500.0],
-            'T0_tool1_subtask0': [
+            'T0_toolIndex1_x': [500.0],
+            'T0_toolIndex1_y': [500.0],
+            'T0_toolIndex1_subtask0': [
                 {'1': 1}
             ],
-            'T0_tool1_subtask1': [
+            'T0_toolIndex1_subtask1': [
                 {'value': [
                     {'option-3': 1},
                     {'option-4': 1},
@@ -40,13 +40,13 @@ extracted_data = [
     {
         'classifier_version': '2.0',
         'frame0': {
-            'T0_tool0_x': [0.0, 100.0],
-            'T0_tool0_y': [0.0, 100.0],
-            'T0_tool0_subtask0': [
+            'T0_toolIndex0_x': [0.0, 100.0],
+            'T0_toolIndex0_y': [0.0, 100.0],
+            'T0_toolIndex0_subtask0': [
                 {'1': 1},
                 {'1': 1}
             ],
-            'T0_tool0_subtask1': [
+            'T0_toolIndex0_subtask1': [
                 {'value': [
                     {'option-1': 1},
                     {'option-2': 1},
@@ -58,12 +58,12 @@ extracted_data = [
                     {'option-5': 1}
                 ]}
             ],
-            'T0_tool1_x': [500.0],
-            'T0_tool1_y': [500.0],
-            'T0_tool1_subtask0': [
+            'T0_toolIndex1_x': [500.0],
+            'T0_toolIndex1_y': [500.0],
+            'T0_toolIndex1_subtask0': [
                 {'1': 1}
             ],
-            'T0_tool1_subtask1': [
+            'T0_toolIndex1_subtask1': [
                 {'value': [
                     {'option-1': 1},
                     {'option-3': 1},
@@ -75,12 +75,12 @@ extracted_data = [
     {
         'classifier_version': '2.0',
         'frame0': {
-            'T0_tool1_x': [500.0],
-            'T0_tool1_y': [500.0],
-            'T0_tool1_subtask0': [
+            'T0_toolIndex1_x': [500.0],
+            'T0_toolIndex1_y': [500.0],
+            'T0_toolIndex1_subtask0': [
                 {'0': 1}
             ],
-            'T0_tool1_subtask1': [
+            'T0_toolIndex1_subtask1': [
                 {'value': [
                     {'option-1': 1},
                     {'option-3': 1},
@@ -94,19 +94,19 @@ extracted_data = [
 reduced_data = {
     'classifier_version': '2.0',
     'frame0': {
-        'T0_tool0_point_x': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_point_y': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_cluster_labels': [0, 1, 0, 1],
-        'T0_tool0_clusters_count': [2, 2],
-        'T0_tool0_clusters_x': [0.0, 100.0],
-        'T0_tool0_clusters_y': [0.0, 100.0],
-        'T0_tool0_subtask0': [
+        'T0_toolIndex0_point_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_toolIndex0_point_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_toolIndex0_cluster_labels': [0, 1, 0, 1],
+        'T0_toolIndex0_clusters_count': [2, 2],
+        'T0_toolIndex0_clusters_x': [0.0, 100.0],
+        'T0_toolIndex0_clusters_y': [0.0, 100.0],
+        'T0_toolIndex0_subtask0': [
             {'0': 1},
             {'1': 1},
             {'1': 1},
             {'1': 1}
         ],
-        'T0_tool0_subtask1': [
+        'T0_toolIndex0_subtask1': [
             {'value': [
                 {'option-1': 1},
                 {'option-2': 1},
@@ -128,11 +128,11 @@ reduced_data = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool0_subtask0_clusters': [
+        'T0_toolIndex0_subtask0_clusters': [
             {'0': 1, '1': 1},
             {'1': 2}
         ],
-        'T0_tool0_subtask1_clusters': [
+        'T0_toolIndex0_subtask1_clusters': [
             {'value': [
                 {'option-1': 2},
                 {'option-2': 2},
@@ -144,18 +144,18 @@ reduced_data = {
                 {'option-5': 2}
             ]}
         ],
-        'T0_tool1_point_x': [500.0, 500.0, 500.0],
-        'T0_tool1_point_y': [500.0, 500.0, 500.0],
-        'T0_tool1_cluster_labels': [0, 0, 0],
-        'T0_tool1_clusters_count': [3],
-        'T0_tool1_clusters_x': [500.0],
-        'T0_tool1_clusters_y': [500.0],
-        'T0_tool1_subtask0': [
+        'T0_toolIndex1_point_x': [500.0, 500.0, 500.0],
+        'T0_toolIndex1_point_y': [500.0, 500.0, 500.0],
+        'T0_toolIndex1_cluster_labels': [0, 0, 0],
+        'T0_toolIndex1_clusters_count': [3],
+        'T0_toolIndex1_clusters_x': [500.0],
+        'T0_toolIndex1_clusters_y': [500.0],
+        'T0_toolIndex1_subtask0': [
             {'1': 1},
             {'1': 1},
             {'0': 1}
         ],
-        'T0_tool1_subtask1': [
+        'T0_toolIndex1_subtask1': [
             {'value': [
                 {'option-3': 1},
                 {'option-4': 1},
@@ -172,10 +172,10 @@ reduced_data = {
                 {'option-5': 1}
             ]}
         ],
-        'T0_tool1_subtask0_clusters': [
+        'T0_toolIndex1_subtask0_clusters': [
             {'0': 1, '1': 2}
         ],
-        'T0_tool1_subtask1_clusters': [
+        'T0_toolIndex1_subtask1_clusters': [
             {'value': [
                 {'option-1': 2, 'option-3': 1},
                 {'option-3': 2, 'option-4': 1},
@@ -195,10 +195,10 @@ TestSubtaskReducerV2 = ReducerTestNoProcessing(
         'eps': 5,
         'min_samples': 2,
         'details': {
-            'T0_tool0_subtask0': 'question_reducer',
-            'T0_tool0_subtask1': 'dropdown_reducer',
-            'T0_tool1_subtask0': 'question_reducer',
-            'T0_tool1_subtask1': 'dropdown_reducer'
+            'T0_toolIndex0_subtask0': 'question_reducer',
+            'T0_toolIndex0_subtask1': 'dropdown_reducer',
+            'T0_toolIndex1_subtask0': 'question_reducer',
+            'T0_toolIndex1_subtask1': 'dropdown_reducer'
         }
     },
     test_name='TestSubtaskReducerV2'
@@ -206,18 +206,18 @@ TestSubtaskReducerV2 = ReducerTestNoProcessing(
 
 reduced_data_no_details = {
     'frame0': {
-        'T0_tool0_point_x': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_point_y': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_cluster_labels': [0, 1, 0, 1],
-        'T0_tool0_clusters_count': [2, 2],
-        'T0_tool0_clusters_x': [0.0, 100.0],
-        'T0_tool0_clusters_y': [0.0, 100.0],
-        'T0_tool1_point_x': [500.0, 500.0, 500.0],
-        'T0_tool1_point_y': [500.0, 500.0, 500.0],
-        'T0_tool1_cluster_labels': [0, 0, 0],
-        'T0_tool1_clusters_count': [3],
-        'T0_tool1_clusters_x': [500.0],
-        'T0_tool1_clusters_y': [500.0],
+        'T0_toolIndex0_point_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_toolIndex0_point_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_toolIndex0_cluster_labels': [0, 1, 0, 1],
+        'T0_toolIndex0_clusters_count': [2, 2],
+        'T0_toolIndex0_clusters_x': [0.0, 100.0],
+        'T0_toolIndex0_clusters_y': [0.0, 100.0],
+        'T0_toolIndex1_point_x': [500.0, 500.0, 500.0],
+        'T0_toolIndex1_point_y': [500.0, 500.0, 500.0],
+        'T0_toolIndex1_cluster_labels': [0, 0, 0],
+        'T0_toolIndex1_clusters_count': [3],
+        'T0_toolIndex1_clusters_x': [500.0],
+        'T0_toolIndex1_clusters_y': [500.0],
     }
 }
 


### PR DESCRIPTION
All entries in the extract and reduction for shape tools with subtasks now use `toolIndex` anywhere `tool` was used before.

Note: `point_extractor`, `point_extractor_by_frame`, `point_reducer`, `point_reducer_hdbscan`, and `point_reducer_dbscan` should be depreciated for the v2.0 classifier!  The point tool should use the `shape` extractor and reducers from now on.

To Do: add depreciation warnings in the extractors/reducers above if v2.0 classifications are passed into them.