### PR TITLE
Refactor userify.py tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ pip install -U git+https://github.com/zooniverse/aggregation-for-caesar.git#egg=
 #### Anaconda build of python
 If your are using the anaconda version of python some of the dependencies should be installed using the `conda` package manager before installing `panoptes_aggregation`:
 ```bash
-conda install -c conda-forge python-levenshtein hdbscan
-conda install wxpython psutil
+conda install -c conda-forge python-levenshtein hdbscan wxpython
+conda install psutil
 ```
 
 #### Mac Anaconda build

--- a/panoptes_aggregation/panoptes/userify.py
+++ b/panoptes_aggregation/panoptes/userify.py
@@ -7,10 +7,14 @@ about all users whose ids appear in the provided object.
 from collections.abc import Iterable
 from json import dumps as jsonify
 from os import getenv
-from panoptes_client import Panoptes, User
-from panoptes_client.panoptes import PanoptesAPIException
 from yaml import safe_load
 import requests
+
+import logging
+panoptes_client_logger = logging.getLogger('panoptes_client').setLevel(logging.ERROR)
+
+from panoptes_client import Panoptes, User
+from panoptes_client.panoptes import PanoptesAPIException
 
 
 class ConfigurationError(Exception):

--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -9,11 +9,16 @@ extracts are full lines of text in the document.
 from sklearn.cluster import OPTICS
 import numpy as np
 from collections import defaultdict
-import collatex as col
 from .optics_text_utils import get_min_samples, metric, remove_user_duplication, cluster_of_one, order_lines
 from .text_utils import consensus_score, tokenize, extractor_index
 from .reducer_wrapper import reducer_wrapper
 import warnings
