### PR TITLE
Use dependabot to update GHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   - dependency-name: numpy
     versions:
     - 1.20.0
+- directory: "/"
+  package-ecosystem: "github-actions"
+  schedule:
+    interval: weekly
+    time: "10:00"


### PR DESCRIPTION
This should allow dependabot to auto-open PRs when GHAs versions are updated.