### PR TITLE
Changing data format for user skill reducer output

### DIFF
--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -48,6 +48,24 @@ def reducer_wrapper(
                 if isinstance(binary, str):
                     binary = ast.literal_eval(binary)
                 kwargs_details['binary'] = binary
+            if 'count_threshold' in kwargs.keys():
+                count_threshold = kwargs['count_threshold']
+                if isinstance(count_threshold, str):
+                    count_threshold = ast.literal_eval(count_threshold)
+                kwargs_details['count_threshold'] = count_threshold
+            if 'skill_threshold' in kwargs.keys():
+                skill_threshold = kwargs['skill_threshold']
+                if isinstance(skill_threshold, str):
+                    skill_threshold = ast.literal_eval(skill_threshold)
+                kwargs_details['skill_threshold'] = skill_threshold
+            if 'strategy' in kwargs.keys():
+                strategy = kwargs['strategy']
+                try:
+                    strategy = ast.literal_eval(strategy)
+                except ValueError:
+                    pass
+                kwargs_details['strategy'] = strategy
+
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:
                 kwargs_process = process_kwargs(kwargs, defaults_process)

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -26,10 +26,16 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
     weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
     per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=0) + 1.e-16)
 
-    return {'skill': per_class_skill.tolist(),
-            'weighted_skill': weight_per_class_skill.tolist(),
-            'classes': classes,
-            'confusion_simple': confusion_simple.tolist()}
+    weighted_per_class_skill_dict = {key: value for key, value in zip(classes, weight_per_class_skill)}
+    per_class_skill_dict = {key: value for key, value in zip(classes, per_class_skill)}
+    per_class_count = {key: value for key, value in zip(classes, np.sum(confusion_simple, axis=0))}
+
+    return {'classes': classes,
+            'confusion_simple': confusion_simple.tolist(),
+            'weighted_skill_dict': weighted_per_class_skill_dict,
+            'skill_dict': per_class_skill_dict,
+            'count': per_class_count
+            }
 
 
 def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -30,11 +30,15 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
     per_class_skill_dict = {key: value for key, value in zip(classes, per_class_skill)}
     per_class_count = {key: value for key, value in zip(classes, np.sum(confusion_simple, axis=0))}
 
+    null_removed_classes = [classi for classi in classes if classi != null_class]
+    mean_skill = np.sum([weighted_per_class_skill_dict[key] for key in null_removed_classes]) / (len(null_removed_classes) + 1.e-16)
+
     return {'classes': classes,
             'confusion_simple': confusion_simple.tolist(),
-            'weighted_skill_dict': weighted_per_class_skill_dict,
-            'skill_dict': per_class_skill_dict,
-            'count': per_class_count
+            'weighted_skill': weighted_per_class_skill_dict,
+            'skill': per_class_skill_dict,
+            'count': per_class_count,
+            'mean_skill': mean_skill
             }
 
 

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -84,9 +84,9 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
 
     # check the leveling up value
     if strategy == 'mean':
-        level_up = (mean_skill > skill_threshold) & all([c > count_threshold for c in null_removed_counts])
+        level_up = (mean_skill >= skill_threshold) & all([c >= count_threshold for c in null_removed_counts])
     elif strategy == 'all':
-        level_up = all([weighted_per_class_skill_dict[s] > skill_threshold for s in null_removed_classes]) & all([c > count_threshold for c in null_removed_counts])
+        level_up = all([weighted_per_class_skill_dict[s] >= skill_threshold for s in null_removed_classes]) & all([c >= count_threshold for c in null_removed_counts])
 
     return {'classes': classes,
             'confusion_simple': confusion_simple.tolist(),

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -39,6 +39,36 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
 
 
 def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
+    '''
+        Returns two confusion matrices (both unweighted and weighted by subject difficulty),
+        and the list of classes (for a k-class run). Note: confusion matrix for the k-class
+        version is a pseudo-confusion matrix since there can be multiple true classes and multiple
+        chosen classes per classification. This will require a many-to-many comparison which is
+        inherently impossible. Therefore, we compare all incorrectly chosen classes with the "null"
+        class instead.
+
+        Parameters
+        ----------
+        extracts : list
+            List of extracts for a given user
+        relevant_reduction : dict
+            Dictionary containing the `subject_difficulty` array that gives
+            the difficulty of the all the subjects seen by the user
+        binary : bool
+            Whether to run the reducer in binary (True/False) mode or k-class mode
+        null_class : string
+            The value of the null/non-existant class
+
+        Returns
+        -------
+        confusion_simple : list
+            Simple confusion matrix without subject difficulty weighting
+        confusion_subject : list
+            Confusion matrix with subject difficulty weighting
+        classes : list
+            List of unique classes corresponding to indices of the confusion matrix.
+            Only returned for k-class mode
+    '''
     if binary:
         # binary always defaults to 2x2 where the second column
         # (gold standard = False) is NaN

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -105,7 +105,8 @@ reduced_data = {
         "zebra": 2,
         "NONE": 1
     },
-    'mean_skill': 0.47826086956521735
+    'mean_skill': 0.47826086956521735,
+    'level_up': False
 }
 
 
