### PR TITLE
Add pypi action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    - uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
     - name: Install panoptes aggregation
       run: |
         pip install -U pip

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPi
+
+on: workflow_dispatch
+
+jobs:
+  build-and-publish:
+    name: Build python package and publish to PyPi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,26 @@
+name: Publish to Test PyPi
+
+on: workflow_dispatch
+
+jobs:
+  build-and-publish:
+    name: Build python package and publish to Test PyPi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish to Test PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -16,9 +16,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
     - name: Install panoptes aggregation
       run: |
         pip install -U pip

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
         'lxml>=4.4,<4.7',
         'numpy>=1.20.0,<1.20.4',
         'packaging>=20.1,<20.10',
-        'pandas>=0.24.2,<1.2.5',
+        'pandas>=1.0.0,<1.2.5',
         'progressbar2>=3.39,<3.54',
         'python-levenshtein>=0.12.0,<0.13',
         'python-slugify>=3.0.0,<5.1',


### PR DESCRIPTION
Two new GHA are added:

- Publish master branch to [PyPi](https://pypi.org/project/panoptes-aggregation/)
- Publish master branch to [TestPyPi](https://test.pypi.org/project/panoptes-aggregation/)

These actions can only be triggered by hand via the `Actions` tab on GitHub.  This ensures the team has full control over when the package is published.