### PR TITLE
Fix `PanoptesAPIException` Could not find user error

### DIFF
--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -1,8 +1,9 @@
 from importlib import import_module
 
 from unittest.mock import MagicMock, PropertyMock, Mock, patch
-from nose.tools import assert_equal, assert_raises, assert_count_equal
+from nose.tools import assert_equal, assert_raises, assert_count_equal, assert_is_instance
 from panoptes_client import Panoptes, User
+from panoptes_client.panoptes import PanoptesAPIException
 import requests
 
 import os
@@ -118,6 +119,15 @@ def test_retrieve_user():
     assert_equal(found_user, mock_user1)
     assert_equal(found_user.id, 1)
     (User.find).assert_not_called()
+
+
+def test_retrieve_user_error():
+    # simulate User.find raising a PanoptesAPIException
+    Panoptes.connect = Mock()
+    User.find = MagicMock(side_effect=[PanoptesAPIException('test')])
+    found_user = panoptes._retrieve_user(10)
+    assert_is_instance(found_user, panoptes.CantFindUser)
+    assert_equal(found_user.id, 10)
 
 
 def test_discover_user_ids():


### PR DESCRIPTION
Handle the `PanoptesAPIException` gracefully and pass "None" for all values typically filled with user information.  The user ID will still show up in the look up dictionary to avoid this looking like an error down the line.

This will clean up https://sentry.io/organizations/zooniverse-27/issues/1652615193/?project=1760084&query=is%3Aunresolved