### PR TITLE
include LICENSE in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include panoptes_aggregation/scripts/icons/*
+include LICENSE


### PR DESCRIPTION
This change ensures the `LICENSE` file is packaged along with source distributions uploaded to PyPI.

The motivation is in getting a [`conda-forge`](https://conda-forge.org/) automated build chain established, and license-box-ticking is one of the "brown m&ms" for well-behaved packages.

I will proceed sourcing it directly from GitHub in the meantime!