### PR TITLE
Added extractor and reducer for use (initially) with Radio Galaxy Zoo: LOFAR

### DIFF
--- a/docs/source/extractors.rst
+++ b/docs/source/extractors.rst
@@ -76,5 +76,5 @@ Extractors
 
 ----
 
-.. automodule:: panoptes_aggregation.extractors.nfn_extractor
+.. automodule:: panoptes_aggregation.extractors.all_tasks_empty_extractor
   :members:

--- a/docs/source/extractors.rst
+++ b/docs/source/extractors.rst
@@ -76,5 +76,10 @@ Extractors
 
 ----
 
+.. automodule:: panoptes_aggregation.extractors.nfn_extractor
+  :members:
+
+----
+
 .. automodule:: panoptes_aggregation.extractors.all_tasks_empty_extractor
   :members:

--- a/docs/source/reducers.rst
+++ b/docs/source/reducers.rst
@@ -88,3 +88,8 @@ Reducers
 
 .. automodule:: panoptes_aggregation.reducers.text_reducer
   :members:
+
+----
+
+.. automodule:: panoptes_aggregation.reducers.first_n_true_reducer
+  :members:

--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -14,6 +14,7 @@ from .slider_extractor import slider_extractor
 from .nfn_extractor import nfn_extractor
 from .i2a_extractor import i2a_extractor
 from .text_extractor import text_extractor
+from .all_tasks_empty_extractor import all_tasks_empty_extractor
 from ..copy_function import copy_function
 
 shortcut_extractor = copy_function(question_extractor, 'shortcut_extractor')
@@ -35,5 +36,6 @@ extractors = {
     'slider_extractor': slider_extractor,
     'i2a_extractor': i2a_extractor,
     'nfn_extractor': nfn_extractor,
-    'text_extractor': text_extractor
+    'text_extractor': text_extractor,
+    'all_tasks_empty_extractor': all_tasks_empty_extractor
 }

--- a/panoptes_aggregation/extractors/all_tasks_empty_extractor.py
+++ b/panoptes_aggregation/extractors/all_tasks_empty_extractor.py
@@ -1,0 +1,31 @@
+"""
+All Tasks Empty Extractor
+-------------------
+Extractor determines whether all task values are empty.
+"""
+from .extractor_wrapper import extractor_wrapper
+import numpy as np
+
+
+@extractor_wrapper()
+def all_tasks_empty_extractor(classification, **kwargs):
+    """Determine whether all task values in a classification are empty.
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing an `annotations` key that is a list of
+        panoptes annotations
+
+    Returns
+    -------
+    extraction : dict
+        `extraction["result"]` is `True` if all task values are `None`. `False`
+        otherwise.
+    """
+    empty_or_absent_value = [
+        task["value"] is None if "value" in task else True
+        for task in classification["annotations"]
+    ]
+
+    return {"result": len(empty_or_absent_value) == 0 or np.all(empty_or_absent_value)}

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -15,6 +15,7 @@ from .tess_reducer_column import tess_reducer_column
 from .tess_gold_standard_reducer import tess_gold_standard_reducer
 from .text_reducer import text_reducer
 from .optics_line_text_reducer import optics_line_text_reducer
+from .first_n_true_reducer import first_n_true_reducer
 from ..copy_function import copy_function
 
 shortcut_reducer = copy_function(question_reducer, 'shortcut_reducer')
@@ -36,5 +37,6 @@ reducers = {
     'slider_reducer': slider_reducer,
     'tess_reducer_column': tess_reducer_column,
     'tess_gold_standard_reducer': tess_gold_standard_reducer,
-    'text_reducer': text_reducer
+    'text_reducer': text_reducer,
+    'first_n_true_reducer' : first_n_true_reducer
 }

