### PR TITLE
Adjust how userify is tested when in offline mode

### DIFF
--- a/panoptes_aggregation/panoptes/__init__.py
+++ b/panoptes_aggregation/panoptes/__init__.py
@@ -3,8 +3,10 @@ from importlib import import_module
 try:
     from .userify import userify
     _userify = import_module('.userify', __name__)
-except ImportError: # pragma: no cover
-    print('`panoptes_aggregation.panoptes.userify` is only available in online mode `pip install panoptes_aggregation[online]`') # pragma: no cover
+except ImportError:  # pragma: no cover
+    userify = None
+    _userify = None
+    print('`panoptes_aggregation.panoptes.userify` is only available in online mode `pip install panoptes_aggregation[online]`')  # pragma: no cover
 
 panoptes = {
   'userify': userify


### PR DESCRIPTION
In offline mode, `userfy` should not be tested.  This PR adjusts the unit tests to check if the package was installed on online mode before running any tests.  I also needed to adjust how the `__init__` file handled a failed import.

This was tested in the local scripts docker container that installs the code on offline mode.