### PR TITLE
Add Notes from Nature WeDigBio 2022 extractor conditions and tests

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -95,6 +95,10 @@ def we_dig_bio(parser):
         return 2021
     elif (date.year == 2021) and (date.month == 10) and (14 <= date.day <= 17):
         return 2021
+    elif (date.year == 2022) and (date.month == 4) and (7 <= date.day <= 10):
+        return 2022
+    elif (date.year == 2022) and (date.month == 10) and (13 <= date.day <= 16):
+        return 2022
     else:
         return None
 

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -338,6 +338,134 @@ TestNfNNotWeDigBio2021 = ExtractorTest(
     test_name='TestNfNNotWeDigBio2021'
 )
 
+classification_we_dig_bio_april_2022 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2022-04-09T05:30:00.000Z",
+}
+
+expected_we_dig_bio_april_2022 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "we_dig_bio": 2022,
+    "country": "United States"
+}
+
+TestNfNWeDigBioApril2022 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_we_dig_bio_april_2022,
+    expected_we_dig_bio_april_2022,
+    'Test NfN during April, 2022, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNWeDigBioApril2022'
+)
+
+classification_we_dig_bio_october_2022 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2022-10-14T05:30:00.000Z",
+}
+
+expected_we_dig_bio_october_2022 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "we_dig_bio": 2022,
+    "country": "United States"
+}
+
+TestNfNWeDigBioOctober2022 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_we_dig_bio_october_2022,
+    expected_we_dig_bio_october_2022,
+    'Test NfN during October, 2022, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNWeDigBioOctober2022'
+)
+
+classification_not_we_dig_bio_2022 = {
+    "annotations": [{
+        "task": "T99",
+        "value": [
+            {
+                "task": "T11",
+                "value": [
+                    {
+                        "value": 2001,
+                        "option": True
+                    }
+                ]
+            }
+        ]
+    }],
+    "metadata": {
+        "utc_offset": "18000",
+    },
+    "subject": {
+        "metadata": {
+            "country": "United States",
+        }
+    },
+    "created_at": "2022-07-16T05:30:00.000Z",
+}
+
+expected_not_we_dig_bio_2022 = {
+    "workflow": "herbarium",
+    "decade": "00s",
+    "time": "lunchbreak",
+    "country": "United States"
+}
+
+TestNfNNotWeDigBio2022 = ExtractorTest(
+    extractors.nfn_extractor,
+    classification_not_we_dig_bio_2022,
+    expected_not_we_dig_bio_2022,
+    'Test NfN during 2022, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
+    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
+    test_name='TestNfNNotWeDigBio2022'
+)
+
 classification_bad_year = {
     "annotations": [
         {


### PR DESCRIPTION
Related to zooniverse/notes-from-nature-field-book#144.
Similar to #368 and #427.

Background:
The Notes From Nature Field Book (https://field-book.notesfromnature.org/, frontend repo - https://github.com/zooniverse/notes-from-nature-field-book) awards badges to volunteers for classifying based on various criteria, including classification creation time. There will be special WeDigBio events April 7-10 and October 13-16, 2022, that a special badge is planned for.

Purpose:
In nfn_extractor, this PR refactors we_dig_bio to:
- return 2022 if a classification is created between (and including) April 7-10, 2022
- return 2022 if a classification is created between (and including) October 13-16, 2022
