### PR TITLE
Allow recursive extraction and reduction

### DIFF
--- a/Scripts.md
+++ b/Scripts.md
@@ -109,6 +109,43 @@ This creates four files:
  - `Reducer_config_workflow_6465_V52.76_question_extractor.yaml`: The configuration for the reducer used for the question task
  - `Task_labels_workflow_6465_V52.76.yaml`: A lookup table to translate the column names used in the extractor/reducer output files into the text originally used on the workflow.
 
+
+````{note}
+If you have a recursive workflow you will need to edit the configuration `yaml` file by hand.  For example, if you have a workflow with three question tasks `T0`, `T1`, and `T2` with an option in `T2` leading back to `T0` the `extractor_config` section of the `yaml` file would be:
+
+```yaml
+extractor_config:
+    question_extractor:
+    -   task: T0
+        recursive: true
+    -   task: T1
+        recursive: true
+    -   task: T2
+        recursive: true
+```
+
+In this setup every instance of `T0` will be extracted with the same subject ID and will be reduced together (`-F all` will need to be set in the reducer for this to work).  
+
+Instead, if each recursion through the workflow should be treated as a **different** subject (e.g. each loop through the questions is for a different row in a data table), the config should be set up as:
+
+```yaml
+extractor_config:
+    question_extractor:
+    -   task: T0
+        recursive: true
+        recursive_subject_ids: true
+    -   task: T1
+        recursive: true
+        recursive_subject_ids: true
+    -   task: T2
+        recursive: true
+        recursive_subject_ids: true
+```
+
+This will adjust the subject ID with a suffix identifying what "loop" it was classified in.  In effect, this will reduce together each pass through the workflow separately.  It also makes the underlying assumption that every volunteer classified the subject in the same order (e.g. for the data table example, each volunteer classified the rows in the same order without skipping any).
+
+These can values be set with the `panoptes_aggregation config` command using the `--keywords` flag (e.g. `--keywords '{"T0": {"recursive": true, "recursive_subject_ids": true}}'`).
+````
 ---
 
 ## Extracting data

--- a/panoptes_aggregation/scripts/extract_panoptes_csv.py
+++ b/panoptes_aggregation/scripts/extract_panoptes_csv.py
@@ -35,10 +35,14 @@ def extract_classification(
     verbose
 ):
     try:
+        recursive_subject_ids = keyword.get('recursive_subject_ids', False)
         extract = extractors.extractors[extractor_key](classification_by_task, **keyword)
         new_extract_row = []
         if isinstance(extract, list):
-            for e in extract:
+            for edx, e in enumerate(extract):
+                subject_id = classification_info['subject_ids']
+                if recursive_subject_ids:
+                    subject_id = f'{subject_id}_{edx}'
                 new_extract_row.append(OrderedDict([
                     ('classification_id', classification_info['classification_id']),
                     ('user_name', classification_info['user_name']),
@@ -46,7 +50,7 @@ def extract_classification(
                     ('workflow_id', classification_info['workflow_id']),
                     ('task', keyword['task']),
                     ('created_at', classification_info['created_at']),
-                    ('subject_id', classification_info['subject_ids']),
+                    ('subject_id', subject_id),
                     ('extractor', extractor_name),
                     ('data', e)
                 ]))


### PR DESCRIPTION
Adds a new keyword for all extractors called `recursive`, if set each instance of each task is extracted as a new row.

Left to do:
- [x] Identify what task types this works with (not sure about drawing tasks)
- [x] Write documentation
- [x] Warn in the documentation that standard reduction will likely not work as expected