### PR TITLE
Fix text subtask

### DIFF
--- a/panoptes_aggregation/reducers/point_reducer_dbscan.py
+++ b/panoptes_aggregation/reducers/point_reducer_dbscan.py
@@ -50,7 +50,7 @@ def process_data(data):
     return data_by_tool
 
 
-@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS)
+@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS, user_id=True)
 @subtask_wrapper
 def point_reducer_dbscan(data_by_tool, **kwargs):
     '''Cluster a list of points by tool using DBSCAN
@@ -59,13 +59,13 @@ def point_reducer_dbscan(data_by_tool, **kwargs):
     ----------
     data_by_tool : dict
         A dictionary returned by :meth:`process_data`
-    kwrgs :
+    kwargs :
         `See DBSCAN <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html>`_
 
     Returns
     -------
     reduction : dict
-        A dictinary with one key per subject `frame`.  Each frame has the following keys
+        A dictionary with one key per subject `frame`.  Each frame has the following keys
 
         * `tool*_points_x` : A list of `x` positions for **all** points drawn with `tool*`
         * `tool*_points_y` : A list of `y` positions for **all** points drawn with `tool*`
@@ -73,9 +73,9 @@ def point_reducer_dbscan(data_by_tool, **kwargs):
         * `tool*_clusters_count` : The number of points in each **cluster** found
         * `tool*_clusters_x` : The `x` position for each **cluster** found
         * `tool*_clusters_y` : The `y` position for each **cluster** found
-        * `tool*_clusters_var_x` : The `x` varaince of points in each **cluster** found
-        * `tool*_clusters_var_y` : The `y` varaince of points in each **cluster** found
-        * `tool*_clusters_var_x_y` : The `x-y` covaraince of points in each **cluster** found
+        * `tool*_clusters_var_x` : The `x` variance of points in each **cluster** found
+        * `tool*_clusters_var_y` : The `y` variance of points in each **cluster** found
+        * `tool*_clusters_var_x_y` : The `x-y` covariance of points in each **cluster** found
 
     '''
     clusters = OrderedDict()
@@ -85,7 +85,7 @@ def point_reducer_dbscan(data_by_tool, **kwargs):
             # clean `None` values for the list
             loc_list_clean = [xy for xy in loc_list if None not in xy]
             loc = np.array(loc_list_clean)
-            # orignal data points in order used by cluster code
+            # original data points in order used by cluster code
             clusters[frame]['{0}_points_x'.format(tool)] = list(loc[:, 0])
             clusters[frame]['{0}_points_y'.format(tool)] = list(loc[:, 1])
             # default each point in no cluster

--- a/panoptes_aggregation/reducers/point_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/point_reducer_hdbscan.py
@@ -36,7 +36,7 @@ def process_data(data):
     -------
     processed_data : dict
         A dictionary with each key being a `tool` with a list of (`x`, `y`)
-        tuples as a vlaue
+        tuples as a value
     '''
     unique_frames = set(sum([list(d.keys()) for d in data], []))
     data_by_tool = {}
@@ -52,7 +52,7 @@ def process_data(data):
     return data_by_tool
 
 
-@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS)
+@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS, user_id=True)
 @subtask_wrapper
 def point_reducer_hdbscan(data_by_tool, **kwargs):
     '''Cluster a list of points by tool using HDBSCAN
@@ -61,25 +61,25 @@ def point_reducer_hdbscan(data_by_tool, **kwargs):
     ----------
     data_by_tool : dict
         A dictionary returned by :meth:`process_data`
-    kwrgs :
+    kwargs :
         `See HDBSCAN <http://hdbscan.readthedocs.io/en/latest/api.html#hdbscan>`_
 
     Returns
     -------
     reduction : dict
-        A dictinary with one key per subject `frame`.  Each frame has the following keys
+        A dictionary with one key per subject `frame`.  Each frame has the following keys
 
         * `tool*_points_x` : A list of `x` positions for **all** points drawn with `tool*`
         * `tool*_points_y` : A list of `y` positions for **all** points drawn with `tool*`
         * `tool*_cluster_labels` : A list of cluster labels for **all** points drawn with `tool*`
         * `tool*_cluster_probabilities`: A list of cluster probabilities for **all** points drawn with `tool*`
-        * `tool*_clusters_persistance`: A mesure for how persistent each **cluster** is (1.0 = stable, 0.0 = unstable)
+        * `tool*_clusters_persistance`: A measure for how persistent each **cluster** is (1.0 = stable, 0.0 = unstable)
         * `tool*_clusters_count` : The number of points in each **cluster** found
         * `tool*_clusters_x` : The weighted `x` position for each **cluster** found
         * `tool*_clusters_y` : The weighted `y` position for each **cluster** found
