### PR TITLE
Added caching for more efficient computation of IoU 

### DIFF
--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -16,6 +16,7 @@ def tupleize(func):
         return func(tuple(params), shape)
     return wrapper
 
+
 @tupleize
 @lru_cache(maxsize=100)
 def panoptes_to_geometry(params, shape):

--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -8,8 +8,9 @@ import shapely.geometry
 import shapely.affinity
 import scipy.optimize
 import numpy
+from functools import lru_cache
 
-
+@lru_cache(maxsize=100)
 def panoptes_to_geometry(params, shape):
     '''Convert shapes created with the Panoptes Front End (PFE) to shapely
     geometry objects.
@@ -85,8 +86,8 @@ def IoU_metric(params1, params2, shape):
         1 means the shapes don't overlap, values in the middle mean partial
         overlap.
     '''
-    geo1 = panoptes_to_geometry(params1, shape)
-    geo2 = panoptes_to_geometry(params2, shape)
+    geo1 = panoptes_to_geometry(tuple(params1), shape)
+    geo2 = panoptes_to_geometry(tuple(params2), shape)
     intersection = geo1.intersection(geo2).area
     union = geo1.union(geo2).area
     if union == 0:
@@ -113,10 +114,10 @@ def average_bounds(params_list, shape):
         This is a list of tuples giving the min and max bounds for
         each shape parameter.
     '''
-    geo = panoptes_to_geometry(params_list[0], shape)
+    geo = panoptes_to_geometry(tuple(params_list[0]), shape)
     # Use the union of all shapes to find the bounding box
     for params in params_list[1:]:
-        geo = geo.union(panoptes_to_geometry(params, shape))
+        geo = geo.union(panoptes_to_geometry(tuple(params), shape))
     # bound on x
     bx = (geo.bounds[0], geo.bounds[2])
     # bound on y

--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -10,6 +10,7 @@ import scipy.optimize
 import numpy
 from functools import lru_cache
 
+
 @lru_cache(maxsize=100)
 def panoptes_to_geometry(params, shape):
     '''Convert shapes created with the Panoptes Front End (PFE) to shapely

--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -11,6 +11,12 @@ import numpy
 from functools import lru_cache
 
 
+def tupleize(func):
+    def wrapper(params, shape):
+        return func(tuple(params), shape)
+    return wrapper
+
+@tupleize
 @lru_cache(maxsize=100)
 def panoptes_to_geometry(params, shape):
     '''Convert shapes created with the Panoptes Front End (PFE) to shapely
@@ -87,8 +93,8 @@ def IoU_metric(params1, params2, shape):
         1 means the shapes don't overlap, values in the middle mean partial
         overlap.
     '''
-    geo1 = panoptes_to_geometry(tuple(params1), shape)
-    geo2 = panoptes_to_geometry(tuple(params2), shape)
+    geo1 = panoptes_to_geometry(params1, shape)
+    geo2 = panoptes_to_geometry(params2, shape)
     intersection = geo1.intersection(geo2).area
     union = geo1.union(geo2).area
     if union == 0:
