### PR TITLE
Add question consensus reducer

### DIFF
--- a/docs/source/reducers.rst
+++ b/docs/source/reducers.rst
@@ -6,6 +6,11 @@ Reducers
 
 ----
 
+.. automodule:: panoptes_aggregation.reducers.question_consensus_reducer
+  :members:
+
+----
+
 .. automodule:: panoptes_aggregation.reducers.slider_reducer
   :members:
 

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -3,6 +3,7 @@ from .point_reducer_dbscan import point_reducer_dbscan
 from .point_reducer_hdbscan import point_reducer_hdbscan
 from .rectangle_reducer import rectangle_reducer
 from .question_reducer import question_reducer
+from .question_consensus_reducer import question_consensus_reducer
 from .survey_reducer import survey_reducer
 from .poly_line_text_reducer import poly_line_text_reducer
 from .dropdown_reducer import dropdown_reducer
@@ -26,6 +27,7 @@ reducers = {
     'point_reducer_hdbscan': point_reducer_hdbscan,
     'rectangle_reducer': rectangle_reducer,
     'question_reducer': question_reducer,
+    'question_consensus_reducer': question_consensus_reducer,
     'shortcut_reducer': shortcut_reducer,
     'survey_reducer': survey_reducer,
     'poly_line_text_reducer': poly_line_text_reducer,
@@ -38,5 +40,5 @@ reducers = {
     'tess_reducer_column': tess_reducer_column,
     'tess_gold_standard_reducer': tess_gold_standard_reducer,
     'text_reducer': text_reducer,
-    'first_n_true_reducer' : first_n_true_reducer
+    'first_n_true_reducer': first_n_true_reducer
 }

--- a/panoptes_aggregation/reducers/question_consensus_reducer.py
+++ b/panoptes_aggregation/reducers/question_consensus_reducer.py
@@ -6,7 +6,6 @@ This module porvides functions to reduce the question task extracts from
 '''
 from collections import Counter
 from .reducer_wrapper import reducer_wrapper
-from .question_reducer import question_reducer
 
 DEFAULTS = {
     'pairs': {'default': False, 'type': bool}
@@ -33,7 +32,14 @@ def question_consensus_reducer(data_list, pairs=False, **kwargs):
         num_votes = vote count for mostly likely `key`
         agreement = fraction of total votes held by most likely `key`.
     '''
-    reduced_data = question_reducer(data_list, pairs, **kwargs)
+    answer_list = []
+    for data in data_list:
+        if pairs:
+            answer_list.append('+'.join(sorted(data)))
+        else:
+            answer_list += list(data)
+    counter_total = Counter(answer_list)
+    reduced_data = dict(counter_total)
     max_key = max(reduced_data, key=lambda k: reduced_data[k])
     summed_vals = sum(reduced_data.values())
     if reduced_data[max_key] > 0:

--- a/panoptes_aggregation/reducers/question_consensus_reducer.py
+++ b/panoptes_aggregation/reducers/question_consensus_reducer.py
@@ -40,14 +40,18 @@ def question_consensus_reducer(data_list, pairs=False, **kwargs):
             answer_list += list(data)
     counter_total = Counter(answer_list)
     reduced_data = dict(counter_total)
-    max_key = max(reduced_data, key=lambda k: reduced_data[k])
-    summed_vals = sum(reduced_data.values())
-    if reduced_data[max_key] > 0:
-        return {
-            "most_likely": max_key,
-            "num_votes": reduced_data[max_key],
-            "agreement": reduced_data[max_key] / summed_vals
-        }
-    return {
+    result = {
         "num_votes": 0,
     }
+    try:
+        max_key = max(reduced_data, key=lambda k: reduced_data[k])
+        summed_vals = sum(reduced_data.values())
+        if reduced_data[max_key] > 0:
+            result = {
+                "most_likely": max_key,
+                "num_votes": reduced_data[max_key],
+                "agreement": reduced_data[max_key] / summed_vals
+            }
+    except ValueError:
+        pass
+    return result

--- a/panoptes_aggregation/reducers/question_consensus_reducer.py
+++ b/panoptes_aggregation/reducers/question_consensus_reducer.py
@@ -35,6 +35,7 @@ def question_consensus_reducer(data_list, pairs=False, **kwargs):
         * `agreement` : fraction of total votes held by most likely `key`.
 
     '''
+    # reduce data (similar to question_reducer)
     answer_list = []
     for data in data_list:
         if pairs:
@@ -42,19 +43,20 @@ def question_consensus_reducer(data_list, pairs=False, **kwargs):
         else:
             answer_list += list(data)
     counter_total = Counter(answer_list)
-    reduced_data = dict(counter_total)
+
+    # default return value
     result = {
         "num_votes": 0,
     }
-    try:
-        max_key = max(reduced_data, key=lambda k: reduced_data[k])
-        summed_vals = sum(reduced_data.values())
-        if reduced_data[max_key] > 0:
-            result = {
-                "most_likely": max_key,
-                "num_votes": reduced_data[max_key],
-                "agreement": reduced_data[max_key] / summed_vals
-            }
-    except ValueError:
-        pass
+    most_common = counter_total.most_common(1)
+    # if there exists a most common element (i.e. keys are not empty)
+    if len(most_common) > 0 and len(most_common[0]) == 2 and most_common[0][1] > 0:
+        max_key = most_common[0][0]
+        # sum the values of every key iff there's a max key that has a value > 0
+        summed_counts = sum(dict(counter_total).values())
+        result = {
+            "most_likely": max_key,
+            "num_votes": most_common[0][1],
+            "agreement": most_common[0][1] / summed_counts
+        }
     return result

--- a/panoptes_aggregation/reducers/question_consensus_reducer.py
+++ b/panoptes_aggregation/reducers/question_consensus_reducer.py
@@ -1,0 +1,47 @@
+'''
+Question Reducer
+----------------
+This module porvides functions to reduce the question task extracts from
+:mod:`panoptes_aggregation.extractors.question_extractor`.
+'''
+from collections import Counter
+from .reducer_wrapper import reducer_wrapper
+from .question_reducer import question_reducer
+
+DEFAULTS = {
+    'pairs': {'default': False, 'type': bool}
+}
+
+
+@reducer_wrapper(defaults_data=DEFAULTS)
+def question_consensus_reducer(data_list, pairs=False, **kwargs):
+    '''Reduce a list of extracted questions into a "counter" dict
+
+    Parameters
+    ----------
+    data_list : list
+        A list of extractions created by
+        :meth:`panoptes_aggregation.extractors.question_extractor.question_extractor`
+    pairs : bool, optional
+        Default `False`. How multiple choice questions are treated.
+        When `True` the set of all choices is treated as a single answer
+
+    Returns
+    -------
+    reduction : dict
+        most_likely = `key` with greatest number of classifications/votes
+        num_votes = vote count for mostly likely `key`
+        agreement = fraction of total votes held by most likely `key`.
+    '''
+    reduced_data = question_reducer(data_list, pairs, **kwargs)
+    max_key = max(reduced_data, key=lambda k: reduced_data[k])
+    summed_vals = sum(reduced_data.values())
+    if reduced_data[max_key] > 0:
+        return {
+            "most_likely": max_key,
+            "num_votes": reduced_data[max_key],
+            "agreement": reduced_data[max_key] / summed_vals
+        }
+    return {
+        "num_votes": 0,
+    }

--- a/panoptes_aggregation/reducers/question_consensus_reducer.py
+++ b/panoptes_aggregation/reducers/question_consensus_reducer.py
@@ -1,6 +1,6 @@
 '''
-Question Reducer
-----------------
+Question Consensus Reducer
+--------------------------
 This module porvides functions to reduce the question task extracts from
 :mod:`panoptes_aggregation.extractors.question_extractor`.
 '''
@@ -14,7 +14,7 @@ DEFAULTS = {
 
 @reducer_wrapper(defaults_data=DEFAULTS)
 def question_consensus_reducer(data_list, pairs=False, **kwargs):
-    '''Reduce a list of extracted questions into a "counter" dict
+    '''Reduce a list of extracted questions into a consensus description dict
 
     Parameters
     ----------
@@ -28,9 +28,12 @@ def question_consensus_reducer(data_list, pairs=False, **kwargs):
     Returns
     -------
     reduction : dict
-        most_likely = `key` with greatest number of classifications/votes
-        num_votes = vote count for mostly likely `key`
-        agreement = fraction of total votes held by most likely `key`.
+        A dictinary with the following keys
+
+        * `most_likely` : `key` with greatest number of classifications/votes
+        * `num_votes` : vote count for mostly likely `key`
+        * `agreement` : fraction of total votes held by most likely `key`.
+
     '''
     answer_list = []
     for data in data_list:

--- a/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
@@ -4,14 +4,15 @@ from .base_test_class import ReducerTestNoProcessing
 extracted_data = [
     {'a': 1, 'b': 1},
     {'a': 1},
+    {'d': 1, 'a': 1},
     {'b': 1, 'c': 1},
     {'b': 1, 'a': 1}
 ]
 
 reduced_data = {
     "most_likely": 'a',
-    "num_votes": 3,
-    "agreement": 3 / 7
+    "num_votes": 4,
+    "agreement": 4 / 9
 }
 
 TestQuestionReducer = ReducerTestNoProcessing(
@@ -25,7 +26,7 @@ TestQuestionReducer = ReducerTestNoProcessing(
 reduced_data_pairs = {
     "most_likely": 'a+b',
     "num_votes": 2,
-    "agreement": 2 / 4
+    "agreement": 2 / 5
 }
 
 TestQuestionReducerPairs = ReducerTestNoProcessing(
@@ -35,4 +36,29 @@ TestQuestionReducerPairs = ReducerTestNoProcessing(
     'Test question consensus reducer as pairs',
     kwargs={'pairs': True},
     test_name='TestQuestionConsensusReducerPairs'
+)
+
+reduced_data_no_votes = {
+    "num_votes": 0
+}
+
+TestQuestionReducerPairsNoVotes = ReducerTestNoProcessing(
+    question_consensus_reducer,
+    extracted_data,
+    reduced_data_no_votes,
+    'Test question consensus reducer with no votes',
+    test_name='TestQuestionConsensusReducerNoVotes'
+)
+
+reduced_data_no_votes_pairs = {
+    "num_votes": 0
+}
+
+TestQuestionReducerPairsNoVotesPairs = ReducerTestNoProcessing(
+    question_consensus_reducer,
+    extracted_data,
+    reduced_data_no_votes_pairs,
+    'Test question consensus reducer with no votes as pairs',
+    kwargs={'pairs': True},
+    test_name='TestQuestionConsensusReducerNoVotesPairs'
 )

--- a/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
@@ -1,0 +1,38 @@
+from panoptes_aggregation.reducers.question_consensus_reducer import question_consensus_reducer
+from .base_test_class import ReducerTestNoProcessing
+
+extracted_data = [
+    {'a': 1, 'b': 1},
+    {'a': 1},
+    {'b': 1, 'c': 1},
+    {'b': 1, 'a': 1}
+]
+
+reduced_data = {
+    "most_likely": 'a',
+    "num_votes": 3,
+    "agreement": 3 / 7
+}
+
+TestQuestionReducer = ReducerTestNoProcessing(
+    question_consensus_reducer,
+    extracted_data,
+    reduced_data,
+    'Test question reducer',
+    test_name='TestQuestionConsensusReducer'
+)
+
+reduced_data_pairs = {
+    "most_likely": 'a+b',
+    "num_votes": 2,
+    "agreement": 2 / 4
+}
+
+TestQuestionReducerPairs = ReducerTestNoProcessing(
+    question_consensus_reducer,
+    extracted_data,
+    reduced_data_pairs,
+    'Test question consensus reducer as pairs',
+    kwargs={'pairs': True},
+    test_name='TestQuestionConsensusReducerPairs'
+)

--- a/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_question_consensus_reducer.py
@@ -44,7 +44,7 @@ reduced_data_no_votes = {
 
 TestQuestionReducerPairsNoVotes = ReducerTestNoProcessing(
     question_consensus_reducer,
-    extracted_data,
+    [],
     reduced_data_no_votes,
     'Test question consensus reducer with no votes',
     test_name='TestQuestionConsensusReducerNoVotes'
@@ -56,7 +56,7 @@ reduced_data_no_votes_pairs = {
 
 TestQuestionReducerPairsNoVotesPairs = ReducerTestNoProcessing(
     question_consensus_reducer,
-    extracted_data,
+    [],
     reduced_data_no_votes_pairs,
     'Test question consensus reducer with no votes as pairs',
     kwargs={'pairs': True},


### PR DESCRIPTION
Background:
The often-used consensus reducer for Caesar would be a nice addition for folks to be able to use for offline analysis. See issue #277 

Purpose:
Return the question option with the most votes.

Outputs:
most_likely = option with greatest number of classifications/votes
num_votes = vote count for mostly likely option
agreement = fraction of total votes held by most likely option.