### PR TITLE
fixed feedback strategy key for survey tasks

### DIFF
--- a/panoptes_aggregation/feedback_strategies.py
+++ b/panoptes_aggregation/feedback_strategies.py
@@ -1,5 +1,5 @@
 FEEDBACK_STRATEGIES = {
     'graph2drange': ['x', 'width'],
     'singleAnswerQuestion': ['answer'],
-    'surveySimple': ['choice']
+    'surveySimple': ['choiceIds']
 }

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -12,7 +12,7 @@ extracted_data = [
         "WILDEBEEST": 1,
         "ZEBRA": 1,
         "feedback": {
-            "true_choice": [
+            "true_choiceIds": [
                 "WILDEBEEST",
                 "ZEBRA"
             ],
@@ -23,7 +23,7 @@ extracted_data = [
         "WILDEBEEST": 1,
         "CHEETAH": 1,
         "feedback": {
-            "true_choice": [
+            "true_choiceIds": [
                 "WILDEBEEST",
                 "ZEBRA"
             ],


### PR DESCRIPTION
Fixing the feedback key for the `surveySimple` strategy. This should be `choiceIds` as per the [FEM documentation](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier/src/store/feedback/strategies/survey/simple) instead of `choice` as it currently is.