@@ -115,10 +121,10 @@ def average_bounds(params_list, shape):
         This is a list of tuples giving the min and max bounds for
         each shape parameter.
     '''
-    geo = panoptes_to_geometry(tuple(params_list[0]), shape)
+    geo = panoptes_to_geometry(params_list[0], shape)
     # Use the union of all shapes to find the bounding box
     for params in params_list[1:]:
-        geo = geo.union(panoptes_to_geometry(tuple(params), shape))
+        geo = geo.union(panoptes_to_geometry(params, shape))
     # bound on x
     bx = (geo.bounds[0], geo.bounds[2])
     # bound on y

--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -18,8 +18,8 @@ def panoptes_to_geometry(params, shape):
 
     Parameters
     ----------
-    params : list
-        A list of the parameters for the shape (as defined by PFE)
+    params : tuple
+        A tuple of the parameters for the shape (as defined by PFE)
     shape : string
         The name of the shape these parameters belong to.  Supported shapes are:
 

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_metric_IoU.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_metric_IoU.py
@@ -12,20 +12,20 @@ class TestIoUMetric(unittest.TestCase):
     def test_panoptes_to_geometry_rect(self):
         '''Test panoptes_to_geometry with rectangle'''
         expected = shapely.geometry.box(3, 5, 8, 8)
-        result = IoU.panoptes_to_geometry([3, 5, 5, 3], 'rectangle')
+        result = IoU.panoptes_to_geometry(tuple([3, 5, 5, 3]), 'rectangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_rot_rect(self):
         '''Test panoptes_to_geometry with rotating rectangle'''
         expected = shapely.geometry.box(3, 5, 8, 8)
         expected = shapely.affinity.rotate(expected, 45)
-        result = IoU.panoptes_to_geometry([3, 5, 5, 3, 45], 'rotateRectangle')
+        result = IoU.panoptes_to_geometry(tuple([3, 5, 5, 3, 45]), 'rotateRectangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_circle(self):
         '''Test panoptes_to_geometry with circle'''
         expected = shapely.geometry.Point(10, 12).buffer(5)
-        result = IoU.panoptes_to_geometry([10, 12, 5], 'circle')
+        result = IoU.panoptes_to_geometry(tuple([10, 12, 5]), 'circle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_ellipse(self):
@@ -33,7 +33,7 @@ class TestIoUMetric(unittest.TestCase):
         expected = shapely.geometry.Point(10, 12).buffer(1)
         expected = shapely.affinity.scale(expected, 3, 5)
         expected = shapely.affinity.rotate(expected, -45)
-        result = IoU.panoptes_to_geometry([10, 12, 3, 5, 45], 'ellipse')
+        result = IoU.panoptes_to_geometry(tuple([10, 12, 3, 5, 45]), 'ellipse')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_triangle(self):
@@ -45,13 +45,13 @@ class TestIoUMetric(unittest.TestCase):
         ])
         expected = shapely.affinity.rotate(expected, -30, origin=(0, 0))
         expected = shapely.affinity.translate(expected, xoff=5, yoff=10)
-        result = IoU.panoptes_to_geometry([5, 10, 3, 30], 'triangle')
+        result = IoU.panoptes_to_geometry(tuple([5, 10, 3, 30]), 'triangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_other(self):
         '''Test panoptes_to_geometry with unsupported shape'''
         with self.assertRaises(ValueError):
-            IoU.panoptes_to_geometry([1], 'not_a_supported_shape')
+            IoU.panoptes_to_geometry(tuple([1]), 'not_a_supported_shape')
 
     def test_IoU_metric(self):
         '''Test the IoU metric'''

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_metric_IoU.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_metric_IoU.py
@@ -12,20 +12,20 @@ class TestIoUMetric(unittest.TestCase):
     def test_panoptes_to_geometry_rect(self):
         '''Test panoptes_to_geometry with rectangle'''
         expected = shapely.geometry.box(3, 5, 8, 8)
-        result = IoU.panoptes_to_geometry(tuple([3, 5, 5, 3]), 'rectangle')
+        result = IoU.panoptes_to_geometry([3, 5, 5, 3], 'rectangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_rot_rect(self):
         '''Test panoptes_to_geometry with rotating rectangle'''
         expected = shapely.geometry.box(3, 5, 8, 8)
         expected = shapely.affinity.rotate(expected, 45)
-        result = IoU.panoptes_to_geometry(tuple([3, 5, 5, 3, 45]), 'rotateRectangle')
+        result = IoU.panoptes_to_geometry([3, 5, 5, 3, 45], 'rotateRectangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_circle(self):
         '''Test panoptes_to_geometry with circle'''
         expected = shapely.geometry.Point(10, 12).buffer(5)
-        result = IoU.panoptes_to_geometry(tuple([10, 12, 5]), 'circle')
+        result = IoU.panoptes_to_geometry([10, 12, 5], 'circle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_ellipse(self):
@@ -33,7 +33,7 @@ class TestIoUMetric(unittest.TestCase):
         expected = shapely.geometry.Point(10, 12).buffer(1)
         expected = shapely.affinity.scale(expected, 3, 5)
         expected = shapely.affinity.rotate(expected, -45)
-        result = IoU.panoptes_to_geometry(tuple([10, 12, 3, 5, 45]), 'ellipse')
+        result = IoU.panoptes_to_geometry([10, 12, 3, 5, 45], 'ellipse')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_triangle(self):
@@ -45,13 +45,13 @@ class TestIoUMetric(unittest.TestCase):
         ])
         expected = shapely.affinity.rotate(expected, -30, origin=(0, 0))
         expected = shapely.affinity.translate(expected, xoff=5, yoff=10)
-        result = IoU.panoptes_to_geometry(tuple([5, 10, 3, 30]), 'triangle')
+        result = IoU.panoptes_to_geometry([5, 10, 3, 30], 'triangle')
         self.assertEqual(result, expected)
 
     def test_panoptes_to_geometry_other(self):
         '''Test panoptes_to_geometry with unsupported shape'''
         with self.assertRaises(ValueError):
-            IoU.panoptes_to_geometry(tuple([1]), 'not_a_supported_shape')
+            IoU.panoptes_to_geometry([1], 'not_a_supported_shape')
 
     def test_IoU_metric(self):
         '''Test the IoU metric'''


### PR DESCRIPTION
In response to #579, added an `lru_cache` decorator to the `panoptes_to_geometry` function to avoid timeouts when calculating the shape average when using the IoU metric. 

Testing shows these performance gains on ~5000 extracts spanning ~2600 subjects:
With caching:
```
panoptes_aggregation reduce   -c 12   2727.73s  user 2.56s system 1192% cpu 3:48.99 total
max memory:                204 MB
```

Without caching:
```
panoptes_aggregation reduce   -c 12   6042.23s  user 2.98s system 1195% cpu 8:25.50 total
max memory:                235 MB
```

For ~20,000 extracts with ~6700 subjects:

With caching:
```
panoptes_aggregation reduce   -c 12   11194.73s  user 4.86s system 1197% cpu 15:35.50 total
max memory:                295 MB
```

Without caching:
```
panoptes_aggregation reduce   -c 12   23560.49s  user 5.71s system 1198% cpu 32:46.43 total
max memory:                519 MB
```

