### PR TITLE
add request post timeout for mast upstream

### DIFF
--- a/panoptes_aggregation/panoptes/userify.py
+++ b/panoptes_aggregation/panoptes/userify.py
@@ -116,7 +116,7 @@ def _forward_contents(payload, destination):
             endpoint['auth-header']: getenv(endpoint['auth-token'])
         }
 
-    return requests.post(**request_args)
+    return requests.post(**request_args, timeout=5)
 
 
 def _stuff_object(service_payload, find_fields):

--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -211,13 +211,14 @@ def test_forward_contents():
     # sends to known endpoints correctly
     requests.post = MagicMock()
     panoptes._forward_contents({'foo': 'bar'}, 'mockable')
-    (requests.post).assert_called_once_with(url='https://demo1580318.mockable.io/mast', json={'foo': 'bar'})
+    (requests.post).assert_called_once_with(timeout=5, url='https://demo1580318.mockable.io/mast', json={'foo': 'bar'})
 
     requests.post = MagicMock()
     with patch.dict(os.environ, {'MAST_AUTH_TOKEN': 'foo'}):
         panoptes._forward_contents({'foo': 'bar'}, 'mast')
 
     (requests.post).assert_called_once_with(
+        timeout=5,
         url='https://mast-forwarder.zooniverse.org/',
         json={'foo': 'bar'},
         headers={'X-ASB-AUTH': 'foo'}


### PR DESCRIPTION
linked to #488 - avoid long running requests when posting data to the upstream mast service.

this will now timeout after 5s connection and/or 5s read response, possibly ~10s in total. https://docs.python-requests.org/en/v2.4.3/user/advanced/