### PR TITLE
Remove workaround for HDBSCAN

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         ]
     },
     install_requires=[
-        'joblib==1.1.0',
         'beautifulsoup4>=4.8.1,<4.11',
         'collatex>=2.2,<2.3',
         'hdbscan>=0.8.20,<0.8.30',


### PR DESCRIPTION
The latest HDBSCAN has been fixed to work with the latest `joblib` package, no need to pin an older version anymore.