-        * `tool*_clusters_var_x` : The weighted `x` varaince of points in each **cluster** found
-        * `tool*_clusters_var_y` : The weighted `y` varaince of points in each **cluster** found
-        * `tool*_clusters_var_x_y` : The weighted `x-y` covaraince of points in each **cluster** found
+        * `tool*_clusters_var_x` : The weighted `x` variance of points in each **cluster** found
+        * `tool*_clusters_var_y` : The weighted `y` variance of points in each **cluster** found
+        * `tool*_clusters_var_x_y` : The weighted `x-y` covariance of points in each **cluster** found
 
     '''
     clusters = OrderedDict()
@@ -89,7 +89,7 @@ def point_reducer_hdbscan(data_by_tool, **kwargs):
             # clean `None` values for the list
             loc_list_clean = [xy for xy in loc_list if None not in xy]
             loc = np.array(loc_list_clean)
-            # orignal data points in order used by cluster code
+            # original data points in order used by cluster code
             clusters[frame]['{0}_points_x'.format(tool)] = list(loc[:, 0])
             clusters[frame]['{0}_points_y'.format(tool)] = list(loc[:, 1])
             # default each point in no cluster

--- a/panoptes_aggregation/reducers/rectangle_reducer.py
+++ b/panoptes_aggregation/reducers/rectangle_reducer.py
@@ -34,7 +34,7 @@ def process_data(data):
     -------
     processed_data : dict
         A dictionary with each key being a `frame` dictionary values with keys being
-        `tool` with a list of (`x`, `y`, `width`, `height`) tuples as a vlaue
+        `tool` with a list of (`x`, `y`, `width`, `height`) tuples as a value
     '''
     unique_frames = set(sum([list(d.keys()) for d in data], []))
     data_by_tool = {}
@@ -60,7 +60,7 @@ def process_data(data):
     return data_by_tool
 
 
-@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS)
+@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS, user_id=True)
 @subtask_wrapper
 def rectangle_reducer(data_by_tool, **kwargs):
     '''Cluster a list of rectangles by tool and frame
@@ -69,13 +69,13 @@ def rectangle_reducer(data_by_tool, **kwargs):
     ----------
     data_by_tool : dict
         A dictionary returned by :meth:`process_data`
-    kwrgs :
+    kwargs :
         `See DBSCAN <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html>`_
 
     Returns
     -------
     reduction : dict
-        A dictinary with the following keys for each frame
+        A dictionary with the following keys for each frame
 
         * `tool*_rec_x` : A list of `x` positions for **all** rectangles drawn with `tool*`
         * `tool*_rec_y` : A list of `y` positions for **all** rectangles drawn with `tool*`
@@ -85,7 +85,7 @@ def rectangle_reducer(data_by_tool, **kwargs):
         * `tool*_clusters_count` : The number of points in each **cluster** found
         * `tool*_clusters_x` : The `x` position for each **cluster** found
         * `tool*_clusters_y` : The `y` position for each **cluster** found
-        * `tool*_clusters_width` : The `widht` value for each **cluster** found
+        * `tool*_clusters_width` : The `width` value for each **cluster** found
         * `tool*_clusters_height` : The `height` value for each **cluster** found
 
     '''

--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -57,7 +57,7 @@ def reducer_wrapper(
             if output_kwargs:
                 reduction['parameters'] = {**kwargs_data, **kwargs_process}
             return reduction
-        #: keep the orignal function around for testing
+        #: keep the original function around for testing
         #: and access by other reducers
         wrapper._original = func
         return wrapper

--- a/panoptes_aggregation/reducers/shape_reducer_dbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_dbscan.py
@@ -23,7 +23,12 @@ DEFAULTS = {
 }
 
 
-@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS, defaults_process=DEFAULTS_PROCESS)
+@reducer_wrapper(
+    process_data=process_data,
+    defaults_data=DEFAULTS,
+    defaults_process=DEFAULTS_PROCESS,
+    user_id=True
+)
 @subtask_wrapper
 def shape_reducer_dbscan(data_by_tool, **kwargs):
     '''Cluster a shape by tool using DBSCAN
@@ -32,15 +37,15 @@ def shape_reducer_dbscan(data_by_tool, **kwargs):
     ----------
     data_by_tool : dict
         A dictionary returned by :meth:`process_data`
-    kwrgs :
+    kwargs :
         `See DBSCAN <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html>`_
 
     Returns
     -------
     reduction : dict
-        A dictinary with the following keys for each frame
+        A dictionary with the following keys for each frame
 
-        * `tool*_<shape>_<param>` : A list of **all** `param` for the `sahpe` drawn with `tool*`
+        * `tool*_<shape>_<param>` : A list of **all** `param` for the `shape` drawn with `tool*`
         * `tool*_cluster_labels` : A list of cluster labels for **all** shapes drawn with `tool*`
         * `tool*_clusters_count` : The number of points in each **cluster** found
         * `tool*_clusters_<param>` : The `param` value for each **cluster** found
@@ -57,7 +62,7 @@ def shape_reducer_dbscan(data_by_tool, **kwargs):
             loc = np.array(loc_list)
             if len(shape_params) == 1:
                 loc = loc.reshape(-1, 1)
-            # orignal data points in order used by cluster code
+            # original data points in order used by cluster code
             for pdx, param in enumerate(shape_params):
                 clusters[frame]['{0}_{1}_{2}'.format(tool, shape, param)] = loc[:, pdx].tolist()
             # default each point in no cluster

--- a/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
@@ -24,7 +24,12 @@ DEFAULTS = {
 }
 
 
-@reducer_wrapper(process_data=process_data, defaults_data=DEFAULTS, defaults_process=DEFAULTS_PROCESS)
+@reducer_wrapper(
+    process_data=process_data,
+    defaults_data=DEFAULTS,
+    defaults_process=DEFAULTS_PROCESS,
+    user_id=True
+)
 @subtask_wrapper
 def shape_reducer_hdbscan(data_by_tool, **kwargs):
     '''Cluster a shape by tool using HDBSCAN

