### PR TITLE
Adding two modes to k-class user skill calculation

### DIFF
--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -43,13 +43,6 @@ def reducer_wrapper(
                 if relevant_reduction:
                     kwargs_extra_data['relevant_reduction'] = kwargs['relevant_reduction']
 
-            if 'mode' in kwargs.keys():
-                skill_mode = kwargs['mode']
-                try:
-                    skill_mode = ast.literal_eval(skill_mode)
-                except ValueError:
-                    pass
-                kwargs_details['mode'] = skill_mode
             if 'count_threshold' in kwargs.keys():
                 count_threshold = kwargs['count_threshold']
                 if isinstance(count_threshold, str):
@@ -60,13 +53,10 @@ def reducer_wrapper(
                 if isinstance(skill_threshold, str):
                     skill_threshold = ast.literal_eval(skill_threshold)
                 kwargs_details['skill_threshold'] = skill_threshold
-            if 'strategy' in kwargs.keys():
-                strategy = kwargs['strategy']
-                try:
-                    strategy = ast.literal_eval(strategy)
-                except ValueError:
-                    pass
-                kwargs_details['strategy'] = strategy
+            if 'mode' in kwargs:
+                kwargs_details['mode'] = kwargs['mode'].strip("\'")
+            if 'strategy' in kwargs:
+                kwargs_details['strategy'] = kwargs['strategy'].strip("\'")
 
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:

--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -43,11 +43,13 @@ def reducer_wrapper(
                 if relevant_reduction:
                     kwargs_extra_data['relevant_reduction'] = kwargs['relevant_reduction']
 
-            if 'binary' in kwargs.keys():
-                binary = kwargs['binary']
-                if isinstance(binary, str):
-                    binary = ast.literal_eval(binary)
-                kwargs_details['binary'] = binary
+            if 'mode' in kwargs.keys():
+                skill_mode = kwargs['mode']
+                try:
+                    skill_mode = ast.literal_eval(skill_mode)
+                except ValueError:
+                    pass
+                kwargs_details['mode'] = skill_mode
             if 'count_threshold' in kwargs.keys():
                 count_threshold = kwargs['count_threshold']
                 if isinstance(count_threshold, str):

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -13,8 +13,14 @@ from ..feedback_strategies import FEEDBACK_STRATEGIES
 from sklearn.metrics import confusion_matrix
 
 
+# smallest possible value for difficulty so that
+# subjects have a non-negligible effect on user skill
+# in extreme cases
+DIFFICULTY_FLOOR = 0.05
+
+
 @reducer_wrapper(relevant_reduction=True)
-def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class='NONE',
+def user_skill_reducer(extracts, relevant_reduction=[], mode='binary', null_class='NONE',
                        skill_threshold=0.7, count_threshold=10, strategy='mean'):
     '''
         Parameters
@@ -57,23 +63,23 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
                 - level_up : bool
                     flag to show whether the user should be leveled up using the input thresholds
     '''
-    if binary:
+    if mode == 'binary':
         classes = ['True', 'False']
-        confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, binary, None)
+        confusion_simple, confusion_subject = get_confusion_matrix(extracts, relevant_reduction, mode, None)
     else:
         confusion_simple, confusion_subject, classes = \
-            get_confusion_matrix(extracts, relevant_reduction, binary, null_class)
+            get_confusion_matrix(extracts, relevant_reduction, mode, null_class)
 
     # get both the weighted and non-weighted skill
-    weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=0) + 1.e-16)
-    per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=0) + 1.e-16)
+    weight_per_class_skill = (confusion_subject.diagonal()) / (np.sum(confusion_subject, axis=1) + 1.e-16)
+    per_class_skill = (confusion_simple.diagonal()) / (np.sum(confusion_simple, axis=1) + 1.e-16)
 
     weighted_per_class_skill_dict = {key: value for key, value in zip(classes, weight_per_class_skill)}
     per_class_skill_dict = {key: value for key, value in zip(classes, per_class_skill)}
-    per_class_count = {key: value for key, value in zip(classes, np.sum(confusion_simple, axis=0))}
+    per_class_count = {key: value for key, value in zip(classes, np.sum(confusion_simple, axis=1))}
 
     # remove the null class from the skill array to calculate the mean skill