--- a/panoptes_aggregation/reducers/first_n_true_reducer.py
+++ b/panoptes_aggregation/reducers/first_n_true_reducer.py
@@ -5,7 +5,6 @@ This module is designed to reduce boolean-valued extracts e.g.
 :mod:`panoptes_aggregation.extractors.all_tasks_empty_extractor`.
 It returns true if and only if the first N extracts are `True`.
 """
-from collections import Counter
 from .reducer_wrapper import reducer_wrapper
 import numpy as np
 

--- a/panoptes_aggregation/reducers/first_n_true_reducer.py
+++ b/panoptes_aggregation/reducers/first_n_true_reducer.py
@@ -12,8 +12,6 @@ DEFAULTS = {"n": {"default": 0, "type": int}}
 
 
 def extractResultKey(extract):
-    if not isinstance(extract, dict):
-        return False
     return extract["result"] if "result" in extract else False
 
 

--- a/panoptes_aggregation/reducers/first_n_true_reducer.py
+++ b/panoptes_aggregation/reducers/first_n_true_reducer.py
@@ -1,0 +1,44 @@
+"""
+First N True Reducer
+----------------
+This module is designed to reduce boolean-valued extracts e.g.
+:mod:`panoptes_aggregation.extractors.all_tasks_empty_extractor`.
+It returns true if and only if the first N extracts are `True`.
+"""
+from collections import Counter
+from .reducer_wrapper import reducer_wrapper
+import numpy as np
+
+DEFAULTS = {"n": {"default": 0, "type": int}}
+
+
+def extractResultKey(extract):
+    if not isinstance(extract, dict):
+        return False
+    return extract["result"] if "result" in extract else False
+
+
+@reducer_wrapper(defaults_data=DEFAULTS)
+def first_n_true_reducer(data_list, n=0, **kwargs):
+    """Reduce a list of boolean values to a single boolean value.
+
+    Parameters
+    ----------
+    data_list : list
+        A list of dicts containing a "result" key which should correspond with a
+        boolean value.
+
+    n: int
+        The first n results in `data_list` must be `True`.
+
+    Returns
+    -------
+    reduction : dict
+        `reduction["result"]` is `True` if the first n results in `data_list`
+        are `True`. Otherwise `False`.
+    """
+    return {
+        "result": n > 0
+        and len(data_list) >= n
+        and np.all(list(map(extractResultKey, data_list[:n])))
+    }

--- a/panoptes_aggregation/tests/extractor_tests/test_all_tasks_empty_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_all_tasks_empty_extractor.py
@@ -1,0 +1,95 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+no_empty_classification = {
+    "annotations": [
+        {"task": "T0", "task_label": "A single question", "value": "Yes"},
+        {"task": "T1", "task_label": "A multi question", "value": ["Blue", "Green"]},
+        {
+            "task": "T2",
+            "value": [
+                {
+                    "frame": 0,
+                    "tool": 0,
+                    "y": 202.87478637695312,
+                    "details": [],
+                    "x": 452.18341064453125,
+                },
+                {
+                    "frame": 0,
+                    "tool": 1,
+                    "y": 583.4398803710938,
+                    "details": [],
+                    "x": 404.61279296875,
+                },
+            ],
+        },
+    ]
+}
+
+no_empty_expected = {"result": False}
+
+TestNoEmpty = ExtractorTest(
+    extractors.all_tasks_empty_extractor,
+    no_empty_classification,
+    no_empty_expected,
+    "Test for zero empty task values",
+    test_name="TestNoEmpty",
+    blank_extract={"result": True},
+)
+
+some_empty_classification = {
+    "annotations": [
+        {"task": "T0", "task_label": "A single question", "value": "Yes"},
+        {"task": "T1", "task_label": "A multi question", "value": None},
+        {
+            "task": "T2",
+            "value": [
+                {
+                    "frame": 0,
+                    "tool": 0,
+                    "y": 202.87478637695312,
+                    "details": [],
+                    "x": 452.18341064453125,
+                },
+                {
+                    "frame": 0,
+                    "tool": 1,
+                    "y": 583.4398803710938,
+                    "details": [],
+                    "x": 404.61279296875,
+                },
+            ],
+        },
+    ]
+}
+
+some_empty_expected = {"result": False}
+
+TestSomeEmpty = ExtractorTest(
+    extractors.all_tasks_empty_extractor,
+    some_empty_classification,
+    some_empty_expected,
+    "Test for some task values populated and some empty",
+    test_name="TestSomeFull",
+    blank_extract={"result": True},
+)
+
+all_empty_classification = {
+    "annotations": [
+        {"task": "T0", "task_label": "A single question", "value": None},
+        {"task": "T1", "task_label": "A multi question", "value": None},
+        {"task": "T2", "value": None},
+    ]
+}
+
+all_empty_expected = {"result": True}
+
+TestAllEmpty = ExtractorTest(
+    extractors.all_tasks_empty_extractor,
+    all_empty_classification,
+    all_empty_expected,
+    "Test for all task values empty",
+    test_name="TestAllEmpty",
+    blank_extract={"result": True},
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_first_n_true_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_first_n_true_reducer.py
@@ -1,0 +1,44 @@
+from panoptes_aggregation.reducers.first_n_true_reducer import first_n_true_reducer
+from .base_test_class import ReducerTestNoProcessing
+
+extracted_data_first_three_true = [
+    {"result": result} for result in [True, True, True, False, False]
+]
+
+extracted_data_three_true = [
+    {"result": result} for result in [True, False, True, False, True]
+]
+
+extracted_data_first_two_true = [
+    {"result": result} for result in [True, True, False, False, False]
+]
+
+reduced_true = {"result": True}
+reduced_false = {"result": False}
+
+FirstThreeTrueTestReducer = ReducerTestNoProcessing(
+    first_n_true_reducer,
+    extracted_data_first_three_true,
+    reduced_true,
+    "Test with first three extracts True",
+    kwargs={"n": 3},
+    test_name="FirstThreeTrueTestReducer",
+)
+
+ThreeTrueTestReducer = ReducerTestNoProcessing(
+    first_n_true_reducer,
+    extracted_data_three_true,
+    reduced_false,
+    "Test with any three extracts True",
+    kwargs={"n": 3},
+    test_name="ThreeTrueTestReducer",
+)
+
+FirstTwoTrueTestReducer = ReducerTestNoProcessing(
+    first_n_true_reducer,
+    extracted_data_first_two_true,
+    reduced_false,
+    "Test with first three extracts True",
+    kwargs={"n": 3},
+    test_name="FirstTwoTrueTestReducer",
+)


### PR DESCRIPTION
`all_tasks_empty_extractor` returns True if and only if all tasks for a classification are empty.
`first_n_true_reducer` returns True if and only the first N extracts for an entity are True.

In combination these enable early retirement for subjects if and only if the first N classifications have null responses for all tasks.

Tests for the new extractor and reducer have also been implemented and pass.
