### PR TITLE
Addition of user skill calculation

### DIFF
--- a/panoptes_aggregation/extractors/utilities.py
+++ b/panoptes_aggregation/extractors/utilities.py
@@ -126,7 +126,11 @@ def get_feedback_info(feedback_dict):
 
     # each feedback tool has a unique set of keys which
     # hold the gold standard data (see feedback_strategies.py)
-    key_list = FEEDBACK_STRATEGIES[feedback_dict[0]['strategy']]
+    try:
+        key_list = FEEDBACK_STRATEGIES[feedback_dict[0]['strategy']]
+    except IndexError: # feedback_dict is empty, so return empty dict
+        return {}
+
 
     for classification in feedback_dict:
         # retrieve the success/failure flag for each classification

--- a/panoptes_aggregation/extractors/utilities.py
+++ b/panoptes_aggregation/extractors/utilities.py
@@ -128,9 +128,9 @@ def get_feedback_info(feedback_dict):
     # hold the gold standard data (see feedback_strategies.py)
     try:
         key_list = FEEDBACK_STRATEGIES[feedback_dict[0]['strategy']]
-    except IndexError: # feedback_dict is empty, so return empty dict
+    except IndexError:
+        # feedback_dict is empty, so return empty dict
         return {}
-
 
     for classification in feedback_dict:
         # retrieve the success/failure flag for each classification

--- a/panoptes_aggregation/feedback_strategies.py
+++ b/panoptes_aggregation/feedback_strategies.py
@@ -1,5 +1,5 @@
 FEEDBACK_STRATEGIES = {
     'graph2drange': ['x', 'width'],
     'singleAnswerQuestion': ['answer'],
-    'surveySimple': ['choice'] 
+    'surveySimple': ['choice']
 }

--- a/panoptes_aggregation/feedback_strategies.py
+++ b/panoptes_aggregation/feedback_strategies.py
@@ -1,4 +1,5 @@
 FEEDBACK_STRATEGIES = {
     'graph2drange': ['x', 'width'],
-    'singleAnswerQuestion': ['answer']
+    'singleAnswerQuestion': ['answer'],
+    'surveySimple': ['choice'] 
 }

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -20,6 +20,7 @@ from .optics_line_text_reducer import optics_line_text_reducer
 from .first_n_true_reducer import first_n_true_reducer
 from .first_n_false_reducer import first_n_false_reducer
 from .subject_difficulty_reducer import subject_difficulty_reducer
+from .test_user_skill import test_user_skill_reducer
 from ..copy_function import copy_function
 
 shortcut_reducer = copy_function(question_reducer, "shortcut_reducer")
@@ -47,4 +48,5 @@ reducers = {
     "first_n_true_reducer": first_n_true_reducer,
     "first_n_false_reducer": first_n_false_reducer,
     "subject_difficulty_reducer": subject_difficulty_reducer,
+    'test_user_skill_reducer': test_user_skill_reducer
 }

--- a/panoptes_aggregation/reducers/__init__.py
+++ b/panoptes_aggregation/reducers/__init__.py
@@ -20,7 +20,7 @@ from .optics_line_text_reducer import optics_line_text_reducer
 from .first_n_true_reducer import first_n_true_reducer
 from .first_n_false_reducer import first_n_false_reducer
 from .subject_difficulty_reducer import subject_difficulty_reducer
-from .test_user_skill import test_user_skill_reducer
+from .user_skill_reducer import user_skill_reducer
 from ..copy_function import copy_function
 
 shortcut_reducer = copy_function(question_reducer, "shortcut_reducer")
@@ -48,5 +48,5 @@ reducers = {
     "first_n_true_reducer": first_n_true_reducer,
     "first_n_false_reducer": first_n_false_reducer,
     "subject_difficulty_reducer": subject_difficulty_reducer,
-    'test_user_skill_reducer': test_user_skill_reducer
+    "user_skill_reducer": user_skill_reducer
 }

