### PR TITLE
Fix blank dropdown reducer

### DIFF
--- a/panoptes_aggregation/reducers/dropdown_reducer.py
+++ b/panoptes_aggregation/reducers/dropdown_reducer.py
@@ -28,9 +28,11 @@ def process_data(data):
     data_out = []
     for extract in data:
         values = []
-        for value in extract['value']:
-            values.append(Counter(value))
-        data_out.append(values)
+        if 'value' in extract:
+            # if the task was left blank there will be no "value" key
+            for value in extract['value']:
+                values.append(Counter(value))
+            data_out.append(values)
     return data_out
 
 
@@ -49,9 +51,11 @@ def dropdown_reducer(votes_list):
         A dictionary with one key `value` the contains a list of dictionaries
         (one for each dropdown in the task) giving the vote count for each `key`
     '''
-    value = np.array(votes_list).sum(axis=0).tolist()
-    value = list(map(dict, value))
-    output = {
-        'value': value
-    }
+    output = {}
+    if len(votes_list) > 0:
+        value = np.array(votes_list).sum(axis=0).tolist()
+        value = list(map(dict, value))
+        output = {
+            'value': value
+        }
     return output

--- a/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py
@@ -62,3 +62,22 @@ TestDropdownReducer = ReducerTest(
     processed_type='list',
     test_name='TestDropdownReducer'
 )
+
+# This example comes from an example project where
+# the task in question is not required
+extracted_data_blank = [{}, {}, {}, {}]
+
+processed_data_blank = []
+
+reduced_data_blank = {}
+
+TestDropdownReducerBlank = ReducerTest(
+    dropdown_reducer,
+    process_data,
+    extracted_data_blank,
+    processed_data_blank,
+    reduced_data_blank,
+    'Test dropdown reducer with blank extracts',
+    processed_type='list',
+    test_name='TestDropdownReducerBlank'
+)


### PR DESCRIPTION
# Context
A project was set up with a series of dropdown tasks, and one of them is not `required` and could be left blank.  For several subjects (the majority actually) every volunteer left this task blank (or never saw the task due to a branching question tree), resulting in a set of empty extracts being passed into the dropdown reducer.

# The bug
When running the aggregation code the following error was seen:
```
Traceback (most recent call last):
  File "/Users/coleman/anaconda3/bin/panoptes_aggregation", line 11, in <module>
    load_entry_point('panoptes-aggregation', 'console_scripts', 'panoptes_aggregation')()
  File "/Users/coleman/Desktop/zooniverse/python-reducers-for-caesar/panoptes_aggregation/scripts/aggregation_parser.py", line 295, in main
    cpu_count=args.cpu_count
  File "/Users/coleman/Desktop/zooniverse/python-reducers-for-caesar/panoptes_aggregation/scripts/reduce_panoptes_csv.py", line 209, in reduce_csv
    **apply_keywords
  File "/Users/coleman/Desktop/zooniverse/python-reducers-for-caesar/panoptes_aggregation/scripts/reduce_panoptes_csv.py", line 59, in reduce_subject
    reduction = reducers.reducers[reducer_name](data, user_id=user_ids, **keywords)
  File "/Users/coleman/Desktop/zooniverse/python-reducers-for-caesar/panoptes_aggregation/reducers/reducer_wrapper.py", line 51, in wrapper
    data = process_data(data_in, **kwargs_process)
  File "/Users/coleman/Desktop/zooniverse/python-reducers-for-caesar/panoptes_aggregation/reducers/dropdown_reducer.py", line 31, in process_data
    for value in extract['value']:
KeyError: 'value'
```

## Example input that caused this error
A set of 4 blank extracts were passed into the reducer looks like:
```
[{}, {}, {}, {}]
```
The code was expected each dictionary in the list to have `"value"` as a key.

This exact test case has been added to `panoptes_aggregation/tests/reducer_tests/test_dropdown_reducer.py` and before the fix below this test reproduced the above error message.

# The fix
When processing the extracts check for the existence of the `"value"` key before trying to access it.  As a result, only non-blank extracts are passed along to the reducer.

In the case where all of the extracts are blank a blank reduction is also returned.