-    if binary:
+    if mode == 'binary':
         null_removed_classes = [classi for classi in classes if classi != 'False']
         null_removed_counts = [ci for classi, ci in per_class_count.items() if classi != 'False']
         mean_skill = np.sum([weighted_per_class_skill_dict[key] for key in null_removed_classes]) / (len(null_removed_classes) + 1.e-16)
@@ -98,7 +104,7 @@ def user_skill_reducer(extracts, relevant_reduction=[], binary=False, null_class
             }
 
 
-def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
+def get_confusion_matrix(extracts, relevant_reduction, mode, null_class):
     '''
         Returns two confusion matrices (both unweighted and weighted by subject difficulty),
         and the list of classes (for a k-class run). Note: confusion matrix for the k-class
@@ -114,10 +120,10 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         relevant_reduction : dict
             Dictionary containing the `subject_difficulty` array that gives
             the difficulty of the all the subjects seen by the user
-        binary : bool
+        mode : str
             Whether to run the reducer in binary (True/False) mode or k-class mode
         null_class : string
-            The value of the null/non-existant class
+            The value of the null/non-existant class for the many-to-many k-class mode
 
         Returns
         -------
@@ -129,63 +135,13 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
             List of unique classes corresponding to indices of the confusion matrix.
             Only returned for k-class mode
     '''
-    if binary:
-        # binary always defaults to 2x2 where the second column
-        # (gold standard = False) is NaN
-        confusion_simple = np.zeros((2, 2))
-        confusion_subject = np.zeros((2, 2))
-
-        successes = []
-        difficulties = []
-
-        # create an array of success/failure. multiple cases
-        # per subject are treated independently, and the final
-        # array is a flattened version of all success/failure checks
-        for extracti, reductioni in zip(extracts, relevant_reduction):
-            successes.extend(extracti['feedback']['success'])
-
-            # input difficulty is inverted... we want higher difficulty
-            # values for subjects which were classified incorrectly
-            difficultyi = 1. - np.array(reductioni['data']['difficulty'])
-
-            difficulties.extend(list(difficultyi))
-        successes = np.asarray(successes)
-        difficulties = np.asarray(difficulties)
-
-        # find the easiest subject in the set and set all fully successful
-        # subjects to this "easy" score. limit the easy score to 0.05 so that
-        # we don't have a runaway growth of easy weights
-        difficulty_min = np.max([np.min(difficulties[difficulties > 0], initial=0), 0.05])
-
-        # limit the difficulty to a mininum of 0.05 so that
-        # easy subjects still have some weight
-        difficulties[difficulties == 0] = difficulty_min
-
-        true_mask = successes == 1
-        false_mask = successes == 0
-
-        # create the confusion matrix from the list of success/failures
-        confusion_simple[0, 0] = np.sum(true_mask)
-        confusion_simple[1, 0] = np.sum(false_mask)
-        confusion_simple[:, 1] = 0
-
-        # the true score is the sum of difficulties of the correct classifications
-        # so hard subjects give you a boost in score and the easy subjects
-        # give you a small increase
-        confusion_subject[0, 0] = np.sum(difficulties[true_mask])
-
-        # do the opposite for failure scores: easy subject failures should be
-        # penalized more strongly compared to difficulty failures
-        neg_difficulty = 1. - difficulties[false_mask]
-        neg_difficulty[neg_difficulty == 0] = difficulty_min
-        confusion_subject[1, 0] = np.sum(neg_difficulty)
-        confusion_subject[:, 1] = 0
-
-        return (confusion_simple, confusion_subject)
+    if mode == 'binary':
+        return get_user_skill_binary(extracts, relevant_reduction)
     else:
+        strategy = extracts[0]['feedback']['strategy']
+
         user_classifications = []
         classes = []
-        strategy = extracts[0]['feedback']['strategy']
 
         true_key = 'true_' + FEEDBACK_STRATEGIES[strategy][0]
 
@@ -193,28 +149,16 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
 
         # first we need a list of labels
         # obtain a list of labels from user classifications
-        if strategy in ['singleAnswerQuestion']:
-            for extracti in extracts:
-                user_classifications += [key for key in extracti if isinstance(extracti[key], int)]
-                # get the same from the feedback data
-                true_values.extend(extracti['feedback'][true_key])
+        for extracti in extracts:
+            user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int) & (extracti[key] == 1)]
 