--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -42,6 +42,9 @@ def reducer_wrapper(
                     kwargs_extra_data['user_id'] = kwargs['user_id']
                 if relevant_reduction:
                     kwargs_extra_data['relevant_reduction'] = kwargs['relevant_reduction']
+
+            if 'binary' in kwargs.keys():
+                kwargs_details['binary'] = kwargs['binary']
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:
                 kwargs_process = process_kwargs(kwargs, defaults_process)

--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -44,7 +44,10 @@ def reducer_wrapper(
                     kwargs_extra_data['relevant_reduction'] = kwargs['relevant_reduction']
 
             if 'binary' in kwargs.keys():
-                kwargs_details['binary'] = kwargs['binary']
+                binary = kwargs['binary']
+                if isinstance(binary, str):
+                    binary = ast.literal_eval(binary)
+                kwargs_details['binary'] = binary
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:
                 kwargs_process = process_kwargs(kwargs, defaults_process)

--- a/panoptes_aggregation/reducers/test_user_skill.py
+++ b/panoptes_aggregation/reducers/test_user_skill.py
@@ -9,27 +9,41 @@ See also: tess_gold_standard_reducer
 '''
 from .reducer_wrapper import reducer_wrapper
 import numpy as np
+from ..feedback_strategies import FEEDBACK_STRATEGIES
 from sklearn.metrics import confusion_matrix
 import sys
+import ast
 
+print2 = lambda x: print(*x, file=sys.stderr, flush=True)
 
 @reducer_wrapper(relevant_reduction=True)
-def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False):
-    confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary)
+def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE'):
+    if isinstance(binary, str):
+        binary = ast.literal_eval(binary)
+    if binary:
+        classes = ['True', 'False']
+        confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary, None)
+    else:
+        confusion_simple, confusion_subject, classes = \
+            get_confusion_matrix(extracts, relevant_reduction, binary, null_class)
 
     #print(confusion_simple, file=sys.stderr)
     #print(confusion_subject, file=sys.stderr)
 
-    per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
+    # get both the weighted and non-weighted skill
+    weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
+    per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=0) + 1.e-16)
 
     #print(per_class_skill, file=sys.stderr)
 
+    # print2(("class skill: ", per_class_skill))
+
     #sys.stderr.flush()
 
-    return {'skill': per_class_skill[0]}
+    return {'skill': per_class_skill, 'weighted_skill': weight_per_class_skill, 'classes': classes, 'confusion_simple': confusion_simple}
 
 
-def get_confusion_matrix(extracts, relevant_reduction, binary):
+def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
     if binary:
         # binary always defaults to 2x2 where the second column
         # (gold standard = False) is NaN
@@ -89,39 +103,145 @@ def get_confusion_matrix(extracts, relevant_reduction, binary):
         
         #print(confusion_subject, file=sys.stderr)
         #sys.stderr.flush()
+        return (confusion_simple, confusion_subject)
     else:
         user_classifications = []
+        classes = []
+        strategy = extracts[0]['feedback']['strategy']
+
+        true_key = 'true_'+FEEDBACK_STRATEGIES[strategy][0]
+
+        true_values = []
 
         # first we need a list of labels
         # obtain a list of labels from user classifications
-        for extracti in extracts:
-            user_classifications += [key for key in extracti if isinstance(extracti[key], int)]
+        if strategy in ['singleAnswerQuestion']:
+            for extracti in extracts:
+                user_classifications += [key for key in extracti if isinstance(extracti[key], int)]
+                # get the same from the feedback data
+                true_values.extend(extracti['feedback'][true_key])
 
-        user_classifications = user_classifications
+            classes = user_classifications
+        elif strategy in ['surveySimple']:
+            # for survey simple, the idea is the same
+            # except that the keys have a value of 1 when the 
+            # user selects that class
+            for j, extracti in enumerate(extracts):
+                user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int)&(extracti[key]==1)]
+                classes              += [key for key in extracti.keys() if isinstance(extracti[key], int)]
+                true_values.extend(extracti['feedback'][true_key])
+                #print2(("classes: ", j, [key for key in extracti.keys() if isinstance(extracti[key], int)&(extracti[key]==1)]))
 
-        # get the same from the feedback data
-        true_values = [extracti['feedback']['true_answer'] for extracti in extracts]
+        #print2(("Extracts: ", extracts))
+
+        #print2(("# extracts: ", len(extracts)))
 
         # get a full list of classes as the union of the two sets of labels
-        classes = np.unique([*np.unique(user_classifications), *np.unique(true_values)])
+        #print2(("Classes: ", np.unique(classes)))
+        #print2(("True_values: ", true_values))
+        classes = np.sort(np.unique([*np.unique(classes), *np.unique(true_values)]))
+        classes = classes.tolist()
+        classes.append(null_class)
 
-        subject_difficulty = 1 - np.asarray([reductioni['data']['difficulty'][0]
-                                             for reductioni in relevant_reduction])
+        #print2(("Merged Classes: ", classes))
+
+
+        #print2(("Classifications: ", user_classifications))
+
+        difficulties = []
+        for reductioni in relevant_reduction:
+            difficulties.append( np.mean(reductioni['data']['difficulty']) )
+
+        subject_difficulty = 1 - np.asarray(difficulties)
 
         # find the easiest subject in the set and set all fully successful
         # subjects to this "easy" score. limit the easy score to 0.05 so that
         # we don't have a runaway growth of easy weights
-        difficulty_min = np.min([np.min(subject_difficulty[subject_difficulty > 0]), 0.05])
+        difficulty_min = np.max([np.min(subject_difficulty[subject_difficulty > 0], initial=0), 0.05])
 
         # limit the difficulty to a mininum of 0.05 so that
         # easy subjects still have some weight
         subject_difficulty[subject_difficulty == 0] = difficulty_min
 
-        mask = (np.asarray(true_values).flatten() == '4') & (np.asarray(user_classifications) == '4')
-        #print(np.asarray(true_values).flatten(), user_classifications, mask, len(mask), len(subject_difficulty), file=sys.stderr)
-        #print(subject_difficulty[mask], np.sum(subject_difficulty[mask]), file=sys.stderr)
+        true_counts = []
+        class_counts = []
+        subject_difficulties = []
 
-        confusion_simple = confusion_matrix(user_classifications, true_values)
-        confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty)
+        #print2(("# of difficulties", len(relevant_reduction)))
+        #print2(("# of extracts", len(extracts)))
 
-    return (confusion_simple, confusion_subject)
+        # we will loop through all the extracts and create a list 
+        # of user classified label and a corresponding gold standard
+        # label. then, the confusion matrix is just determined using
+        # the element-wise comparison between the two lists
+        for j, extract in enumerate(extracts):
+
+            # find a list of user classified labels in this extract
+            user_class_i  = [key for key in extract.keys() if isinstance(extract[key], int)&(extract[key]==1)]
+
+            # get a full list of classifications
+            classi = np.sort(np.unique([*np.unique(extract['feedback'][true_key]),
+                                        *np.unique(user_class_i)]))
+            classi = classi.tolist()
+
+            # create a temporary list of classes that will
+            # incorporate both the user selected classes
+            # and the tru classes
+            true_count_i = [null_class]*len(classi)
+            #print2(("Classi: ", extract['feedback'][true_key]))
+
+            # loop through the true classes and populate the corresponding
+            # indices in the list
+            for value in extract['feedback'][true_key]:
+                true_count_i[classi.index(value)] = value
+
+            # do the same for the user classifications
+            class_count_i = [null_class]*len(classi)
+            #print2((j, "user classi: ", user_class_i))
+            for value in user_class_i:
+                class_count_i[classi.index(value)] = value
+            
+            # add both lists to the master list of 
+            # classifications and true classes
+            true_counts.extend(true_count_i)
+            class_counts.extend(class_count_i)
+
+            # also add the subject difficulties for each extract. subject
+            # difficulty per class is not trivial to do, so we will average
+            # the subject difficulty across all the classes in this subject.
+            # easy subjects should get small bump for correct classifications
+            # while difficult subjects will get a huge bump for success
+            # do the opposite for failure scores: easy subject failures should be
+            # penalized more strongly compared to difficulty failures
+            subject_difficulty_i = [subject_difficulty[j]]*len(classi)
+            for class_ind in range(len(classi)):
+                if true_count_i[class_ind] != class_count_i[class_ind]:
+                    subject_difficulty_i[class_ind] = np.max([1. - subject_difficulty_i[class_ind], 0.05])
+
+            subject_difficulties.extend(subject_difficulty_i)
+
+        
+        #mask = (np.array(class_counts)!='NONE')&(np.array(true_counts)!='NONE')
+        #class_counts = np.asarray(class_counts)[mask]
+        #true_counts  = np.asarray(true_counts)[mask]
+        #print("Mask = ", mask, file=sys.stderr)
+        #print2(("Class counts: ", class_counts))
+        #print2(("True counts: ", subject_difficulties))
+
+        # get the simple confusion matrix without the subject difficulty
+        confusion_simple  = confusion_matrix(class_counts, true_counts, labels=classes)
+
+        # get the more complicated confusion matrix accounting for subject difficulty
+        confusion_subject = confusion_matrix(class_counts, true_counts, sample_weight=subject_difficulties,
+                                             labels=classes)
+
+        #print2(("Confusion: ", confusion_simple[classes.index('HIPPOPOTAMUS'),:]))
+        #confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty, labels=classes)
+
+        #confusion_simple  = confusion_matrix(user_classifications, true_values, labels=classes)
+        #confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty, labels=classes)
+
+        #print2(("Confusion_simple: ", confusion_simple))
+        #print2(("Len conf simple: ", len(confusion_simple)))
+
+        return (confusion_simple, confusion_subject, classes)

--- a/panoptes_aggregation/reducers/test_user_skill.py
+++ b/panoptes_aggregation/reducers/test_user_skill.py
@@ -1,0 +1,122 @@
+'''
+Subject Gold Standard Reducer for difficulty calculation
+---------------------------------------------------------
+This module provides functions to reduce the gold standard task extracts
+to determine a `difficulty' score per subject (defined as the fraction
+of succesful classification by all users for that subject)
+
+See also: tess_gold_standard_reducer
+'''
+from .reducer_wrapper import reducer_wrapper
+import numpy as np
+from sklearn.metrics import confusion_matrix
+import sys
+
+@reducer_wrapper(relevant_reduction=True)
+def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False):
+    confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary)
+
+    print(confusion_simple, file=sys.stderr)
+    print(confusion_subject, file=sys.stderr)
+
+    per_class_skill = (confusion_subject.diagonal())/(np.sum(confusion_subject, axis=0) + 1.e-16)
+
+    print(per_class_skill, file=sys.stderr)
+
+    sys.stderr.flush()
+
+    return {'skill': per_class_skill[0]}
+
+
+def get_confusion_matrix(extracts, relevant_reduction, binary):
+    if binary:
+        # binary always defaults to 2x2 where the second column
+        # (gold standard = False) is NaN
+        confusion_simple = np.zeros((2, 2))
+        confusion_subject = np.zeros((2, 2))
+
+        successes = []
+        difficulties = []
+
+        # create an array of success/failure. multiple cases
+        # per subject are treated independently, and the final
+        # array is a flattened version of all success/failure checks
+        for extracti, reductioni in zip(extracts, relevant_reduction):
+            successes.extend(extracti['feedback']['success'])
+
+            # input difficulty is inverted... we want higher difficulty
+            # values for subjects which were classified incorrectly
+            difficultyi = 1. - np.array(reductioni['data']['difficulty'])
+
+
+            difficulties.extend( list(difficultyi))
+        successes = np.asarray(successes)
+        difficulties = np.asarray(difficulties)
+
+        # find the easiest subject in the set and set all fully successful 
+        # subjects to this "easy" score. limit the easy score to 0.05 so that 
+        # we don't have a runaway growth of easy weights
+        difficulty_min = np.min([np.min(difficulties[difficulties>0], initial=0), 0.05])
+
+        # limit the difficulty to a mininum of 0.05 so that 
+        # easy subjects still have some weight
+        difficulties[difficulties==0] = difficulty_min
+
+        print(difficulties, file=sys.stderr)
+        print(successes, file=sys.stderr)
+
+        true_mask = successes==True
+        false_mask = successes==False
+
+        # create the confusion matrix from the list of success/failures
+        confusion_simple[0,0] = np.sum(true_mask)
+        confusion_simple[1,0] = np.sum(false_mask)
+        confusion_simple[:,1] = np.nan
+
+        # the true score is the sum of difficulties of the correct classifications
+        # so hard subjects give you a boost in score and the difficult subjects 
+        # give you a small increase
+        confusion_subject[0,0] = np.sum(difficulties[true_mask])
+
+        # do the opposite for failure scores: easy subject failures should be
+        # penalized more strongly compared to difficulty failures
+        confusion_subject[1,0] = np.sum(1. - difficulties[false_mask])
+        confusion_subject[:,1] = np.nan
+    else:
+        #feedback_data = [extracti['feedback'] for extracti in extracts if 'feedback' in extracti.keys()]
+        user_classifications = []
+
+        # first we need a list of labels 
+        # obtain a list of labels from user classifications
+        for extracti in extracts:
+            user_classifications += [key for key in extracti if isinstance(extracti[key], int)]
+
+        user_classifications = user_classifications
+
+        # get the same from the feedback data
+        true_values = [extracti['feedback']['true_answer'] for extracti in extracts]
+
+        # get a full list of classes as the union of the two sets of labels
+        classes = np.unique([*np.unique(user_classifications), *np.unique(true_values)])
+
+        nclasses = len(classes)
+
+        subject_difficulty = 1 - np.asarray([reductioni['data']['difficulty'][0] for reductioni in relevant_reduction])
+
+        # find the easiest subject in the set and set all fully successful 
+        # subjects to this "easy" score. limit the easy score to 0.05 so that 
+        # we don't have a runaway growth of easy weights
+        difficulty_min = np.min([np.min(subject_difficulty[subject_difficulty>0]), 0.05])
+
+        # limit the difficulty to a mininum of 0.05 so that 
+        # easy subjects still have some weight
+        subject_difficulty[subject_difficulty==0] = difficulty_min
+
+        mask = (np.asarray(true_values).flatten()=='4')&(np.asarray(user_classifications)=='4')
+        print(np.asarray(true_values).flatten(), user_classifications, mask, len(mask), len(subject_difficulty), file=sys.stderr)
+        print(subject_difficulty[mask], np.sum(subject_difficulty[mask]), file=sys.stderr)
+
+        confusion_simple = confusion_matrix(user_classifications, true_values)
+        confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty)
+
+    return (confusion_simple, confusion_subject)

--- a/panoptes_aggregation/reducers/test_user_skill.py
+++ b/panoptes_aggregation/reducers/test_user_skill.py
@@ -12,18 +12,19 @@ import numpy as np
 from sklearn.metrics import confusion_matrix
 import sys
 
+
 @reducer_wrapper(relevant_reduction=True)
 def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False):
     confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary)
 
-    print(confusion_simple, file=sys.stderr)
-    print(confusion_subject, file=sys.stderr)
+    #print(confusion_simple, file=sys.stderr)
+    #print(confusion_subject, file=sys.stderr)
 
-    per_class_skill = (confusion_subject.diagonal())/(np.sum(confusion_subject, axis=0) + 1.e-16)
+    per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
 
-    print(per_class_skill, file=sys.stderr)
+    #print(per_class_skill, file=sys.stderr)
 
-    sys.stderr.flush()
+    #sys.stderr.flush()
 
     return {'skill': per_class_skill[0]}
 
@@ -48,45 +49,50 @@ def get_confusion_matrix(extracts, relevant_reduction, binary):
             # values for subjects which were classified incorrectly
             difficultyi = 1. - np.array(reductioni['data']['difficulty'])
 
-
-            difficulties.extend( list(difficultyi))
+            difficulties.extend(list(difficultyi))
         successes = np.asarray(successes)
         difficulties = np.asarray(difficulties)
 
-        # find the easiest subject in the set and set all fully successful 
-        # subjects to this "easy" score. limit the easy score to 0.05 so that 
+        # find the easiest subject in the set and set all fully successful
+        # subjects to this "easy" score. limit the easy score to 0.05 so that
         # we don't have a runaway growth of easy weights
-        difficulty_min = np.min([np.min(difficulties[difficulties>0], initial=0), 0.05])
+        difficulty_min = np.max([np.min(difficulties[difficulties > 0], initial=0), 0.05])
 
-        # limit the difficulty to a mininum of 0.05 so that 
+        # limit the difficulty to a mininum of 0.05 so that
         # easy subjects still have some weight
-        difficulties[difficulties==0] = difficulty_min
+        difficulties[difficulties == 0] = difficulty_min
 
-        print(difficulties, file=sys.stderr)
-        print(successes, file=sys.stderr)
+        #print(f" Difficulty min: {difficulty_min}", file=sys.stderr)
+        #print(f"Difficulties: {difficulties}", file=sys.stderr)
+        #print(f"Success: {successes}", file=sys.stderr)
 
-        true_mask = successes==True
-        false_mask = successes==False
+        true_mask = successes == 1
+        false_mask = successes == 0
 
         # create the confusion matrix from the list of success/failures
-        confusion_simple[0,0] = np.sum(true_mask)
-        confusion_simple[1,0] = np.sum(false_mask)
-        confusion_simple[:,1] = np.nan
+        confusion_simple[0, 0] = np.sum(true_mask)
+        confusion_simple[1, 0] = np.sum(false_mask)
+        confusion_simple[:, 1] = np.nan
+
 
         # the true score is the sum of difficulties of the correct classifications
-        # so hard subjects give you a boost in score and the difficult subjects 
+        # so hard subjects give you a boost in score and the easy subjects
         # give you a small increase
-        confusion_subject[0,0] = np.sum(difficulties[true_mask])
+        confusion_subject[0, 0] = np.sum(difficulties[true_mask])
 
         # do the opposite for failure scores: easy subject failures should be
         # penalized more strongly compared to difficulty failures
-        confusion_subject[1,0] = np.sum(1. - difficulties[false_mask])
-        confusion_subject[:,1] = np.nan
+        neg_difficulty = 1. - difficulties[false_mask]
+        neg_difficulty[neg_difficulty==0] = difficulty_min
+        confusion_subject[1, 0] = np.sum(neg_difficulty)
+        confusion_subject[:, 1] = np.nan
+        
+        #print(confusion_subject, file=sys.stderr)
+        #sys.stderr.flush()
     else:
-        #feedback_data = [extracti['feedback'] for extracti in extracts if 'feedback' in extracti.keys()]
         user_classifications = []
 
-        # first we need a list of labels 
+        # first we need a list of labels
         # obtain a list of labels from user classifications
         for extracti in extracts:
             user_classifications += [key for key in extracti if isinstance(extracti[key], int)]
@@ -99,22 +105,21 @@ def get_confusion_matrix(extracts, relevant_reduction, binary):
         # get a full list of classes as the union of the two sets of labels
         classes = np.unique([*np.unique(user_classifications), *np.unique(true_values)])
 
-        nclasses = len(classes)
+        subject_difficulty = 1 - np.asarray([reductioni['data']['difficulty'][0]
+                                             for reductioni in relevant_reduction])
 
-        subject_difficulty = 1 - np.asarray([reductioni['data']['difficulty'][0] for reductioni in relevant_reduction])
-
-        # find the easiest subject in the set and set all fully successful 
-        # subjects to this "easy" score. limit the easy score to 0.05 so that 
+        # find the easiest subject in the set and set all fully successful
+        # subjects to this "easy" score. limit the easy score to 0.05 so that
         # we don't have a runaway growth of easy weights
-        difficulty_min = np.min([np.min(subject_difficulty[subject_difficulty>0]), 0.05])
+        difficulty_min = np.min([np.min(subject_difficulty[subject_difficulty > 0]), 0.05])
 
-        # limit the difficulty to a mininum of 0.05 so that 
+        # limit the difficulty to a mininum of 0.05 so that
         # easy subjects still have some weight
-        subject_difficulty[subject_difficulty==0] = difficulty_min
+        subject_difficulty[subject_difficulty == 0] = difficulty_min
 
-        mask = (np.asarray(true_values).flatten()=='4')&(np.asarray(user_classifications)=='4')
-        print(np.asarray(true_values).flatten(), user_classifications, mask, len(mask), len(subject_difficulty), file=sys.stderr)
-        print(subject_difficulty[mask], np.sum(subject_difficulty[mask]), file=sys.stderr)
+        mask = (np.asarray(true_values).flatten() == '4') & (np.asarray(user_classifications) == '4')
+        #print(np.asarray(true_values).flatten(), user_classifications, mask, len(mask), len(subject_difficulty), file=sys.stderr)
+        #print(subject_difficulty[mask], np.sum(subject_difficulty[mask]), file=sys.stderr)
 
         confusion_simple = confusion_matrix(user_classifications, true_values)
         confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty)

--- a/panoptes_aggregation/reducers/test_user_skill.py
+++ b/panoptes_aggregation/reducers/test_user_skill.py
@@ -11,10 +11,8 @@ from .reducer_wrapper import reducer_wrapper
 import numpy as np
 from ..feedback_strategies import FEEDBACK_STRATEGIES
 from sklearn.metrics import confusion_matrix
-import sys
 import ast
 
-print2 = lambda x: print(*x, file=sys.stderr, flush=True)
 
 @reducer_wrapper(relevant_reduction=True)
 def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE'):
@@ -27,18 +25,9 @@ def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_
         confusion_simple, confusion_subject, classes = \
             get_confusion_matrix(extracts, relevant_reduction, binary, null_class)
 
-    #print(confusion_simple, file=sys.stderr)
-    #print(confusion_subject, file=sys.stderr)
-
     # get both the weighted and non-weighted skill
     weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
     per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=0) + 1.e-16)
-
-    #print(per_class_skill, file=sys.stderr)
-
-    # print2(("class skill: ", per_class_skill))
-
-    #sys.stderr.flush()
 
     return {'skill': per_class_skill, 'weighted_skill': weight_per_class_skill, 'classes': classes, 'confusion_simple': confusion_simple}
 
@@ -76,10 +65,6 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         # easy subjects still have some weight
         difficulties[difficulties == 0] = difficulty_min
 
-        #print(f" Difficulty min: {difficulty_min}", file=sys.stderr)
-        #print(f"Difficulties: {difficulties}", file=sys.stderr)
-        #print(f"Success: {successes}", file=sys.stderr)
-
         true_mask = successes == 1
         false_mask = successes == 0
 
@@ -87,7 +72,6 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         confusion_simple[0, 0] = np.sum(true_mask)
         confusion_simple[1, 0] = np.sum(false_mask)
         confusion_simple[:, 1] = np.nan
-
 
         # the true score is the sum of difficulties of the correct classifications
         # so hard subjects give you a boost in score and the easy subjects
@@ -97,19 +81,17 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         # do the opposite for failure scores: easy subject failures should be
         # penalized more strongly compared to difficulty failures
         neg_difficulty = 1. - difficulties[false_mask]
-        neg_difficulty[neg_difficulty==0] = difficulty_min
+        neg_difficulty[neg_difficulty == 0] = difficulty_min
         confusion_subject[1, 0] = np.sum(neg_difficulty)
         confusion_subject[:, 1] = np.nan
-        
-        #print(confusion_subject, file=sys.stderr)
-        #sys.stderr.flush()
+
         return (confusion_simple, confusion_subject)
     else:
         user_classifications = []
         classes = []
         strategy = extracts[0]['feedback']['strategy']
 
-        true_key = 'true_'+FEEDBACK_STRATEGIES[strategy][0]
+        true_key = 'true_' + FEEDBACK_STRATEGIES[strategy][0]
 
         true_values = []
 
@@ -124,33 +106,21 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
             classes = user_classifications
         elif strategy in ['surveySimple']:
             # for survey simple, the idea is the same
-            # except that the keys have a value of 1 when the 
+            # except that the keys have a value of 1 when the
             # user selects that class
             for j, extracti in enumerate(extracts):
-                user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int)&(extracti[key]==1)]
-                classes              += [key for key in extracti.keys() if isinstance(extracti[key], int)]
+                user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int) & (extracti[key] == 1)]
+                classes += [key for key in extracti.keys() if isinstance(extracti[key], int)]
                 true_values.extend(extracti['feedback'][true_key])
-                #print2(("classes: ", j, [key for key in extracti.keys() if isinstance(extracti[key], int)&(extracti[key]==1)]))
-
-        #print2(("Extracts: ", extracts))
-
-        #print2(("# extracts: ", len(extracts)))
 
         # get a full list of classes as the union of the two sets of labels
-        #print2(("Classes: ", np.unique(classes)))
-        #print2(("True_values: ", true_values))
         classes = np.sort(np.unique([*np.unique(classes), *np.unique(true_values)]))
         classes = classes.tolist()
         classes.append(null_class)
 
-        #print2(("Merged Classes: ", classes))
-
-
-        #print2(("Classifications: ", user_classifications))
-
         difficulties = []
         for reductioni in relevant_reduction:
-            difficulties.append( np.mean(reductioni['data']['difficulty']) )
+            difficulties.append(np.mean(reductioni['data']['difficulty']))
 
         subject_difficulty = 1 - np.asarray(difficulties)
 
@@ -167,17 +137,14 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         class_counts = []
         subject_difficulties = []
 
-        #print2(("# of difficulties", len(relevant_reduction)))
-        #print2(("# of extracts", len(extracts)))
-
-        # we will loop through all the extracts and create a list 
+        # we will loop through all the extracts and create a list
         # of user classified label and a corresponding gold standard
         # label. then, the confusion matrix is just determined using
         # the element-wise comparison between the two lists
         for j, extract in enumerate(extracts):
 
             # find a list of user classified labels in this extract
-            user_class_i  = [key for key in extract.keys() if isinstance(extract[key], int)&(extract[key]==1)]
+            user_class_i = [key for key in extract.keys() if isinstance(extract[key], int) & (extract[key] == 1)]
 
             # get a full list of classifications
             classi = np.sort(np.unique([*np.unique(extract['feedback'][true_key]),
@@ -187,8 +154,7 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
             # create a temporary list of classes that will
             # incorporate both the user selected classes
             # and the tru classes
-            true_count_i = [null_class]*len(classi)
-            #print2(("Classi: ", extract['feedback'][true_key]))
+            true_count_i = [null_class] * len(classi)
 
             # loop through the true classes and populate the corresponding
             # indices in the list
@@ -196,12 +162,12 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
                 true_count_i[classi.index(value)] = value
 
             # do the same for the user classifications
-            class_count_i = [null_class]*len(classi)
-            #print2((j, "user classi: ", user_class_i))
+            class_count_i = [null_class] * len(classi)
+
             for value in user_class_i:
                 class_count_i[classi.index(value)] = value
-            
-            # add both lists to the master list of 
+
+            # add both lists to the master list of
             # classifications and true classes
             true_counts.extend(true_count_i)
             class_counts.extend(class_count_i)
@@ -213,35 +179,18 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
             # while difficult subjects will get a huge bump for success
             # do the opposite for failure scores: easy subject failures should be
             # penalized more strongly compared to difficulty failures
-            subject_difficulty_i = [subject_difficulty[j]]*len(classi)
+            subject_difficulty_i = [subject_difficulty[j]] * len(classi)
             for class_ind in range(len(classi)):
                 if true_count_i[class_ind] != class_count_i[class_ind]:
                     subject_difficulty_i[class_ind] = np.max([1. - subject_difficulty_i[class_ind], 0.05])
 
             subject_difficulties.extend(subject_difficulty_i)
 
-        
-        #mask = (np.array(class_counts)!='NONE')&(np.array(true_counts)!='NONE')
-        #class_counts = np.asarray(class_counts)[mask]
-        #true_counts  = np.asarray(true_counts)[mask]
-        #print("Mask = ", mask, file=sys.stderr)
-        #print2(("Class counts: ", class_counts))
-        #print2(("True counts: ", subject_difficulties))
-
         # get the simple confusion matrix without the subject difficulty
-        confusion_simple  = confusion_matrix(class_counts, true_counts, labels=classes)
+        confusion_simple = confusion_matrix(class_counts, true_counts, labels=classes)
 
         # get the more complicated confusion matrix accounting for subject difficulty
         confusion_subject = confusion_matrix(class_counts, true_counts, sample_weight=subject_difficulties,
                                              labels=classes)
-
-        #print2(("Confusion: ", confusion_simple[classes.index('HIPPOPOTAMUS'),:]))
-        #confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty, labels=classes)
-
-        #confusion_simple  = confusion_matrix(user_classifications, true_values, labels=classes)
-        #confusion_subject = confusion_matrix(user_classifications, true_values, sample_weight=subject_difficulty, labels=classes)
-
-        #print2(("Confusion_simple: ", confusion_simple))
-        #print2(("Len conf simple: ", len(confusion_simple)))
 
         return (confusion_simple, confusion_subject, classes)

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -111,7 +111,7 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
             # for survey simple, the idea is the same
             # except that the keys have a value of 1 when the
             # user selects that class
-            for j, extracti in enumerate(extracts):
+            for extracti in extracts:
                 user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int) & (extracti[key] == 1)]
                 classes += [key for key in extracti.keys() if isinstance(extracti[key], int)]
                 true_values.extend(extracti['feedback'][true_key])

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -15,7 +15,7 @@ import ast
 
 
 @reducer_wrapper(relevant_reduction=True)
-def test_user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE'):
+def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE'):
     if isinstance(binary, str):
         binary = ast.literal_eval(binary)
     if binary:

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -29,7 +29,10 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
     weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
     per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=0) + 1.e-16)
 
-    return {'skill': per_class_skill, 'weighted_skill': weight_per_class_skill, 'classes': classes, 'confusion_simple': confusion_simple}
+    return {'skill': per_class_skill.tolist(),
+            'weighted_skill': weight_per_class_skill.tolist(),
+            'classes': classes,
+            'confusion_simple': confusion_simple.tolist()}
 
 
 def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
@@ -71,7 +74,7 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         # create the confusion matrix from the list of success/failures
         confusion_simple[0, 0] = np.sum(true_mask)
         confusion_simple[1, 0] = np.sum(false_mask)
-        confusion_simple[:, 1] = np.nan
+        confusion_simple[:, 1] = 0
 
         # the true score is the sum of difficulties of the correct classifications
         # so hard subjects give you a boost in score and the easy subjects
@@ -83,7 +86,7 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         neg_difficulty = 1. - difficulties[false_mask]
         neg_difficulty[neg_difficulty == 0] = difficulty_min
         confusion_subject[1, 0] = np.sum(neg_difficulty)
-        confusion_subject[:, 1] = np.nan
+        confusion_subject[:, 1] = 0
 
         return (confusion_simple, confusion_subject)
     else:

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -11,13 +11,10 @@ from .reducer_wrapper import reducer_wrapper
 import numpy as np
 from ..feedback_strategies import FEEDBACK_STRATEGIES
 from sklearn.metrics import confusion_matrix
-import ast
 
 
 @reducer_wrapper(relevant_reduction=True)
 def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE'):
-    if isinstance(binary, str):
-        binary = ast.literal_eval(binary)
     if binary:
         classes = ['True', 'False']
         confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary, None)

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -1,0 +1,290 @@
+from panoptes_aggregation.reducers.user_skill_reducer import user_skill_reducer
+from .base_test_class import ReducerTest
+import numpy as np
+
+
+def process(data):
+    return data
+
+
+extracted_data = [
+    {
+        "WILDEBEEST": 1,
+        "ZEBRA": 1,
+        "feedback": {
+            "true_choice": [
+                "WILDEBEEST",
+                "ZEBRA"
+            ],
+            "strategy": "surveySimple"
+        },
+    },
+    {
+        "WILDEBEEST": 1,
+        "CHEETAH": 1,
+        "feedback": {
+            "true_choice": [
+                "WILDEBEEST",
+                "ZEBRA"
+            ],
+            "strategy": "surveySimple"
+        },
+    }
+]
+
+kwargs_extra_data = {
+    "relevant_reduction": [
+        {
+            "data": {
+                "difficulty": [
+                    1.0,
+                    0.13043478260869565
+                ]
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    1.0,
+                    0.13043478260869565
+                ]
+            }
+        }
+    ]
+}
+
+
+reduced_data = {
+    "classes": [
+        "CHEETAH",
+        "WILDEBEEST",
+        "ZEBRA",
+        "NONE"
+    ],
+    "confusion_simple": [
+        [
+            0,
+            0,
+            0,
+            1
+        ],
+        [
+            0,
+            2,
+            0,
+            0
+        ],
+        [
+            0,
+            0,
+            1,
+            0
+        ],
+        [
+            0,
+            0,
+            1,
+            0
+        ]
+    ],
+    "skill": [
+        0.0,
+        1.0,
+        0.5,
+        0.0
+    ],
+    "weighted_skill": [
+        0.0,
+        0.9999999999999999,
+        0.4347826086956522,
+        0.0
+    ]
+}
+
+
+TestkClassUserSkillReducer = ReducerTest(
+    user_skill_reducer,
+    process,
+    extracted_data,
+    extracted_data,
+    reduced_data,
+    'Test k-class user skill reducer',
+    network_kwargs=kwargs_extra_data,
+    add_version=False,
+    processed_type='list',
+    test_name='TestkClassUserSkillReducer'
+)
+
+extracted_data = [
+    {
+        "frame0.T1_tool0_x": [
+            7.007341202533306,
+            15.085714457468555,
+            23.197817872132134
+        ],
+        "frame0.T1_tool0_width": [
+            0.3710317570116386,
+            0.4722222361966306,
+            0.43849207646830024
+        ],
+        "feedback": {
+            "success": [
+                True,
+                True,
+                True
+            ],
+            "true_x": [
+                23.143580364475866,
+                15.054503464475864,
+                6.965426564475864
+            ],
+            "true_width": [
+                0.3,
+                0.3,
+                0.3
+            ]
+        },
+    },
+    {
+        "frame0.T1_tool0_x": [
+            1.0201915505666743,
+            7.546677964132965,
+            20.683972321156585,
+            27.345373182548535
+        ],
+        "frame0.T1_tool0_width": [
+            0.40474334347697927,
+            0.43847195543339446,
+            0.33728611956414767,
+            0.4384719554333891
+        ],
+        "feedback": {
+            "success": [
+                True,
+                True,
+                True,
+                True
+            ],
+            "true_x": [
+                27.29064002867498,
+                20.71495532867498,
+                7.5635859286749785,
+                0.9879012286749784
+            ],
+            "true_width": [
+                0.3,
+                0.3,
+                0.3,
+                0.3
+            ]
+        },
+    },
+    {
+        "frame0.T1_tool0_x": [
+            6.702486768179421,
+            19.95589913093957
+        ],
+        "frame0.T1_tool0_width": [
+            0.43840804253405086,
+            0.37096065137496126
+        ],
+        "feedback": {
+            "success": [
+                False,
+                True,
+                False,
+                False,
+                True,
+                False
+            ],
+            "true_x": [
+                24.38699889454371,
+                19.956099794543707,
+                15.525200694543706,
+                11.094301594543705,
+                6.663402494543703,
+                2.232503394543703
+            ],
+            "true_width": [
+                0.3,
+                0.3,
+                0.3,
+                0.3,
+                0.3,
+                0.3
+            ]
+        }
+    }
+]
+
+kwargs_extra_data = {
+    "relevant_reduction": [
+        {
+            "data": {
+                "difficulty": [
+                    0.8333333333333334,
+                    0.8333333333333334,
+                    0.8333333333333334
+                ]
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    0.8,
+                    0.8,
+                    0.8,
+                    0.8
+                ]
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    0.0,
+                    0.8571428571428571,
+                    0.14285714285714285,
+                    0.0,
+                    0.8571428571428571,
+                    0.0
+                ]
+            }
+        }
+    ],
+}
+
+
+reduced_data = {
+    "skill": np.asarray([
+        0.6923076923076923, 0
+    ]).tolist(),
+    "weighted_skill": np.asarray([
+        0.844106463878327, 0
+    ]).tolist(),
+    "classes": [
+        "True",
+        "False"
+    ],
+    "confusion_simple": np.asarray([
+        [
+            9.0, 0
+        ],
+        [
+            4.0, 0
+        ]
+    ]).tolist(),
+}
+
+TestBinaryUserSkillReducer = ReducerTest(
+    user_skill_reducer,
+    process,
+    extracted_data,
+    extracted_data,
+    reduced_data,
+    'Test binary user skill reducer',
+    network_kwargs=kwargs_extra_data,
+    kwargs={'binary': True},
+    add_version=False,
+    processed_type='list',
+    test_name='TestBinaryUserSkillReducer'
+)


### PR DESCRIPTION
Added a generalized user skill calculation which works in two modes:

* Binary: this is when you don't have multiple classes for the data, but rather just a calculation of whether the user got a classification correct vs incorrect. For example, this is the case for projects like Planet Hunters TESS, where there are no classes to the lightcurve
* k-class: when the user has multiple classes to select from (e.g. through question/survey task) and we need to track the success/failure for individual classes

The mode is determined by passing the `binary` keyword to the reducer. Setting `binary=False` runs the reducer in k-class mode (default).

Success/failure is tracked on FEM using the feedback module. We use a pluck extract to extract the feedback metadata and calculate subject difficulty (#509). This is passed as `relevant_reduction` to the user skill reducer. 

The general framework is to using feedback data to evaluate the skill of the user as they complete gold standard classifications. Correct classifications should increase the user skill, while incorrect gold standard classifications will reduce the user skill. The subject difficulty is used to weight the relative increase/decrease of user skill. Getting difficult subjects (i.e. those that very few users have gotten correctly) will boost user skill much more than getting easy subjects correct. Conversely, getting difficult subjects incorrect should lead to a smaller skill penalty compared to getting easy subjects incorrect.

## Basic algorithm:

### Binary problem
The reducer creates a 2x2 confusion matrix (TP, TN, FP, FN), where the TN and FN entries are not defined. TP is the sum of successes weighted by the subject difficulty, while FP is the sum of failures weighted by `1-subject_difficulty`. 

### k-class problem
First, we obtain a full list of labels from both the `true_` keyword from the feedback pluck as well as from the classifications. For `k` labels, we define a `k x k` confusion matrix. The matrix is then filled by looping through the extracts and adding counts to the relevant cell (weighted by difficulty of the subject in that extract). Confusion matrix is constructed using `sklearn.metrics.confusion_matrix` by passing the `subject_difficulty` as the weights for each entry.

For both modes, we set a minimum subject difficulty at `0.05`, so that very easy subjects still have a non-zero effect on the user skill. 