### PR TITLE
Refactor Notes from Nature WeDigBio extractor for 2021 events

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -91,6 +91,10 @@ def we_dig_bio(parser):
     date = dateparse(parser.created_at)
     if (date.year == 2020) and (date.month == 10) and (15 <= date.day <= 18):
         return 2020
+    elif (date.year == 2021) and (date.month == 4) and (8 <= date.day <= 11):
+        return 2021
+    elif (date.year == 2021) and (date.month == 10) and (14 <= date.day <= 17):
+        return 2021
     else:
         return None
 

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -89,7 +89,7 @@ def earth_day(parser):
 
 def we_dig_bio(parser):
     date = dateparse(parser.created_at)
-    if (date.year == 2020) and (15 <= date.day <= 18):
+    if (date.year == 2020) and (date.month == 10) and (15 <= date.day <= 18):
         return 2020
     else:
         return None

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -125,7 +125,7 @@ TestNfNThree = ExtractorTest(
     test_name='TestNfNThree'
 )
 
-classification_we_dig_bio = {
+classification_we_dig_bio_october_2020 = {
     "annotations": [{
         "task": "T99",
         "value": [
@@ -151,7 +151,7 @@ classification_we_dig_bio = {
     "created_at": "2020-10-16T05:30:00.000Z",
 }
 
-expected_we_dig_bio = {
+expected_we_dig_bio_october_2020 = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
@@ -159,7 +159,57 @@ expected_we_dig_bio = {
     "country": "United States"
 }
 
-TestNfNWeDigBio = ExtractorTest(
+TestNfNWeDigBioOctober2020 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_we_dig_bio_october_2020,
+    expected_we_dig_bio_october_2020,
+    'Test NfN during October, 2020, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNWeDigBioOctober2020'
+)
+
+classification_not_we_dig_bio_2020 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2020-07-16T05:30:00.000Z",
+}
+
+expected_not_we_dig_bio_2020 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "country": "United States"
+}
+
+TestNfNNotWeDigBio2020 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_not_we_dig_bio_2020,
+    expected_not_we_dig_bio_2020,
+    'Test NfN during 2020, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNNotWeDigBio2020'
+)
+
     extractors.nfn_extractor,
     classification_we_dig_bio,
     expected_we_dig_bio,

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -210,12 +210,132 @@ TestNfNNotWeDigBio2020 = ExtractorTest(
     test_name='TestNfNNotWeDigBio2020'
 )
 
+classification_we_dig_bio_april_2021 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2021-04-09T05:30:00.000Z",
+}
+
+expected_we_dig_bio_april_2021 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "we_dig_bio": 2021,
+    "country": "United States"
+}
+
+TestNfNWeDigBioApril2021 = ExtractorTest(
     extractors.nfn_extractor,
-    classification_we_dig_bio,
-    expected_we_dig_bio,
-    'Test NfN during WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    classification_we_dig_bio_april_2021,
+    expected_we_dig_bio_april_2021,
+    'Test NfN during April, 2021, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBio'
+    test_name='TestNfNWeDigBioApril2021'
+)
+
+classification_we_dig_bio_october_2021 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2021-10-15T05:30:00.000Z",
+}
+
+expected_we_dig_bio_october_2021 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "we_dig_bio": 2021,
+    "country": "United States"
+}
+
+TestNfNWeDigBioOctober2021 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_we_dig_bio_october_2021,
+    expected_we_dig_bio_october_2021,
+    'Test NfN during October, 2021, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNWeDigBioOctober2021'
+)
+
+classification_not_we_dig_bio_2021 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2021-07-16T05:30:00.000Z",
+}
+
+expected_not_we_dig_bio_2021 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "country": "United States"
+}
+
+TestNfNNotWeDigBio2021 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_not_we_dig_bio_2021,
+    expected_not_we_dig_bio_2021,
+    'Test NfN during 2021, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNNotWeDigBio2021'
 )
 
 classification_bad_year = {


### PR DESCRIPTION
Related to https://github.com/zooniverse/notes-from-nature-field-book/issues/121.
Similar to #368.

Background:
The Notes From Nature Field Book (https://field-book.notesfromnature.org/, frontend repo - https://github.com/zooniverse/notes-from-nature-field-book) awards badges to volunteers for classifying based on various criteria, including classification creation time. There will be special WeDigBio events April 8-11 and October 14-17, 2021, that a special badge is planned for.

Purpose:
In `nfn_extractor`, this PR refactors `we_dig_bio` to:
- return `2020` if a classification is created during October, and only October, 2020, fixing my previous omission to check for the appropriate month
- return `2021` if a classification is created between (and including) April 8-11, 2021
- return `2021` if a classification is created between (and including) October 14-17, 2021