+
+with warnings.catch_warnings():
+    # collatex is a bit old, we can safely ignore this message as the display
+    # functions are optional and never used in this code
+    warnings.filterwarnings('ignore', category=DeprecationWarning, message='Importing display')
+    import collatex as col
 
 DEFAULTS = {
     'min_samples': {'default': 'auto', 'type': int},

--- a/panoptes_aggregation/reducers/shape_reducer_optics.py
+++ b/panoptes_aggregation/reducers/shape_reducer_optics.py
@@ -96,7 +96,9 @@ def shape_reducer_optics(data_by_tool, **kwargs):
             # default each point in no cluster
             clusters[frame]['{0}_cluster_labels'.format(tool)] = [-1] * loc.shape[0]
             if loc.shape[0] >= kwargs['min_samples']:
-                db = OPTICS(**kwargs).fit(loc)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings('ignore', category=RuntimeWarning)
+                    db = OPTICS(**kwargs).fit(loc)
                 # what cluster each point belongs to
                 clusters[frame]['{0}_cluster_labels'.format(tool)] = db.labels_.tolist()
                 for k in set(db.labels_):

--- a/panoptes_aggregation/reducers/text_reducer.py
+++ b/panoptes_aggregation/reducers/text_reducer.py
@@ -4,9 +4,15 @@ Text Tool Reducer
 This module provides functions to reducer the panoptes text tool into an
 alignment table.
 '''
-import collatex as col
 from .text_utils import consensus_score, tokenize
 from .reducer_wrapper import reducer_wrapper
+import warnings
+
+with warnings.catch_warnings():
+    # collatex is a bit old, we can safely ignore this message as the display
+    # functions are optional and never used in this code
+    warnings.filterwarnings('ignore', category=DeprecationWarning, message='Importing display')
+    import collatex as col
 
 # override the built-in tokenize
 col.core_classes.WordPunctuationTokenizer.tokenize = tokenize

--- a/panoptes_aggregation/reducers/text_utils.py
+++ b/panoptes_aggregation/reducers/text_utils.py
@@ -4,12 +4,18 @@ Text aggregation utilities
 This module provides utility functions used in the polyton-as-line-text-reducer code from
 :mod:`panoptes_aggregation.reducers.poly_line_text_reducer`.
 '''
-import collatex as col
 from collections import OrderedDict, Counter
 import copy
 import numpy as np
 from sklearn.cluster import DBSCAN
 import re
+import warnings
+
+with warnings.catch_warnings():
+    # collatex is a bit old, we can safely ignore this message as the display
+    # functions are optional and never used in this code
+    warnings.filterwarnings('ignore', category=DeprecationWarning, message='Importing display')
+    import collatex as col
 
 
 def tokenize(self, contents):

--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -1,6 +1,5 @@
 from importlib import import_module
 from unittest.mock import MagicMock, PropertyMock, Mock, patch
-from nose.tools import assert_equal, assert_raises, assert_count_equal, assert_is_instance
 import requests
 import unittest
 
@@ -29,213 +28,214 @@ def build_mock_user(**kwargs):
     return mock_user
 
 
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_userify():
-    panoptes._read_config = Mock(return_value={
-        'endpoints': {
-            'mockable': {
-                'url': 'https://demo1580318.mockable.io/mast',
-            },
-            'mast': {
-                'url': 'https://mast-forwarder.zooniverse.org/',
-                'auth-header': 'X-ASB-AUTH',
-                'auth-token': 'MAST_AUTH_TOKEN',
-            },
-        }
-    })
-
-    # doesn't choke if nothing to do
-    assert_equal(panoptes.userify({}, {'foo': 'bar'}), '{"foo": "bar"}')
-    assert_equal(panoptes.userify({'login': None}, {'foo': 'bar'}), '{"foo": "bar"}')
-    assert_equal(panoptes.userify({}, {}), '{}')
-    assert_equal(panoptes.userify({'login': None}, {}), '{}')
-
-    # removes restricted payload key/value pairs
-    assert_equal(panoptes.userify({'login': None}, {'reducer_key': 'T0', 'id': '1'}), '{"id": "1"}')
-
-    # fills out object correctly
-    (User.find) = Mock(return_value=build_mock_user(id=3, login="login 3"))
-    assert_equal(panoptes.userify({'login': None}, {'user_id': 3}), '{"user_id": 3, "users": [{"id": 3, "login": "login 3"}]}')
-
-    # forwards appropriately
-    requests.post = MagicMock()
-    assert_equal(panoptes.userify({'login': None, 'destination': 'mockable'}, {'user_id': 3}), '{"user_id": 3, "users": [{"id": 3, "login": "login 3"}]}')
-    (requests.post).assert_called_once()
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_unique():
-    # removes duplicate elements
-    assert_count_equal(panoptes._unique([]), [])
-    assert_count_equal(panoptes._unique([3]), [3])
-    assert_count_equal(panoptes._unique([3, 3]), [3])
-    assert_count_equal(panoptes._unique([3, 3, 3]), [3])
-    assert_count_equal(panoptes._unique([3, 4]), [3, 4])
-    assert_count_equal(panoptes._unique([1, 1, 2, 3]), [1, 2, 3])
-    assert_count_equal(panoptes._unique([1, 2, 3, 1]), [1, 2, 3])
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_flatten():
-    # makes any combination of lists and not-lists into a single flat list
-    assert_count_equal(list(panoptes._flatten([])), [])
-    assert_count_equal(list(panoptes._flatten([1])), [1])
-    assert_count_equal(list(panoptes._flatten([1, 2])), [1, 2])
-    assert_count_equal(list(panoptes._flatten([1, [2]])), [1, 2])
-    assert_count_equal(list(panoptes._flatten([[1], 2])), [1, 2])
-    assert_count_equal(list(panoptes._flatten([[1], [2]])), [1, 2])
-    assert_count_equal(list(panoptes._flatten([1, [2], 3])), [1, 2, 3])
-    assert_count_equal(list(panoptes._flatten([1, [2], 2])), [1, 2, 2])
-    assert_count_equal(list(panoptes._flatten([[1], 2, []])), [1, 2])
-    assert_count_equal(list(panoptes._flatten([[1], [], 2])), [1, 2])
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_discover_user_lookup_fields():
-    # can find list of allowd user fields
-    allowed_user_fields = {'login': '', 'credited_name': '', 'display_name': '', 'id': ''}
-    assert_count_equal(panoptes._discover_user_lookup_fields(allowed_user_fields), ['login', 'credited_name', 'display_name', 'id'])
-
-    # ignores missing or not allowed known user fields
-    assert_count_equal(panoptes._discover_user_lookup_fields({}), [])
-    assert_count_equal(panoptes._discover_user_lookup_fields({'email': ''}), [])
-    assert_count_equal(panoptes._discover_user_lookup_fields({'f1': 'v1', 'created_at': 'v2'}), [])
-    assert_count_equal(panoptes._discover_user_lookup_fields({'f1': 'v1', 'destination': 'd1', 'f2': 'v2'}), [])
-
-    # ignores known fields
-    assert_count_equal(panoptes._discover_user_lookup_fields({'destination': 'v1'}), [])
-    assert_count_equal(panoptes._discover_user_lookup_fields({'destination': 'v1', 'f2': 'v2'}), [])
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_build_user_hash():
-    mock_user = build_mock_user(id=1, login='login', display_name='display_name')
-
-    # fetches the specified properties and puts them in a hash
-    assert_equal(panoptes._build_user_hash(mock_user, []), {'id': 1})
-    assert_equal(panoptes._build_user_hash(mock_user, ['login']), {'id': 1, 'login': 'login'})
-    assert_equal(panoptes._build_user_hash(mock_user, ['display_name']), {'id': 1, 'display_name': 'display_name'})
-    assert_equal(panoptes._build_user_hash(mock_user, ['login', 'display_name']), {'id': 1, 'login': 'login', 'display_name': 'display_name'})
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_retrieve_user():
-    mock_user1 = build_mock_user(id=1, login='login', display_name='display_name')
-    mock_user2 = build_mock_user(id=2, login='login', display_name='display_name')
-
-    # finds user by calling API
-    User.find = Mock(return_value=mock_user1)
-    found_user = panoptes._retrieve_user(1)
-    assert_equal(found_user, mock_user1)
-    assert_equal(found_user.id, 1)
-    (User.find).assert_called_once_with(1)
-
-    # uses cached user object when possible instead of finding it again
-    User.find = Mock(return_value=mock_user2)
-    found_user = panoptes._retrieve_user(1)
-    assert_equal(found_user, mock_user1)
-    assert_equal(found_user.id, 1)
-    (User.find).assert_not_called()
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_retrieve_user_error():
-    User.find = MagicMock(side_effect=[PanoptesAPIException('test')])
-    found_user = panoptes._retrieve_user(10)
-    assert_is_instance(found_user, panoptes.CantFindUser)
-    assert_equal(found_user.id, 10)
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_discover_user_ids():
-    # finds user_id if present
-    assert_count_equal(panoptes._discover_user_ids({'foo': 'bar'}), [])
-    assert_count_equal(panoptes._discover_user_ids({'user_id': 3}), [3])
-    assert_count_equal(panoptes._discover_user_ids({'foo': 'bar', 'user_id': 3}), [3])
-
-    # doesn't recurse into child objects
-    assert_count_equal(panoptes._discover_user_ids({'foo': {'user_id': 3}}), [])
-
-    # finds user_ids
-    assert_count_equal(panoptes._discover_user_ids({'user_ids': [3, 4]}), [3, 4])
-
-    # combines user_ids and user_id if both present
-    assert_count_equal(panoptes._discover_user_ids({'user_ids': [3, 4], 'user_id': 5}), [3, 4, 5])
-
-
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
 def user_find_side_effect(*args, **_):
     user_id = args[0]
     return build_mock_user(id=user_id, login='login {0}'.format(user_id), display_name='display_name {0}'.format(user_id))
 
 
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_stuff_object():
-    User.find = MagicMock(side_effect=user_find_side_effect)
+class TestUserify(unittest.TestCase):
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_userify(self):
+        panoptes._read_config = Mock(
+            return_value={
+                'endpoints': {
+                    'mockable': {
+                        'url': 'https://demo1580318.mockable.io/mast',
+                    },
+                    'mast': {
+                        'url': 'https://mast-forwarder.zooniverse.org/',
+                        'auth-header': 'X-ASB-AUTH',
+                        'auth-token': 'MAST_AUTH_TOKEN',
+                    },
+                }
+            }
+        )
 
-    # doesn't crash on an empty object
-    assert_equal(panoptes._stuff_object({}, []), {})
-    assert_equal(panoptes._stuff_object({}, ['login']), {})
+        # doesn't choke if nothing to do
+        self.assertEqual(panoptes.userify({}, {'foo': 'bar'}), '{"foo": "bar"}')
+        self.assertEqual(panoptes.userify({'login': None}, {'foo': 'bar'}), '{"foo": "bar"}')
+        self.assertEqual(panoptes.userify({}, {}), '{}')
+        self.assertEqual(panoptes.userify({'login': None}, {}), '{}')
 
-    # maintains existing properties
-    assert_equal(panoptes._stuff_object({'foo': 'bar'}, ['login']), {'foo': 'bar'})
-    assert_equal(panoptes._stuff_object({'foo': 'bar'}, []), {'foo': 'bar'})
+        # removes restricted payload key/value pairs
+        self.assertEqual(panoptes.userify({'login': None}, {'reducer_key': 'T0', 'id': '1'}), '{"id": "1"}')
 
-    # builds a user even if no fields are requested
-    assert_equal(panoptes._stuff_object({'user_id': 3}, []), {'user_id': 3, 'users': [{'id': 3}]})
+        # fills out object correctly
+        (User.find) = Mock(return_value=build_mock_user(id=3, login="login 3"))
+        self.assertEqual(panoptes.userify({'login': None}, {'user_id': 3}), '{"user_id": 3, "users": [{"id": 3, "login": "login 3"}]}')
 
-    # adds requested fields
-    assert_equal(panoptes._stuff_object({'user_id': 3}, ['login']), {'user_id': 3, 'users': [{'id': 3, 'login': 'login 3'}]})
-    assert_equal(panoptes._stuff_object({'user_id': 3}, ['display_name']), {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3'}]})
-    assert_equal(panoptes._stuff_object({'user_id': 3}, ['login', 'display_name']), {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3', 'login': 'login 3'}]})
+        # forwards appropriately
+        requests.post = MagicMock()
+        self.assertEqual(panoptes.userify({'login': None, 'destination': 'mockable'}, {'user_id': 3}), '{"user_id": 3, "users": [{"id": 3, "login": "login 3"}]}')
+        (requests.post).assert_called_once()
 
-    # finds fields in nested objects
-    assert_equal(panoptes._stuff_object({'foo': {'user_id': 3}}, ['login', 'display_name']), {'foo': {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3', 'login': 'login 3'}]}})
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_unique(self):
+        # removes duplicate elements
+        self.assertCountEqual(panoptes._unique([]), [])
+        self.assertCountEqual(panoptes._unique([3]), [3])
+        self.assertCountEqual(panoptes._unique([3, 3]), [3])
+        self.assertCountEqual(panoptes._unique([3, 3, 3]), [3])
+        self.assertCountEqual(panoptes._unique([3, 4]), [3, 4])
+        self.assertCountEqual(panoptes._unique([1, 1, 2, 3]), [1, 2, 3])
+        self.assertCountEqual(panoptes._unique([1, 2, 3, 1]), [1, 2, 3])
 
-    # fetches multiple users if user_ids
-    assert_equal(panoptes._stuff_object({'user_ids': [3, 4]}, []), {'user_ids': [3, 4], 'users': [{'id': 3}, {'id': 4}]})
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_flatten(self):
+        # makes any combination of lists and not-lists into a single flat list
+        self.assertCountEqual(list(panoptes._flatten([])), [])
+        self.assertCountEqual(list(panoptes._flatten([1])), [1])
+        self.assertCountEqual(list(panoptes._flatten([1, 2])), [1, 2])
+        self.assertCountEqual(list(panoptes._flatten([1, [2]])), [1, 2])
+        self.assertCountEqual(list(panoptes._flatten([[1], 2])), [1, 2])
+        self.assertCountEqual(list(panoptes._flatten([[1], [2]])), [1, 2])
+        self.assertCountEqual(list(panoptes._flatten([1, [2], 3])), [1, 2, 3])
+        self.assertCountEqual(list(panoptes._flatten([1, [2], 2])), [1, 2, 2])
+        self.assertCountEqual(list(panoptes._flatten([[1], 2, []])), [1, 2])
+        self.assertCountEqual(list(panoptes._flatten([[1], [], 2])), [1, 2])
 
-    # handles null user ids
-    assert_equal(panoptes._stuff_object({'user_ids': [3, None]}, []), {'user_ids': [3, None], 'users': [{'id': 3}]})
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_discover_user_lookup_fields(self):
+        # can find list of allowed user fields
+        allowed_user_fields = {'login': '', 'credited_name': '', 'display_name': '', 'id': ''}
+        self.assertCountEqual(panoptes._discover_user_lookup_fields(allowed_user_fields), ['login', 'credited_name', 'display_name', 'id'])
 
-    # finds fields at multiple levels
-    assert_equal(panoptes._stuff_object({'foo': {'user_id': 3}, 'user_id': 4}, []), {'foo': {'user_id': 3, 'users': [{'id': 3}]}, 'user_id': 4, 'users': [{'id': 4}]})
+        # ignores missing or not allowed known user fields
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({}), [])
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({'email': ''}), [])
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({'f1': 'v1', 'created_at': 'v2'}), [])
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({'f1': 'v1', 'destination': 'd1', 'f2': 'v2'}), [])
 
+        # ignores known fields
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({'destination': 'v1'}), [])
+        self.assertCountEqual(panoptes._discover_user_lookup_fields({'destination': 'v1', 'f2': 'v2'}), [])
 
-@unittest.skipIf(OFFLINE, 'Installed in offline mode')
-def test_forward_contents():
-    panoptes._read_config = Mock(return_value={
-        'endpoints': {
-            'mockable': {
-                'url': 'https://demo1580318.mockable.io/mast',
-            },
-            'mast': {
-                'url': 'https://mast-forwarder.zooniverse.org/',
-                'auth-header': 'X-ASB-AUTH',
-                'auth-token': 'MAST_AUTH_TOKEN',
-            },
-        }
-    })
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_build_user_hash(self):
+        mock_user = build_mock_user(id=1, login='login', display_name='display_name')
 
-    # only will send to known endpoints
-    requests.post = MagicMock()
-    assert_raises(panoptes.ConfigurationError, lambda: panoptes._forward_contents('contents', None))
-    assert_raises(panoptes.ConfigurationError, lambda: panoptes._forward_contents('contents', ''))
-    assert_raises(panoptes.ConfigurationError, lambda: panoptes._forward_contents('contents', 'blah'))
-    (requests.post).assert_not_called()
+        # fetches the specified properties and puts them in a hash
+        self.assertEqual(panoptes._build_user_hash(mock_user, []), {'id': 1})
+        self.assertEqual(panoptes._build_user_hash(mock_user, ['login']), {'id': 1, 'login': 'login'})
+        self.assertEqual(panoptes._build_user_hash(mock_user, ['display_name']), {'id': 1, 'display_name': 'display_name'})
+        self.assertEqual(panoptes._build_user_hash(mock_user, ['login', 'display_name']), {'id': 1, 'login': 'login', 'display_name': 'display_name'})
 
-    # sends to known endpoints correctly
-    requests.post = MagicMock()
-    panoptes._forward_contents({'foo': 'bar'}, 'mockable')
-    (requests.post).assert_called_once_with(timeout=5, url='https://demo1580318.mockable.io/mast', json={'foo': 'bar'})
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_retrieve_user(self):
+        mock_user1 = build_mock_user(id=1, login='login', display_name='display_name')
+        mock_user2 = build_mock_user(id=2, login='login', display_name='display_name')
 
-    requests.post = MagicMock()
-    with patch.dict(os.environ, {'MAST_AUTH_TOKEN': 'foo'}):
-        panoptes._forward_contents({'foo': 'bar'}, 'mast')
+        # finds user by calling API
+        User.find = Mock(return_value=mock_user1)
+        found_user = panoptes._retrieve_user(1)
+        self.assertEqual(found_user, mock_user1)
+        self.assertEqual(found_user.id, 1)
+        (User.find).assert_called_once_with(1)
 
-    (requests.post).assert_called_once_with(
-        timeout=5,
-        url='https://mast-forwarder.zooniverse.org/',
-        json={'foo': 'bar'},
-        headers={'X-ASB-AUTH': 'foo'}
-    )
+        # uses cached user object when possible instead of finding it again
+        User.find = Mock(return_value=mock_user2)
+        found_user = panoptes._retrieve_user(1)
+        self.assertEqual(found_user, mock_user1)
+        self.assertEqual(found_user.id, 1)
+        (User.find).assert_not_called()
+
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_retrieve_user_error(self):
+        User.find = MagicMock(side_effect=[PanoptesAPIException('test')])
+        found_user = panoptes._retrieve_user(10)
+        self.assertIsInstance(found_user, panoptes.CantFindUser)
+        self.assertEqual(found_user.id, 10)
+
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_discover_user_ids(self):
+        # finds user_id if present
+        self.assertCountEqual(panoptes._discover_user_ids({'foo': 'bar'}), [])
+        self.assertCountEqual(panoptes._discover_user_ids({'user_id': 3}), [3])
+        self.assertCountEqual(panoptes._discover_user_ids({'foo': 'bar', 'user_id': 3}), [3])
+
+        # doesn't recurse into child objects
+        self.assertCountEqual(panoptes._discover_user_ids({'foo': {'user_id': 3}}), [])
+
+        # finds user_ids
+        self.assertCountEqual(panoptes._discover_user_ids({'user_ids': [3, 4]}), [3, 4])
+
+        # combines user_ids and user_id if both present
+        self.assertCountEqual(panoptes._discover_user_ids({'user_ids': [3, 4], 'user_id': 5}), [3, 4, 5])
+
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_stuff_object(self):
+        User.find = MagicMock(side_effect=user_find_side_effect)
+
+        # doesn't crash on an empty object
+        self.assertEqual(panoptes._stuff_object({}, []), {})
+        self.assertEqual(panoptes._stuff_object({}, ['login']), {})
+
+        # maintains existing properties
+        self.assertEqual(panoptes._stuff_object({'foo': 'bar'}, ['login']), {'foo': 'bar'})
+        self.assertEqual(panoptes._stuff_object({'foo': 'bar'}, []), {'foo': 'bar'})
+
+        # builds a user even if no fields are requested
+        self.assertEqual(panoptes._stuff_object({'user_id': 3}, []), {'user_id': 3, 'users': [{'id': 3}]})
+
+        # adds requested fields
+        self.assertEqual(panoptes._stuff_object({'user_id': 3}, ['login']), {'user_id': 3, 'users': [{'id': 3, 'login': 'login 3'}]})
+        self.assertEqual(panoptes._stuff_object({'user_id': 3}, ['display_name']), {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3'}]})
+        self.assertEqual(panoptes._stuff_object({'user_id': 3}, ['login', 'display_name']), {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3', 'login': 'login 3'}]})
+
+        # finds fields in nested objects
+        self.assertEqual(panoptes._stuff_object({'foo': {'user_id': 3}}, ['login', 'display_name']), {'foo': {'user_id': 3, 'users': [{'id': 3, 'display_name': 'display_name 3', 'login': 'login 3'}]}})
+
+        # fetches multiple users if user_ids
+        self.assertEqual(panoptes._stuff_object({'user_ids': [3, 4]}, []), {'user_ids': [3, 4], 'users': [{'id': 3}, {'id': 4}]})
+
+        # handles null user ids
+        self.assertEqual(panoptes._stuff_object({'user_ids': [3, None]}, []), {'user_ids': [3, None], 'users': [{'id': 3}]})
+
+        # finds fields at multiple levels
+        self.assertEqual(panoptes._stuff_object({'foo': {'user_id': 3}, 'user_id': 4}, []), {'foo': {'user_id': 3, 'users': [{'id': 3}]}, 'user_id': 4, 'users': [{'id': 4}]})
+
+    @unittest.skipIf(OFFLINE, 'Installed in offline mode')
+    def test_forward_contents(self):
+        panoptes._read_config = Mock(
+            return_value={
+                'endpoints': {
+                    'mockable': {
+                        'url': 'https://demo1580318.mockable.io/mast',
+                    },
+                    'mast': {
+                        'url': 'https://mast-forwarder.zooniverse.org/',
+                        'auth-header': 'X-ASB-AUTH',
+                        'auth-token': 'MAST_AUTH_TOKEN',
+                    },
+                }
+            }
+        )
+
+        # only will send to known endpoints
+        requests.post = MagicMock()
+        with self.assertRaises(panoptes.ConfigurationError):
+            panoptes._forward_contents('contents', None)
+
+        with self.assertRaises(panoptes.ConfigurationError):
+            panoptes._forward_contents('contents', '')
+
+        with self.assertRaises(panoptes.ConfigurationError):
+            panoptes._forward_contents('contents', 'blah')
+
+        (requests.post).assert_not_called()
+
+        # sends to known endpoints correctly
+        requests.post = MagicMock()
+        panoptes._forward_contents({'foo': 'bar'}, 'mockable')
+        (requests.post).assert_called_once_with(timeout=5, url='https://demo1580318.mockable.io/mast', json={'foo': 'bar'})
+
+        requests.post = MagicMock()
+        with patch.dict(os.environ, {'MAST_AUTH_TOKEN': 'foo'}):
+            panoptes._forward_contents({'foo': 'bar'}, 'mast')
+
+        (requests.post).assert_called_once_with(
+            timeout=5,
+            url='https://mast-forwarder.zooniverse.org/',
+            json={'foo': 'bar'},
+            headers={'X-ASB-AUTH': 'foo'}
+        )

--- a/panoptes_aggregation/tests/panoptes_tests/test_userify.py
+++ b/panoptes_aggregation/tests/panoptes_tests/test_userify.py
@@ -6,6 +6,9 @@ import unittest
 import os
 from os import environ
 
+import logging
+panoptes_client_logger = logging.getLogger('panoptes_client').setLevel(logging.ERROR)
+
 try:
     from panoptes_client import Panoptes, User
     from panoptes_client.panoptes import PanoptesAPIException


### PR DESCRIPTION
This PR refactors the userify tests to use python's built-in unit test package rather than `nose`.  This brings consistency in how all the tests are written and will allow the package to switch test runners in the future (it will be change to `pytest` in a future PR).

In preparation for the `pytest` switch various warnings in the code have been addressed throughout the code (in most cases they are false flags and are just fine as is).