### PR TITLE
update the userify function

### DIFF
--- a/panoptes_aggregation/panoptes/userify.py
+++ b/panoptes_aggregation/panoptes/userify.py
@@ -22,6 +22,8 @@ class ConfigurationError(Exception):
 reserved_params = ['destination']
 # allow list of allowed fields args for API user resource lookups
 allowed_user_fields = ['credited_name', 'display_name', 'id', 'login']
+# restricted service_payload key value pairs
+restricted_payload_keys = ['reducer_key']
 
 users = {}
 
@@ -73,6 +75,11 @@ def userify(all_args, service_payload):
 
     allowed_user_lookup_fields = _discover_user_lookup_fields(all_args)
     destination = all_args.get('destination')
+
+    # remove restricted payload data before sending to destination (mast)
+    # https://github.com/zooniverse/caesar/pull/1342#issuecomment-917096083
+    for restriced_key in restricted_payload_keys:
+      service_payload.pop(restriced_key, None)
 
     _stuff_object(service_payload, allowed_user_lookup_fields)
     users = {}

--- a/panoptes_aggregation/panoptes/userify.py
+++ b/panoptes_aggregation/panoptes/userify.py
@@ -137,7 +137,13 @@ def _discover_user_ids(target_object):
     if 'user_id' in target_object:
         user_ids.append(target_object['user_id'])
 
-    return _unique(_flatten(user_ids))
+    flattened_user_ids = _unique(_flatten(user_ids))
+    if flattened_user_ids:
+      # if we found some user_ids then we should connect the API client
+      # for the user lookups
+      connect_api_client()
+
+    return flattened_user_ids
 
 
 def _build_user_hash(user, find_fields):
@@ -165,16 +171,18 @@ class CantFindUser():
     def __init__(self, id):
         self.id = id
 
-
-def _retrieve_user(user_id):
-    if user_id in users:
-        user = users[user_id]
-    else:
+def connect_api_client():
+  # connect to the API only once for this function request
         Panoptes.connect(
             endpoint=getenv('PANOPTES_URL', 'https://panoptes.zooniverse.org/'),
             client_id=getenv('PANOPTES_CLIENT_ID'),
             client_secret=getenv('PANOPTES_CLIENT_SECRET')
         )
+
+def _retrieve_user(user_id):
+    if user_id in users:
+        user = users[user_id]
+    else:
         try:
             user = User.find(user_id)
         except PanoptesAPIException:

--- a/panoptes_aggregation/panoptes/userify.py
+++ b/panoptes_aggregation/panoptes/userify.py
@@ -18,6 +18,7 @@ class ConfigurationError(Exception):
     '''
     pass
 
+
 # arg fields that contain non user lookup fields, i.e. the destination service 'mast'
 reserved_params = ['destination']
 # allow list of allowed fields args for API user resource lookups
@@ -79,7 +80,7 @@ def userify(all_args, service_payload):
     # remove restricted payload data before sending to destination (mast)
     # https://github.com/zooniverse/caesar/pull/1342#issuecomment-917096083
     for restriced_key in restricted_payload_keys:
-      service_payload.pop(restriced_key, None)
+        service_payload.pop(restriced_key, None)
 
     _stuff_object(service_payload, allowed_user_lookup_fields)
     users = {}
@@ -151,9 +152,9 @@ def _discover_user_ids(service_payload):
 
     flattened_user_ids = _unique(_flatten(user_ids))
     if flattened_user_ids:
-      # if we found some user_ids then we should connect the API client
-      # for the user lookups
-      connect_api_client()
+        # if we found some user_ids then we should connect the API client
+        # for the user lookups
+        connect_api_client()
 
     return flattened_user_ids
 
@@ -183,13 +184,15 @@ class CantFindUser():
     def __init__(self, id):
         self.id = id
 
+
 def connect_api_client():
-  # connect to the API only once for this function request
-  Panoptes.connect(
-      endpoint=getenv('PANOPTES_URL', 'https://panoptes.zooniverse.org/'),
-      client_id=getenv('PANOPTES_CLIENT_ID'),
-      client_secret=getenv('PANOPTES_CLIENT_SECRET')
-  )
+    # connect to the API only once for this function request
+    Panoptes.connect(
+        endpoint=getenv('PANOPTES_URL', 'https://panoptes.zooniverse.org/'),
+        client_id=getenv('PANOPTES_CLIENT_ID'),
+        client_secret=getenv('PANOPTES_CLIENT_SECRET')
+    )
+
 
 def _retrieve_user(user_id):
     if user_id in users:

--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -16,6 +16,7 @@ panoptes = import_module('panoptes_aggregation.panoptes', __name__).panoptes_tes
 # make the API client connect call a no-op for all tests
 Panoptes.connect = Mock()
 
+
 def build_mock_user(**kwargs):
     mock_user = MagicMock()
     for key, value in kwargs.items():
@@ -110,7 +111,6 @@ def test_build_user_hash():
 def test_retrieve_user():
     mock_user1 = build_mock_user(id=1, login='login', display_name='display_name')
     mock_user2 = build_mock_user(id=2, login='login', display_name='display_name')
-
 
     # finds user by calling API
     User.find = Mock(return_value=mock_user1)

--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -43,6 +43,9 @@ def test_userify():
     assert_equal(panoptes.userify({}, {}), '{}')
     assert_equal(panoptes.userify({'login': None}, {}), '{}')
 
+    # removes restricted payload key/value pairs
+    assert_equal(panoptes.userify({'login': None}, {'reducer_key': 'T0', 'id': '1'}), '{"id": "1"}')
+
     # fills out object correctly
     (User.find) = Mock(return_value=build_mock_user(id=3, login="login 3"))
     assert_equal(panoptes.userify({'login': None}, {'user_id': 3}), '{"user_id": 3, "users": [{"id": 3, "login": "login 3"}]}')


### PR DESCRIPTION
This PR updates the userify function for sending user data to the mast service destination for PH-Tess reducers in caesar

This is in response to a change in the reducer payloads including possibly invalid data at the mast endpoint, https://github.com/zooniverse/caesar/pull/1342#issuecomment-917096083

in order to ensure we keep mast / PH-Tess integration working we decided to augement the behaviour of this userify function. It's currently only used by caesar to send data to mast destination. As such this PR 
1. restricts the behaviour of the function to close #164 by adding an allowed list of user attributes for API lookup. 
2. only calls the Panoptes.connect method once per request, not on each user attribute
3. removes the 'reducer_key' data on the incoming `service_payload` object to ensure we submit the same data to `mast` service once https://github.com/zooniverse/caesar/pull/1342 is merged and deployed