### PR TITLE
Add more type checking to NfN extractor

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -30,6 +30,7 @@ class ClassificationParser(object):
         return (
             isinstance(arg, collections.abc.Iterable)
             and not isinstance(arg, str)
+            and not isinstance(arg, int)
         )
 
     def flatten(self, anno):
@@ -38,7 +39,7 @@ class ClassificationParser(object):
             f[a['task']] = a['value']
             if (self.iterable(a['value'])):
                 for subanno in a['value']:
-                    if 'task' in subanno:
+                    if isinstance(subanno, dict) and 'task' in subanno:
                         f[subanno['task']] = subanno['value']
         return f
 

--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -30,7 +30,6 @@ class ClassificationParser(object):
         return (
             isinstance(arg, collections.abc.Iterable)
             and not isinstance(arg, str)
-            and not isinstance(arg, int)
         )
 
     def flatten(self, anno):

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -447,3 +447,33 @@ TestNfNNotInMetadataOrParams = ExtractorTest(
     kwargs={'year': 'T10', 'workflow': 'herbarium', 'state': 'metadata'},
     test_name='TestNfNNotInMetadataOrParams'
 )
+
+classification_multiselect = {
+    "annotations": [
+        {
+            "task": "T1",
+            "value": [4]
+        }
+    ],
+    "metadata": {
+        "utc_offset": "21600",
+    },
+    "subject": {
+        "metadata": {}
+    },
+    "created_at": "2019-05-22T10:28:13.667Z",
+}
+
+expected_multiselect = {
+    "workflow": "labs",
+    "time": "dinnertime"
+}
+
+TestNfNMultiselect = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_multiselect,
+    expected_multiselect,
+    'Test NfN multiselect (array of ints) in a single task',
+    kwargs={'workflow': 'labs'},
+    test_name='TestNfNMultiselect'
+)


### PR DESCRIPTION
* `iterable` now checks and returns false for `int` as well as `str`. 
* `flatten` includes a check to ensure that the subannotation is a dict, which is the only possible type for a subannotation. Anything else shouldn't be flattened.
* Includes a new test based on the error report.