-            classes = user_classifications
-        elif strategy in ['surveySimple']:
-            # for survey simple, the idea is the same
-            # except that the keys have a value of 1 when the
-            # user selects that class
-            for extracti in extracts:
-                user_classifications += [key for key in extracti.keys() if isinstance(extracti[key], int) & (extracti[key] == 1)]
-
-                # convert all answers to lower case to be consistent across both lists
-                classes += [key.lower() for key in extracti.keys() if isinstance(extracti[key], int)]
-                true_values.extend(list(map(lambda e: e.lower(), extracti['feedback'][true_key])))
+            # convert all answers to lower case to be consistent across both lists
+            classes += [key.lower() for key in extracti.keys() if isinstance(extracti[key], int)]
+            true_values.extend(list(map(lambda e: e.lower(), extracti['feedback'][true_key])))
 
         # get a full list of classes as the union of the two sets of labels
         classes = np.sort(np.unique([*np.unique(classes), *np.unique(true_values)]))
         classes = classes.tolist()
-        classes.append(null_class)
 
         difficulties = []
         for reductioni in relevant_reduction:
@@ -225,71 +169,164 @@ def get_confusion_matrix(extracts, relevant_reduction, binary, null_class):
         # find the easiest subject in the set and set all fully successful
         # subjects to this "easy" score. limit the easy score to 0.05 so that
         # we don't have a runaway growth of easy weights
-        difficulty_min = np.max([np.min(subject_difficulty[subject_difficulty > 0], initial=0), 0.05])
+        difficulty_min = np.max([np.min(subject_difficulty[subject_difficulty > 0], initial=0), DIFFICULTY_FLOOR])
 
         # limit the difficulty to a mininum of 0.05 so that
         # easy subjects still have some weight
         subject_difficulty[subject_difficulty == 0] = difficulty_min
 
-        true_counts = []
-        class_counts = []
-        subject_difficulties = []
-
         # we will loop through all the extracts and create a list
         # of user classified label and a corresponding gold standard
         # label. then, the confusion matrix is just determined using
         # the element-wise comparison between the two lists
-        for j, extract in enumerate(extracts):
-
-            # find a list of user classified labels in this extract
-            user_class_i = [key.lower() for key in extract.keys() if isinstance(extract[key], int) & (extract[key] == 1)]
-            true_keys = [key.lower() for key in extract['feedback'][true_key]]
-
-            # get a full list of classifications
-            classi = np.sort(np.unique([*np.unique(true_keys),
-                                        *np.unique(user_class_i)]))
-            classi = classi.tolist()
-
-            # create a temporary list of classes that will
-            # incorporate both the user selected classes
-            # and the tru classes
-            true_count_i = [null_class] * len(classi)
-
-            # loop through the true classes and populate the corresponding
-            # indices in the list
-            for value in true_keys:
-                true_count_i[classi.index(value)] = value
-
-            # do the same for the user classifications
-            class_count_i = [null_class] * len(classi)
-
-            for value in user_class_i:
-                class_count_i[classi.index(value)] = value
-
-            # add both lists to the master list of
-            # classifications and true classes
-            true_counts.extend(true_count_i)
-            class_counts.extend(class_count_i)
-
-            # also add the subject difficulties for each extract. subject
-            # difficulty per class is not trivial to do, so we will average
-            # the subject difficulty across all the classes in this subject.
-            # easy subjects should get small bump for correct classifications
-            # while difficult subjects will get a huge bump for success
-            # do the opposite for failure scores: easy subject failures should be
-            # penalized more strongly compared to difficulty failures
-            subject_difficulty_i = [subject_difficulty[j]] * len(classi)
-            for class_ind in range(len(classi)):
-                if true_count_i[class_ind] != class_count_i[class_ind]:
-                    subject_difficulty_i[class_ind] = np.max([1. - subject_difficulty_i[class_ind], 0.05])
-
-            subject_difficulties.extend(subject_difficulty_i)
+        if mode == 'one-to-one':
+            true_counts, class_counts, subject_difficulties = get_one_to_one(extracts, subject_difficulty, true_key)
+        elif mode == 'many-to-many':
+            true_counts, class_counts, subject_difficulties = get_multi_class(extracts, subject_difficulty, true_key, null_class)
+            classes.append(null_class)
 
         # get the simple confusion matrix without the subject difficulty