--- a/panoptes_aggregation/reducers/slider_reducer.py
+++ b/panoptes_aggregation/reducers/slider_reducer.py
@@ -1,7 +1,7 @@
 '''
 Slider Reducer
 --------------
-This module porvides functions to reduce the slider task extracts from
+This module provides functions to reduce the slider task extracts from
 :mod:`panoptes_aggregation.extractors.slider_extractor`.
 '''
 from .reducer_wrapper import reducer_wrapper

--- a/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
@@ -8,6 +8,7 @@ def subtask_wrapper(func):
     @wraps(func)
     def wrapper(data, **kwargs):
         details_functions = kwargs.pop('details', None)
+        user_id = kwargs.pop('user_id', None)
         # data_in is the list of original extracts
         # data is the `processed` data_in
         data_in = kwargs.pop('data_in', None)
@@ -39,7 +40,9 @@ def subtask_wrapper(func):
                                             detail_reduced.append('No reducer for this subtask type')
                                         else:
                                             reducer = reducers.reducers[details_functions[df][ddx]]
-                                            detail_reduced.append(reducer(detail, no_version=True))
+                                            detail_reduced.append(
+                                                reducer(detail, no_version=True, user_id=user_id)
+                                            )
                                     output[frame_key].setdefault(kc, []).append(detail_reduced)
             elif all(classifier_versions >= version.parse('2.0')):
                 # classifier version 2.0 and up
@@ -61,7 +64,9 @@ def subtask_wrapper(func):
                                 if label > -1:
                                     subtask_cluster = subtask_array[cluster_labels == label]
                                     reducer = reducers.reducers[details_functions[subtask]]
-                                    subtask_reduced.append(reducer(subtask_cluster, no_version=True))
+                                    subtask_reduced.append(
+                                        reducer(subtask_cluster, no_version=True, user_id=user_id)
+                                    )
                             frame['{0}_clusters'.format(subtask)] = subtask_reduced
                 output['classifier_version'] = str(classifier_versions.max())
             else:

--- a/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/subtask_reducer_wrapper.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import numpy as np
+from collections import defaultdict
 from panoptes_aggregation import reducers
 from packaging import version
 
@@ -8,7 +9,7 @@ def subtask_wrapper(func):
     @wraps(func)
     def wrapper(data, **kwargs):
         details_functions = kwargs.pop('details', None)
-        user_id = kwargs.pop('user_id', None)
+        user_id = np.array(kwargs.pop('user_id', []))
         # data_in is the list of original extracts
         # data is the `processed` data_in
         data_in = kwargs.pop('data_in', None)
@@ -20,20 +21,25 @@ def subtask_wrapper(func):
                 keys_details = ['{0}_details'.format(k) for k in details_functions.keys()]
                 keys_labels = ['{0}_cluster_labels'.format(k) for k in details_functions.keys()]
                 keys_clusters = ['{0}_clusters_details'.format(k) for k in details_functions.keys()]
-                for extract in data_in:
+                user_ids_per_subtask = defaultdict(lambda: defaultdict(list))
+                for edx, extract in enumerate(data_in):
                     for frame_key, frame in extract.items():
                         for k in keys_details:
                             output[frame_key].setdefault(k, [])
                             if k in frame:
                                 output[frame_key][k] += frame[k]
+                                user_ids_per_subtask[frame_key][k] += [user_id[edx]] * len(frame[k])
                 for frame_key, _frame in output.items():
                     for kd, kl, kc, df in zip(keys_details, keys_labels, keys_clusters, details_functions.keys()):
                         detail_array = np.array(output[frame_key][kd])
+                        user_id_array = np.array(user_ids_per_subtask[frame_key][kd])
                         if kl in output[frame_key]:
                             cluster_labels = np.array(output[frame_key][kl])
                             for label in np.unique(cluster_labels):
                                 if label > -1:
-                                    detail_cluster = detail_array[cluster_labels == label]
+                                    cdx = cluster_labels == label
+                                    detail_cluster = detail_array[cdx]
+                                    user_id_cluster = user_id_array[cdx]
                                     detail_reduced = []
                                     for ddx, detail in enumerate(detail_cluster.T):
                                         if details_functions[df][ddx] is None:
@@ -41,31 +47,36 @@ def subtask_wrapper(func):
                                         else:
                                             reducer = reducers.reducers[details_functions[df][ddx]]
                                             detail_reduced.append(
-                                                reducer(detail, no_version=True, user_id=user_id)
+                                                reducer(detail, no_version=True, user_id=user_id_cluster)
                                             )
                                     output[frame_key].setdefault(kc, []).append(detail_reduced)
             elif all(classifier_versions >= version.parse('2.0')):
                 # classifier version 2.0 and up
-                for extract in data_in:
+                user_ids_per_subtask = defaultdict(lambda: defaultdict(list))
+                for edx, extract in enumerate(data_in):
                     for frame_key, frame in extract.items():
                         for k in details_functions.keys():
                             output[frame_key].setdefault(k, [])
                             if k in frame:
                                 output[frame_key][k] += frame[k]
-                for frame in output.values():
+                                user_ids_per_subtask[frame_key][k] += [user_id[edx]] * len(frame[k])
+                for frame_key, frame in output.items():
                     unique_tools = set(['_'.join(k.split('_')[:2]) for k in frame.keys()])
                     for tool in unique_tools:
                         subtasks = [k for k in details_functions.keys() if k.startswith(tool)]
                         for subtask in subtasks:
                             cluster_labels = np.array(frame['{0}_cluster_labels'.format(tool)])
                             subtask_array = np.array(frame[subtask])
+                            user_id_array = np.array(user_ids_per_subtask[frame_key][subtask])
                             subtask_reduced = []
                             for label in np.unique(cluster_labels):
                                 if label > -1:
-                                    subtask_cluster = subtask_array[cluster_labels == label]
+                                    cdx = cluster_labels == label
+                                    subtask_cluster = subtask_array[cdx]
+                                    user_id_cluster = user_id_array[cdx]
                                     reducer = reducers.reducers[details_functions[subtask]]
                                     subtask_reduced.append(
-                                        reducer(subtask_cluster, no_version=True, user_id=user_id)
+                                        reducer(subtask_cluster, no_version=True, user_id=user_id_cluster)
                                     )
                             frame['{0}_clusters'.format(subtask)] = subtask_reduced
                 output['classifier_version'] = str(classifier_versions.max())

--- a/panoptes_aggregation/reducers/utilities.py
+++ b/panoptes_aggregation/reducers/utilities.py
@@ -1,4 +1,4 @@
-'''Unility used for transforming a list of extracted data for use in tests'''
+'''Utility used for transforming a list of extracted data for use in tests'''
 import copy
 
 

--- a/panoptes_aggregation/tests/reducer_tests/base_test_class.py
+++ b/panoptes_aggregation/tests/reducer_tests/base_test_class.py
@@ -111,6 +111,7 @@ def ReducerTestNoProcessing(
     reduced,
     name,
     kwargs={},
+    network_kwargs={},
     test_name=None
 ):
     class ReducerTestNoProcessing(unittest.TestCase):
