### PR TITLE
Add Notes from Nature extractor for WeDigBio event

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -87,6 +87,14 @@ def earth_day(parser):
         return None
 
 
+def we_dig_bio(parser):
+    date = dateparse(parser.created_at)
+    if (15 <= date.day <= 18) and (date.year == 2020):
+        return True
+    else:
+        return None
+
+
 @extractor_wrapper()
 def nfn_extractor(classification, **kwargs):
     response = {}
@@ -104,5 +112,6 @@ def nfn_extractor(classification, **kwargs):
 
         response['time'] = check_time(parser)
         response['earth_day'] = earth_day(parser)
+        response['we_dig_bio'] = we_dig_bio(parser)
 
     return {k: v for k, v in response.items() if v is not None}

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -89,8 +89,8 @@ def earth_day(parser):
 
 def we_dig_bio(parser):
     date = dateparse(parser.created_at)
-    if (15 <= date.day <= 18) and (date.year == 2020):
-        return True
+    if (date.year == 2020) and (15 <= date.day <= 18):
+        return 2020
     else:
         return None
 

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -155,7 +155,7 @@ expected_we_dig_bio = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
-    "we_dig_bio": True,
+    "we_dig_bio": 2020,
     "country": "United States"
 }
 

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -125,6 +125,49 @@ TestNfNThree = ExtractorTest(
     test_name='TestNfNThree'
 )
 
+classification_we_dig_bio = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2020-10-16T05:30:00.000Z",
+}
+
+expected_we_dig_bio = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "we_dig_bio": True,
+    "country": "United States"
+}
+
+TestNfNWeDigBio = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_we_dig_bio,
+    expected_we_dig_bio,
+    'Test NfN during WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNWeDigBio'
+)
+
 classification_bad_year = {
     "annotations": [
         {


### PR DESCRIPTION
Closes https://github.com/zooniverse/nfn-faas/issues/3.

Background:
The Notes From Nature Field Book (https://field-book.notesfromnature.org/, frontend repo - https://github.com/zooniverse/notes-from-nature-field-book) awards badges to volunteers for classifying based on various criteria, including classification creation time. There's a special event, WeDigBio, that will occur October 15-18, 2020, that a special badge is desired for.

Purpose:
In `nfn_extractor`, this PR adds a `we_dig_bio` extraction response property, similar to `earth_day`, which will return `True` if a classification is created between (and including) October 15-18, 2020.

