### PR TITLE
Un-break HDBSCAN install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         ]
     },
     install_requires=[
+        'joblib==1.1.0',
         'beautifulsoup4>=4.8.1,<4.11',
         'collatex>=2.2,<2.3',
         'hdbscan>=0.8.20,<0.8.29',


### PR DESCRIPTION
One of HDBSCAN's dependencies was updated and broke its ability to be installed.  This PR pins that dependency to a working version.  Once HDBSCAN releases an update this can be reverted.