-        confusion_simple = confusion_matrix(class_counts, true_counts, labels=classes)
+        confusion_simple = confusion_matrix(true_counts, class_counts, labels=classes)
 
         # get the more complicated confusion matrix accounting for subject difficulty
-        confusion_subject = confusion_matrix(class_counts, true_counts, sample_weight=subject_difficulties,
+        confusion_subject = confusion_matrix(true_counts, class_counts, sample_weight=subject_difficulties,
                                              labels=classes)
 
         return (confusion_simple, confusion_subject, classes)
+
+
+def get_user_skill_binary(extracts, relevant_reduction):
+    # binary always defaults to 2x2 where the second column
+    # (gold standard = False) is NaN
+    confusion_simple = np.zeros((2, 2))
+    confusion_subject = np.zeros((2, 2))
+
+    successes = []
+    difficulties = []
+
+    # create an array of success/failure. multiple cases
+    # per subject are treated independently, and the final
+    # array is a flattened version of all success/failure checks
+    for extracti, reductioni in zip(extracts, relevant_reduction):
+        successes.extend(extracti['feedback']['success'])
+
+        # input difficulty is inverted... we want higher difficulty
+        # values for subjects which were classified incorrectly
+        difficultyi = 1. - np.array(reductioni['data']['difficulty'])
+
+        difficulties.extend(list(difficultyi))
+    successes = np.asarray(successes)
+    difficulties = np.asarray(difficulties)
+
+    # find the easiest subject in the set and set all fully successful
+    # subjects to this "easy" score. limit the easy score to 0.05 so that
+    # we don't have a runaway growth of easy weights
+    difficulty_min = np.max([np.min(difficulties[difficulties > 0], initial=0), DIFFICULTY_FLOOR])
+
+    # limit the difficulty to a mininum of 0.05 so that
+    # easy subjects still have some weight
+    difficulties[difficulties == 0] = difficulty_min
+
+    true_mask = successes == 1
+    false_mask = successes == 0
+
+    # create the confusion matrix from the list of success/failures
+    confusion_simple[0, 0] = np.sum(true_mask)
+    confusion_simple[1, 0] = np.sum(false_mask)
+    confusion_simple[:, 1] = 0
+
+    # the true score is the sum of difficulties of the correct classifications
+    # so hard subjects give you a boost in score and the easy subjects
+    # give you a small increase
+    confusion_subject[0, 0] = np.sum(difficulties[true_mask])
+
+    # do the opposite for failure scores: easy subject failures should be
+    # penalized more strongly compared to difficulty failures
+    neg_difficulty = 1. - difficulties[false_mask]
+    neg_difficulty[neg_difficulty == 0] = difficulty_min
+    confusion_subject[1, 0] = np.sum(neg_difficulty)
+    confusion_subject[:, 1] = 0
+
+    return (confusion_simple.T, confusion_subject.T)
+
+
+def get_multi_class(extracts, subject_difficulty, true_key, null_class):
+    true_counts = []
+    class_counts = []
+    subject_difficulties = []
+
+    for j, extract in enumerate(extracts):
+        # find a list of user classified labels in this extract
+        user_class_i = [key.lower() for key in extract.keys() if isinstance(extract[key], int) & (extract[key] == 1)]
+        true_keys = [key.lower() for key in extract['feedback'][true_key]]
+
+        # get a full list of classifications
+        classi = np.sort(np.unique([*np.unique(true_keys),
+                                    *np.unique(user_class_i)]))
+        classi = classi.tolist()
+
+        # create a temporary list of classes that will
+        # incorporate both the user selected classes
+        # and the tru classes
+        true_count_i = [null_class] * len(classi)
+
+        # loop through the true classes and populate the corresponding
+        # indices in the list
+        for value in true_keys:
+            true_count_i[classi.index(value)] = value
+
+        # do the same for the user classifications
+        class_count_i = [null_class] * len(classi)
+
+        for value in user_class_i:
+            class_count_i[classi.index(value)] = value
+
+        # add both lists to the master list of
+        # classifications and true classes
+        true_counts.extend(true_count_i)
+        class_counts.extend(class_count_i)
+
+        # also add the subject difficulties for each extract. subject
+        # difficulty per class is not trivial to do, so we will average
+        # the subject difficulty across all the classes in this subject.
+        # easy subjects should get small bump for correct classifications
+        # while difficult subjects will get a huge bump for success
+        # do the opposite for failure scores: easy subject failures should be
+        # penalized more strongly compared to difficulty failures
+        subject_difficulty_i = [subject_difficulty[j]] * len(classi)
+        for class_ind in range(len(classi)):
+            if true_count_i[class_ind] != class_count_i[class_ind]:
+                subject_difficulty_i[class_ind] = max([1. - subject_difficulty[j], DIFFICULTY_FLOOR])
+
+        subject_difficulties.extend(subject_difficulty_i)
+
+    return true_counts, class_counts, subject_difficulties
+
+
+def get_one_to_one(extracts, subject_difficulty, true_key):
+    true_counts = []
+    class_counts = []
+    subject_difficulties = []
+
+    for j, extract in enumerate(extracts):
+        # find a list of user classified labels in this extract
+        # here, we know that there is only one classification class and true class
+        user_class_i = [key.lower() for key in extract.keys() if isinstance(extract[key], int) & (extract[key] == 1)]
+        true_keys = [key.lower() for key in extract['feedback'][true_key]]
+
+        # also add the subject difficulties for each extract. subject
+        # difficulty per class is not trivial to do, so we will average
+        # the subject difficulty across all the classes in this subject.
+        # easy subjects should get small bump for correct classifications
+        # while difficult subjects will get a huge bump for success
+        # do the opposite for failure scores: easy subject failures should be
+        # penalized more strongly compared to difficulty failures
+        if user_class_i == true_keys:
+            subject_difficulties.append(max([subject_difficulty[j], DIFFICULTY_FLOOR]))
+        else:
+            subject_difficulties.append(max([1 - subject_difficulty[j], DIFFICULTY_FLOOR]))
+
+        true_counts.extend(true_keys)
+        class_counts.extend(user_class_i)
+
+    return true_counts, class_counts, subject_difficulties

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -66,7 +66,7 @@ reduced_data = {
             0,
             0,
             0,
-            1
+            0
         ],
         [
             0,
@@ -78,12 +78,12 @@ reduced_data = {
             0,
             0,
             1,
-            0
+            1
         ],
         [
-            0,
-            0,
             1,
+            0,
+            0,
             0
         ]
     ],
@@ -118,6 +118,7 @@ TestkClassUserSkillReducer = ReducerTest(
     reduced_data,
     'Test k-class user skill reducer',
     network_kwargs=kwargs_extra_data,
+    kwargs={'mode': 'many-to-many'},
     add_version=False,
     processed_type='list',
     test_name='TestkClassUserSkillReducer'
@@ -136,7 +137,7 @@ reduced_data_strategy_all = {
             0,
             0,
             0,
-            1
+            0
         ],
         [
             0,
@@ -148,12 +149,12 @@ reduced_data_strategy_all = {
             0,
             0,
             1,
-            0
+            1
         ],
         [
-            0,
-            0,
             1,
+            0,
+            0,
             0
         ]
     ],
@@ -189,7 +190,7 @@ TestkClassUserSkillReducerStrategyAll = ReducerTest(
     'Test k-class user skill reducer',
     network_kwargs=kwargs_extra_data,
     add_version=False,
-    kwargs={'strategy': 'all', 'skill_threshold': 0.5, 'count_threshold': 1},
+    kwargs={'mode': 'many-to-many', 'strategy': 'all', 'skill_threshold': 0.5, 'count_threshold': 1},
     processed_type='list',
     test_name='TestkClassUserSkillReducer'
 )
@@ -207,6 +208,7 @@ extracted_data = [
             0.43849207646830024
         ],
         "feedback": {
+            "strategy": "graph2drange",
             "success": [
                 True,
                 True,
@@ -238,6 +240,7 @@ extracted_data = [
             0.4384719554333891
         ],
         "feedback": {
+            "strategy": "graph2drange",
             "success": [
                 True,
                 True,
@@ -268,6 +271,7 @@ extracted_data = [
             0.37096065137496126
         ],
         "feedback": {
+            "strategy": "graph2drange",
             "success": [
                 False,
                 True,
@@ -352,10 +356,10 @@ reduced_data = {
     ],
     "confusion_simple": np.asarray([
         [
-            9.0, 0
+            9.0, 4.0
         ],
         [
-            4.0, 0
+            0.0, 0.0
         ]
     ]).tolist(),
     'mean_skill': 0.844106463878327,
@@ -370,8 +374,134 @@ TestBinaryUserSkillReducer = ReducerTest(
     reduced_data,
     'Test binary user skill reducer',
     network_kwargs=kwargs_extra_data,
-    kwargs={'binary': True},
+    kwargs={'mode': 'binary'},
     add_version=False,
     processed_type='list',
     test_name='TestBinaryUserSkillReducer'
+)
+
+
+extracted_data = [
+    {
+        "BLIP": 1,
+        "feedback": {
+            "true_choiceIds": [
+                "BLIP",
+            ],
+            "strategy": "surveySimple"
+        },
+    },
+    {
+        "WHISTLE": 1,
+        "feedback": {
+            "true_choiceIds": [
+                "WHISTLE",
+            ],
+            "strategy": "surveySimple"
+        },
+    },
+    {
+        "NONEOFTHEABOVE": 1,
+        "feedback": {
+            "true_choiceIds": [
+                "CHIRP",
+            ],
+            "strategy": "surveySimple"
+        },
+    }
+]
+
+kwargs_extra_data = {
+    "relevant_reduction": [
+        {
+            "data": {
+                "difficulty": [
+                    1
+                ]
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    0.5,
+                ]
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    0.99,
+                ]
+            }
+        }
+    ]
+}
+
+reduced_data = {
+    "classes": [
+        "blip",
+        "chirp",
+        "noneoftheabove",
+        "whistle"
+    ],
+    "confusion_simple": [
+        [
+            1,
+            0,
+            0,
+            0
+        ],
+        [
+            0,
+            0,
+            1,
+            0
+        ],
+        [
+            0,
+            0,
+            0,
+            0
+        ],
+        [
+            0,
+            0,
+            0,
+            1
+        ]
+    ],
+    "count": {
+        "blip": 1,
+        "chirp": 1,
+        "noneoftheabove": 0,
+        "whistle": 1
+    },
+    "level_up": False,
+    "mean_skill": 0.49999999999999944,
+    "skill": {
+        "blip": 1.0,
+        "chirp": 0.0,
+        "noneoftheabove": 0.0,
+        "whistle": 1.0
+    },
+    "weighted_skill": {
+        "blip": 0.9999999999999981,
+        "chirp": 0.0,
+        "noneoftheabove": 0.0,
+        "whistle": 0.9999999999999998
+    }
+}
+
+TestOneToOneUserSkillReducer = ReducerTest(
+    user_skill_reducer,
+    process,
+    extracted_data,
+    extracted_data,
+    reduced_data,
+    'Test one-to-one user skill reducer',
+    network_kwargs=kwargs_extra_data,
+    kwargs={'mode': 'one-to-one'},
+    add_version=False,
+    processed_type='list',
+    test_name='TestOneToOneUserSkillReducer'
 )


### PR DESCRIPTION
The current version of the k-class user skill calculation assumed that multiple classes were allowed per user classification and this will need to be compared with multiple classes from the gold standard data. However, for projects like Gravity Spy, there is only one class per classification and one class in the gold standard, which makes the comparison much more simple (and provides a more meaningful confusion matrix). 

This PR adds two modes to the k-class calculation. Setting `mode='one-to-one'` allows the calculation of a true confusion matrix (where each volunteer classification is compared directly against the gold standard). Setting `mode='many-to-many'` is the more general case where the volunteer may choose multiple classes, and this is compared against multiple classes in the gold standard data. Since it is not possible to associate incorrectly identified classes with their corresponding "true" labels, we can't directly compare individual classes. Therefore, we calculate a pseudo-confusion matrix. The only difference between these two modes is the confusion matrix. The per-class and mean skill calculations are equivalent across the two modes. 