### PR TITLE
Improve service availbility 

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -25,16 +25,27 @@ spec:
             limits:
               memory: "1000Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            # wait 6 * 10 seconds(default periodSeconds) for the container to start
+            # after this succeeds once the liveness probe takes over
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 10
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 10
+            # start checking for readiness after 20s (to serve traffic)
+            initialDelaySeconds: 20
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
           env:
             - name: FLASK_ENV
               value: production

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -93,7 +93,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: aggregation-caesar
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 ---


### PR DESCRIPTION
Linked to the work in https://github.com/zooniverse/panoptes/pull/3648

This PR improves the service availability by
- adding a startup probe, https://v1-19.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
- increasing the pod timeouts so lots of slow requests take longer to fail and thus restart this service (changing from 1s to 10s)
- run 2 service pods for higher availability

Note: we can increase the pod probe timeouts to a larger value if we know some requests take a lot longer (user reduction requests?)