### PR TITLE
Update text docs

### DIFF
--- a/panoptes_aggregation/extractors/all_tasks_empty_extractor.py
+++ b/panoptes_aggregation/extractors/all_tasks_empty_extractor.py
@@ -1,6 +1,6 @@
 """
 All Tasks Empty Extractor
--------------------
+-------------------------
 Extractor determines whether all task values are empty.
 """
 from .extractor_wrapper import extractor_wrapper

--- a/panoptes_aggregation/reducers/first_n_true_reducer.py
+++ b/panoptes_aggregation/reducers/first_n_true_reducer.py
@@ -1,6 +1,6 @@
 """
 First N True Reducer
-----------------
+--------------------
 This module is designed to reduce boolean-valued extracts e.g.
 :mod:`panoptes_aggregation.extractors.all_tasks_empty_extractor`.
 It returns true if and only if the first N extracts are `True`.

--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -99,6 +99,7 @@ def optics_line_text_reducer(data_by_frame, **kwargs_optics):
           Note: This will only change the order of the lines.
         * `min_line_length` : The minimum length a transcribed line of text needs to be in order to be used in the reduction.
         * `low_consensus_threshold` : The minimum consensus score allowed to be considered "done".
+        * `minimum_views` : A value that is passed along to the font-end to set when lines should turn grey (has no effect on aggregation)
 
     Returns
     -------

--- a/panoptes_aggregation/reducers/poly_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/poly_line_text_reducer.py
@@ -96,6 +96,7 @@ def poly_line_text_reducer(data_by_frame, **kwargs_dbscan):
           Set this to 1 for all annotations to be kept
         * `min_word_count` : The minimum number of times a word must be identified for it to be kept in the consensus text.
         * `low_consensus_threshold` : The minimum consensus score allowed to be considered "done"
+        * `minimum_views` : A value that is passed along to the font-end to set when lines should turn grey (has no effect on aggregation)
 
     Returns
     -------


### PR DESCRIPTION
Add documentation for `minimum_views` value on the transcription reducers.  This value is passed along to the front-end and has no effect on the reduction results.  I think any further documentation for how the front-end uses this value should belong with the front-end code so can stay up to date if it ever changes.

Happy to link to the documentation from here if a link exists.

Closes #387