### PR TITLE
update k8s deployment

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -85,3 +85,13 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+   name: aggregation-caesar
+spec:
+  minAvailable: 50%
+  selector:
+    matchLabels:
+      app: aggregation-caesar

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -20,11 +20,11 @@ spec:
             - containerPort: 80
           resources:
             requests:
-              memory: "600Mi"
+              memory: "500Mi"
               cpu: "500m"
             limits:
-              memory: "600Mi"
-              cpu: "1500m"
+              memory: "1000Mi"
+              cpu: "1000m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
This PR adds a PodDisruptionBudget (https://v1-19.docs.kubernetes.io/docs/tasks/run-application/configure-pdb/) to the deployment to ensure we've always got a service pod running for to handle traffic.

Also I've tweaked the pod resource values
- decrease the RAM request to match the baseline of the app (measure against a running app) to allow better pod scheduling
- increased the RAM limit to allow it to grow if needed
- decreased the CPU limit to 1vCPU as this service has a HPA to increase the pod count where required (but also python has a GIL which normally means it won't saturate more than 1 vcpu)