@@ -118,6 +119,77 @@ TestkClassUserSkillReducer = ReducerTest(
     'Test k-class user skill reducer',
     network_kwargs=kwargs_extra_data,
     add_version=False,
+    processed_type='list',
+    test_name='TestkClassUserSkillReducer'
+)
+
+
+reduced_data_strategy_all = {
+    "classes": [
+        "cheetah",
+        "wildebeest",
+        "zebra",
+        "NONE"
+    ],
+    "confusion_simple": [
+        [
+            0,
+            0,
+            0,
+            1
+        ],
+        [
+            0,
+            2,
+            0,
+            0
+        ],
+        [
+            0,
+            0,
+            1,
+            0
+        ],
+        [
+            0,
+            0,
+            1,
+            0
+        ]
+    ],
+    "skill": {
+        "cheetah": 0.0,
+        "wildebeest": 1.0,
+        "zebra": 0.5,
+        "NONE": 0.0
+    },
+    "weighted_skill": {
+        "cheetah": 0.0,
+        "wildebeest": 0.9999999999999999,
+        "zebra": 0.4347826086956522,
+        "NONE": 0.0
+    },
+    "count": {
+        "cheetah": 0,
+        "wildebeest": 2,
+        "zebra": 2,
+        "NONE": 1
+    },
+    'mean_skill': 0.47826086956521735,
+    'level_up': False
+}
+
+
+TestkClassUserSkillReducerStrategyAll = ReducerTest(
+    user_skill_reducer,
+    process,
+    extracted_data,
+    extracted_data,
+    reduced_data,
+    'Test k-class user skill reducer',
+    network_kwargs=kwargs_extra_data,
+    add_version=False,
+    kwargs={'strategy': 'all', 'skill_threshold': 0.5, 'count_threshold': 1},
     processed_type='list',
     test_name='TestkClassUserSkillReducer'
 )
@@ -264,11 +336,11 @@ kwargs_extra_data = {
 reduced_data = {
     "skill": {
         "True": 0.6923076923076923,
-        "False": 0
+        "False": 0.0
     },
     "weighted_skill": {
         "True": 0.844106463878327,
-        "False": 0
+        "False": 0.0
     },
     "count": {
         "True": 13.0,
@@ -286,7 +358,8 @@ reduced_data = {
             4.0, 0
         ]
     ]).tolist(),
-    'mean_skill': 0.4220532319391635
+    'mean_skill': 0.844106463878327,
+    'level_up': True
 }
 
 TestBinaryUserSkillReducer = ReducerTest(

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -87,18 +87,25 @@ reduced_data = {
             0
         ]
     ],
-    "skill": [
-        0.0,
-        1.0,
-        0.5,
-        0.0
-    ],
-    "weighted_skill": [
-        0.0,
-        0.9999999999999999,
-        0.4347826086956522,
-        0.0
-    ]
+    "skill": {
+        "cheetah": 0.0,
+        "wildebeest": 1.0,
+        "zebra": 0.5,
+        "NONE": 0.0
+    },
+    "weighted_skill": {
+        "cheetah": 0.0,
+        "wildebeest": 0.9999999999999999,
+        "zebra": 0.4347826086956522,
+        "NONE": 0.0
+    },
+    "count": {
+        "cheetah": 0,
+        "wildebeest": 2,
+        "zebra": 2,
+        "NONE": 1
+    },
+    'mean_skill': 0.47826086956521735
 }
 
 
@@ -255,12 +262,18 @@ kwargs_extra_data = {
 
 
 reduced_data = {
-    "skill": np.asarray([
-        0.6923076923076923, 0
-    ]).tolist(),
-    "weighted_skill": np.asarray([
-        0.844106463878327, 0
-    ]).tolist(),
+    "skill": {
+        "True": 0.6923076923076923,
+        "False": 0
+    },
+    "weighted_skill": {
+        "True": 0.844106463878327,
+        "False": 0
+    },
+    "count": {
+        "True": 13.0,
+        "False": 0.0
+    },
     "classes": [
         "True",
         "False"
@@ -273,6 +286,7 @@ reduced_data = {
             4.0, 0
         ]
     ]).tolist(),
+    'mean_skill': 0.4220532319391635
 }
 
 TestBinaryUserSkillReducer = ReducerTest(


### PR DESCRIPTION
There are some issues in terms of setting up the rules with the current user skill reducer data format. It currently looks something like:

```
data: {
   confusion_matrix: [ [ ... ], [ ... ] ],
   skill: [...]
   classes: [...]
}
```

and this is difficult for calculating rules (since we want to level up users based on their skill in specific classes. We have to calculate the index of the class in the classes array and then find the corresponding skill from the skill array.
Instead, we replaced this data format with the below:
```
data: {
   confusion_matrix: [ [ ... ], [ ... ] ],
   skill: {
      class1: skill1,
      class2: skill2, ...
   },
   mean_skill: 0.5,
   classes: [...],
   level_up: False
}
```
and this way, we can use the `LOOKUP` keyword to extract specific keys from the skill dictionary or just use the `mean_skill` to level up users. Furthermore, we also do a simple level up check within the reducer as a default. This has two forms: 

 - `strategy = 'mean'`: Here we compare the mean skill with the `skill_threshold` parameter. If the mean skill is greater than this threshold and the number of classifications for each class is greater than `count_threshold`, the level up parameter is set to `True`
 - `strategy = 'all'`: Here we compare the skill for every class with the `skill_threshold` parameter. If all classes have a skill greater than this threshold and the number of classifications for each class is greater than `count_threshold`, the level up parameter is set to `True`.