### PR TITLE
use python slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM python:3.7
+FROM python:3.7-slim
 
 ENV LANG=C.UTF-8
 
 WORKDIR /usr/src/aggregation
 
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+    build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # install dependencies
 COPY setup.py .
 RUN pip install --upgrade pip
-RUN pip install .[online,test,doc] 
+RUN pip install .[online,test,doc]
 
 # install package
 COPY . .


### PR DESCRIPTION
decrease the number of packages in the base image and only install what we need.

this helps with package deployments (smaller images copy faster with less IO) and also decreases the security attack surface by reducing possible vulnerable packages

I'm not sure what else is impacted by using the base image but all tests pass in the newly build image so I assume functionally this change is the same as current just with a lot less cruft installed in the resulting docker image.