@@ -128,14 +129,14 @@ def ReducerTestNoProcessing(
 
         def test_reducer(self):
             '''Test the offline reducer'''
-            result = reducer(self.extracted_with_version, **kwargs)
+            result = reducer(self.extracted_with_version, **kwargs, **network_kwargs)
             self.assertDictEqual(cast_to_dict(result), self.reduced_with_version)
 
         @unittest.skipIf(OFFLINE, 'Installed in offline mode')
         def test_request(self):
             '''Test the online reducer'''
             request_kwargs = {
-                'data': json.dumps(extract_in_data(self.extracted_with_version)),
+                'data': json.dumps(extract_in_data(self.extracted_with_version, **network_kwargs)),
                 'content_type': 'application/json'
             }
             app = flask.Flask(__name__)
@@ -220,6 +221,7 @@ def ReducerTestPoints(
     reduced,
     name,
     kwargs={},
+    network_kwargs={},
     atol=2,
     test_name=None
 ):
@@ -260,17 +262,17 @@ def ReducerTestPoints(
 
         def test_original_reducer(self):
             '''Test the reducer function starting with the processed data'''
-            result = reducer._original(self.processed, **kwargs)
+            result = reducer._original(self.processed, **kwargs, **network_kwargs)
             self.assertPoints(result, self.reduced)
 
         def test_reducer(self):
             '''Test the offline reducer'''
-            result = reducer(self.extracted_with_version, **kwargs)
+            result = reducer(self.extracted_with_version, **kwargs, **network_kwargs)
             self.assertPoints(result, self.reduced_with_version)
 
         def test_keys(self):
             '''Test the keys match up'''
-            result = reducer(self.extracted_with_version, **kwargs)
+            result = reducer(self.extracted_with_version, **kwargs, **network_kwargs)
             for i in self.reduced_with_version.keys():
                 with self.subTest(i=i):
                     self.assertIn(i, result)
@@ -284,7 +286,7 @@ def ReducerTestPoints(
             '''Test the online reducer'''
             app = flask.Flask(__name__)
             request_kwargs = {
-                'data': json.dumps(extract_in_data(self.extracted_with_version)),
+                'data': json.dumps(extract_in_data(self.extracted_with_version, **network_kwargs)),
                 'content_type': 'application/json'
             }
             if len(kwargs) > 0:

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer_dbscan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer_dbscan.py
@@ -29,6 +29,14 @@ extracted_data = [
         }
     }
 ]
+
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2
+    ]
+}
+
 processed_data = {
     'frame0': {
         'tool1': [tuple(z) for z in list(xy)],
@@ -60,6 +68,7 @@ TestPointsCluster = ReducerTestPoints(
     processed_data,
     reduced_data,
     'Test point reducer DBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'eps': 5,
         'min_samples': 3
@@ -76,6 +85,11 @@ extracted_data_one_point = [
         }
     }
 ]
+kwargs_extra_data_one_point = {
+    'user_id': [
+        1
+    ]
+}
 processed_data_one_point = {
     'frame0': {
         'tool1': [(0, 0)]
@@ -102,6 +116,7 @@ TestOnePointCluster = ReducerTestPoints(
     processed_data_one_point,
     reduced_data_one_point,
     'Test point reducer DBSCAN with one data point',
+    network_kwargs=kwargs_extra_data_one_point,
     kwargs={
         'eps': 5,
         'min_samples': 1

--- a/panoptes_aggregation/tests/reducer_tests/test_point_reducer_hdbscan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_point_reducer_hdbscan.py
@@ -29,6 +29,14 @@ extracted_data = [
         }
     }
 ]
+
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2
+    ]
+}
+
 processed_data = {
     'frame0': {
         'tool1': [tuple(z) for z in list(xy)],
@@ -87,6 +95,7 @@ TestPointsCluster = ReducerTestPoints(
     processed_data,
     reduced_data,
     'Test point reducer HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'min_cluster_size': 5,
         'min_samples': 3

--- a/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_rectangle_reducer.py
@@ -53,6 +53,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'frame0': {
         'T0_tool0': [
@@ -128,6 +138,7 @@ TestRectReducer = ReducerTest(
     processed_data,
     reduced_data,
     'Test rectangle reducer',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'eps': 5,
         'min_samples': 2
@@ -161,6 +172,13 @@ extracted_data_sw = [
         }
     }
 ]
+
+kwargs_extra_data_sw = {
+    'user_id': [
+        1,
+        2
+    ]
+}
 
 processed_data_sw = {
     'frame0': {
@@ -207,6 +225,7 @@ TestSWRectReducer = ReducerTest(
     processed_data_sw,
     reduced_data_sw,
     'Test SW rectangle reducer',
+    network_kwargs=kwargs_extra_data_sw,
     kwargs={
         'eps': 5,
         'min_samples': 2

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_circle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_circle.py
@@ -48,6 +48,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'circle',
     'symmetric': False,
@@ -118,6 +128,7 @@ TestShapeReducerCircle = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape circle reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'circle'},
     kwargs={
         'eps': 5,
@@ -142,6 +153,7 @@ TestShapeReducerCircleHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape circle reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'circle'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_column.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_column.py
@@ -41,6 +41,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'column',
     'symmetric': False,
@@ -104,6 +114,7 @@ TestShapeReducerColumn = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape column reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'column'},
     kwargs={
         'eps': 5,
@@ -128,6 +139,7 @@ TestShapeReducerColumnHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape column reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'column'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_ellipse.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_ellipse.py
@@ -62,6 +62,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'ellipse',
     'symmetric': False,
@@ -146,6 +156,7 @@ TestShapeReducerEllipse = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape ellipse reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'ellipse'},
     kwargs={
         'eps': 5,
@@ -170,6 +181,7 @@ TestShapeReducerEllipseHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape ellipse reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'ellipse'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_fan.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_fan.py
@@ -62,6 +62,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'fan',
     'symmetric': False,
@@ -146,6 +156,7 @@ TestShapeReducerFan = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape fan reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'fan'},
     kwargs={
         'eps': 5,
@@ -170,6 +181,7 @@ TestShapeReducerFanHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape fan reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'fan'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_height_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_height_line.py
@@ -34,6 +34,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'fullHeightLine',
     'symmetric': False,
@@ -88,6 +98,7 @@ TestShapeReducerFullHeightLine = ReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test shape fullHeightLine reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'eps': 5,
         'min_samples': 2,
@@ -110,6 +121,7 @@ TestShapeReducerFullHeightLineHdbscan = ReducerTestNoProcessing(
     extracted_data,
     reduced_data_hdbscan,
     'Test shape fullHeightLine reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'min_cluster_size': 2,
         'min_samples': 1,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_width_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_full_width_line.py
@@ -34,6 +34,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'fullWidthLine',
     'symmetric': False,
@@ -88,6 +98,7 @@ TestShapeReducerFullWidthLine = ReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test shape fullWidthLine reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'eps': 5,
         'min_samples': 2,
@@ -110,6 +121,7 @@ TestShapeReducerFullWidthLineHdbscan = ReducerTestNoProcessing(
     extracted_data,
     reduced_data_hdbscan,
     'Test shape fullWidthLine reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'min_cluster_size': 2,
         'min_samples': 1,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_line.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_line.py
@@ -55,6 +55,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'line',
     'symmetric': False,
@@ -128,6 +138,7 @@ TestShapeReducerLine = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape line reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'line'},
     kwargs={
         'eps': 5,
@@ -213,6 +224,7 @@ TestShapeReducerLineSymmetric = ReducerTest(
     processed_data_symmetric,
     reduced_data_symmetric,
     'Test shape line reducer with DBSCAN with symmetries',
+    network_kwargs=kwargs_extra_data,
     pkwargs={
         'shape': 'line',
         'symmetric': True
@@ -247,6 +259,7 @@ TestShapeReducerLineHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape line reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'line'},
     kwargs={
         'min_cluster_size': 2,
@@ -272,6 +285,7 @@ TestShapeReducerLineHdbscanSymmetric = ReducerTest(
     processed_data_symmetric,
     reduced_data_hdbscan_symmetric,
     'Test shape line reducer with HDBSCAN with symmetries',
+    network_kwargs=kwargs_extra_data,
     pkwargs={
         'shape': 'line',
         'symmetric': True

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_point.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_point.py
@@ -41,6 +41,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'point',
     'symmetric': False,
@@ -104,6 +114,7 @@ TestShapeReducerPoint = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape point reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'point'},
     kwargs={
         'eps': 5,
@@ -128,6 +139,7 @@ TestShapeReducerPointHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape point reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'point'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rectangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rectangle.py
@@ -55,6 +55,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'rectangle',
     'symmetric': False,
@@ -132,6 +142,7 @@ TestShapeReducerRectangle = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape rectangle reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'rectangle'},
     kwargs={
         'eps': 5,
@@ -156,6 +167,7 @@ TestShapeReducerRectangleHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape rectangle reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'rectangle'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rotate_rectangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_rotate_rectangle.py
@@ -62,6 +62,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'rotateRectangle',
     'symmetric': False,
@@ -146,6 +156,7 @@ TestShapeReducerRotateRectangle = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape rotateRectangle reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'rotateRectangle'},
     kwargs={
         'eps': 5,
@@ -170,6 +181,7 @@ TestShapeReducerRotateRectangleHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape rotateRectangle reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'rotateRectangle'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_triangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_triangle.py
@@ -55,6 +55,16 @@ extracted_data = [
     {}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}
+
 processed_data = {
     'shape': 'triangle',
     'symmetric': False,
@@ -132,6 +142,7 @@ TestShapeReducerTriangle = ReducerTest(
     processed_data,
     reduced_data,
     'Test shape triangle reducer with DBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'triangle'},
     kwargs={
         'eps': 5,
@@ -156,6 +167,7 @@ TestShapeReducerTriangleHdbscan = ReducerTest(
     processed_data,
     reduced_data_hdbscan,
     'Test shape triangle reducer with HDBSCAN',
+    network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'triangle'},
     kwargs={
         'min_cluster_size': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer.py
@@ -80,6 +80,14 @@ extracted_data = [
     }
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3
+    ]
+}
+
 reduced_data = {
     'frame0': {
         'T0_tool0_rec_x': [0.0, 100.0, 0.0, 100.0],
@@ -174,6 +182,7 @@ TestSubtaskReducer = ReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test subtask reducer',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'eps': 5,
         'min_samples': 2,

--- a/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_subtask_reducer_v2.py
@@ -91,6 +91,14 @@ extracted_data = [
     }
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2,
+        3
+    ]
+}
+
 reduced_data = {
     'classifier_version': '2.0',
     'frame0': {
@@ -190,6 +198,7 @@ TestSubtaskReducerV2 = ReducerTestNoProcessing(
     extracted_data,
     reduced_data,
     'Test subtask reducer with classifier v2 extracts',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'shape': 'point',
         'eps': 5,
@@ -226,6 +235,7 @@ TestSubtaskReducerV2NoDetails = ReducerTestNoProcessing(
     extracted_data,
     reduced_data_no_details,
     'Test subtask reducer with classifier v2 extracts',
+    network_kwargs=kwargs_extra_data,
     kwargs={
         'shape': 'point',
         'eps': 5,

--- a/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer.py
@@ -18,6 +18,7 @@ extracted_data = [
             }]
         ]
     }},
+    {},
     {'frame0': {
         'T0_tool0_x': [0.0, 100.0],
         'T0_tool0_y': [0.0, 100.0],
@@ -39,6 +40,7 @@ extracted_data = [
 kwargs_extra_data = {
     'user_id': [
         1,
+        3,
         2
     ]
 }

--- a/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer.py
@@ -1,4 +1,4 @@
-from panoptes_aggregation.reducers.rectangle_reducer import rectangle_reducer
+from panoptes_aggregation.reducers.shape_reducer_dbscan import shape_reducer_dbscan
 from .base_test_class import ReducerTestNoProcessing
 
 extracted_data = [
@@ -36,12 +36,19 @@ extracted_data = [
     }}
 ]
 
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2
+    ]
+}
+
 reduced_data = {
     'frame0': {
-        'T0_tool0_rec_x': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_rec_y': [0.0, 100.0, 0.0, 100.0],
-        'T0_tool0_rec_width': [50.0, 10.0, 50.0, 10.0],
-        'T0_tool0_rec_height': [20.0, 8.0, 20.0, 8.0],
+        'T0_tool0_rectangle_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_rectangle_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_rectangle_width': [50.0, 10.0, 50.0, 10.0],
+        'T0_tool0_rectangle_height': [20.0, 8.0, 20.0, 8.0],
         'T0_tool0_cluster_labels': [0, 1, 0, 1],
         'T0_tool0_clusters_count': [2, 2],
         'T0_tool0_clusters_x': [0.0, 100.0],
@@ -97,20 +104,18 @@ reduced_data = {
 }
 
 TestTextSubtaskReducer = ReducerTestNoProcessing(
-    rectangle_reducer,
+    shape_reducer_dbscan,
     extracted_data,
     reduced_data,
     'Test text subtask reducer',
+    network_kwargs=kwargs_extra_data,
     kwargs={
+        'shape': 'rectangle',
         'eps': 5,
         'min_samples': 2,
         'details': {
             'T0_tool0': ['text_reducer']
-        },
-        'user_id': [
-            1,
-            2
-        ]
+        }
     },
     test_name='TestTextSubtaskReducer'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer_v2.py
@@ -19,6 +19,7 @@ extracted_data = [
             ]
         }
     },
+    {'classifier_version': '2.0'},
     {
         'classifier_version': '2.0',
         'frame0': {
@@ -41,6 +42,7 @@ extracted_data = [
 kwargs_extra_data = {
     'user_id': [
         1,
+        3,
         2
     ]
 }

--- a/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer_v2.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reducer_v2.py
@@ -1,0 +1,120 @@
+from panoptes_aggregation import reducers
+from .base_test_class import ReducerTestNoProcessing
+
+extracted_data = [
+    {
+        'classifier_version': '2.0',
+        'frame0': {
+            'T0_tool0_x': [0.0, 100.0],
+            'T0_tool0_y': [0.0, 100.0],
+            'T0_tool0_subtask0': [
+                {
+                    'text': 'this is some test text',
+                    'gold_standard': True
+                },
+                {
+                    'text': 'more text',
+                    'gold_standard': True
+                }
+            ]
+        }
+    },
+    {
+        'classifier_version': '2.0',
+        'frame0': {
+            'T0_tool0_x': [0.0, 100.0],
+            'T0_tool0_y': [0.0, 100.0],
+            'T0_tool0_subtask0': [
+                {
+                    'text': 'this is some text text',
+                    'gold_standard': False
+                },
+                {
+                    'text': 'more test',
+                    'gold_standard': False
+                }
+            ]
+        }
+    }
+]
+
+kwargs_extra_data = {
+    'user_id': [
+        1,
+        2
+    ]
+}
+
+reduced_data = {
+    'classifier_version': '2.0',
+    'frame0': {
+        'T0_tool0_point_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_point_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_cluster_labels': [0, 1, 0, 1],
+        'T0_tool0_clusters_count': [2, 2],
+        'T0_tool0_clusters_x': [0.0, 100.0],
+        'T0_tool0_clusters_y': [0.0, 100.0],
+        'T0_tool0_subtask0': [
+            {
+                'text': 'this is some test text',
+                'gold_standard': True
+            },
+            {
+                'text': 'more text',
+                'gold_standard': True
+            },
+            {
+                'text': 'this is some text text',
+                'gold_standard': False
+            },
+            {
+                'text': 'more test',
+                'gold_standard': False
+            }
+        ],
+        'T0_tool0_subtask0_clusters': [
+            {
+                'aligned_text': [
+                    ['this', 'this'],
+                    ['is', 'is'],
+                    ['some', 'some'],
+                    ['test', 'text'],
+                    ['text', 'text']
+                ],
+                'number_views': 2,
+                'consensus_score': 1.8,
+                'consensus_text': 'this is some test text',
+                'gold_standard': [True, False],
+                'user_ids': [1, 2]
+            },
+            {
+                'aligned_text': [
+                    ['more', 'more'],
+                    ['text', 'test']
+                ],
+                'number_views': 2,
+                'consensus_score': 1.5,
+                'consensus_text': 'more text',
+                'gold_standard': [True, False],
+                'user_ids': [1, 2]
+            }
+        ]
+    }
+}
+
+TestTextSubtaskReducerV2 = ReducerTestNoProcessing(
+    reducers.shape_reducer_dbscan,
+    extracted_data,
+    reduced_data,
+    'Test text subtask reducer with classifier v2 extracts',
+    network_kwargs=kwargs_extra_data,
+    kwargs={
+        'shape': 'point',
+        'eps': 5,
+        'min_samples': 2,
+        'details': {
+            'T0_tool0_subtask0': 'text_reducer'
+        }
+    },
+    test_name='TestTextSubtaskReducerV2'
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reduction.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_text_subtask_reduction.py
@@ -1,0 +1,116 @@
+from panoptes_aggregation.reducers.rectangle_reducer import rectangle_reducer
+from .base_test_class import ReducerTestNoProcessing
+
+extracted_data = [
+    {'frame0': {
+        'T0_tool0_x': [0.0, 100.0],
+        'T0_tool0_y': [0.0, 100.0],
+        'T0_tool0_width': [50.0, 10.0],
+        'T0_tool0_height': [20.0, 8.0],
+        'T0_tool0_details': [
+            [{
+                'text': 'this is some test text',
+                'gold_standard': True
+            }],
+            [{
+                'text': 'more text',
+                'gold_standard': True
+            }]
+        ]
+    }},
+    {'frame0': {
+        'T0_tool0_x': [0.0, 100.0],
+        'T0_tool0_y': [0.0, 100.0],
+        'T0_tool0_width': [50.0, 10.0],
+        'T0_tool0_height': [20.0, 8.0],
+        'T0_tool0_details': [
+            [{
+                'text': 'this is some text text',
+                'gold_standard': False
+            }],
+            [{
+                'text': 'more test',
+                'gold_standard': False
+            }]
+        ]
+    }}
+]
+
+reduced_data = {
+    'frame0': {
+        'T0_tool0_rec_x': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_rec_y': [0.0, 100.0, 0.0, 100.0],
+        'T0_tool0_rec_width': [50.0, 10.0, 50.0, 10.0],
+        'T0_tool0_rec_height': [20.0, 8.0, 20.0, 8.0],
+        'T0_tool0_cluster_labels': [0, 1, 0, 1],
+        'T0_tool0_clusters_count': [2, 2],
+        'T0_tool0_clusters_x': [0.0, 100.0],
+        'T0_tool0_clusters_y': [0.0, 100.0],
+        'T0_tool0_clusters_width': [50.0, 10.0],
+        'T0_tool0_clusters_height': [20.0, 8.0],
+        'T0_tool0_details': [
+            [{
+                'text': 'this is some test text',
+                'gold_standard': True
+            }],
+            [{
+                'text': 'more text',
+                'gold_standard': True
+            }],
+            [{
+                'text': 'this is some text text',
+                'gold_standard': False
+            }],
+            [{
+                'text': 'more test',
+                'gold_standard': False
+            }]
+        ],
+        'T0_tool0_clusters_details': [
+            [{
+                'aligned_text': [
+                    ['this', 'this'],
+                    ['is', 'is'],
+                    ['some', 'some'],
+                    ['test', 'text'],
+                    ['text', 'text']
+                ],
+                'number_views': 2,
+                'consensus_score': 1.8,
+                'consensus_text': 'this is some test text',
+                'gold_standard': [True, False],
+                'user_ids': [1, 2]
+            }],
+            [{
+                'aligned_text': [
+                    ['more', 'more'],
+                    ['text', 'test']
+                ],
+                'number_views': 2,
+                'consensus_score': 1.5,
+                'consensus_text': 'more text',
+                'gold_standard': [True, False],
+                'user_ids': [1, 2]
+            }]
+        ]
+    }
+}
+
+TestTextSubtaskReducer = ReducerTestNoProcessing(
+    rectangle_reducer,
+    extracted_data,
+    reduced_data,
+    'Test text subtask reducer',
+    kwargs={
+        'eps': 5,
+        'min_samples': 2,
+        'details': {
+            'T0_tool0': ['text_reducer']
+        },
+        'user_id': [
+            1,
+            2
+        ]
+    },
+    test_name='TestTextSubtaskReducer'
+)


### PR DESCRIPTION
Fixes #280 

This PR make sure `user_id` information is passed along to the subtasks of all shape reducers.  This information is required for text subtasks to work.

Also fixed typos in doc strings of any file that was updated.