### PR TITLE
Add Notes from Nature WeDigBio 2023 extractor conditions and tests 

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -99,6 +99,10 @@ def we_dig_bio(parser):
         return 2022
     elif (date.year == 2022) and (date.month == 10) and (13 <= date.day <= 16):
         return 2022
+    elif (date.year == 2023) and (date.month == 4) and (13 <= date.day <= 16):
+        return 2023
+    elif (date.year == 2023) and (date.month == 10) and (12 <= date.day <= 15):
+        return 2023
     else:
         return None
 

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -125,7 +125,7 @@ TestNfNThree = ExtractorTest(
     test_name='TestNfNThree'
 )
 
-classification_we_dig_bio_october_2020 = {
+classification_we_dig_bio_april_2023 = {
     "annotations": [{
         "task": "T99",
         "value": [
@@ -148,27 +148,27 @@ classification_we_dig_bio_october_2020 = {
             "country": "United States",
         }
     },
-    "created_at": "2020-10-16T05:30:00.000Z",
+    "created_at": "2023-04-14T05:30:00.000Z",
 }
 
-expected_we_dig_bio_october_2020 = {
+expected_we_dig_bio_april_2023 = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
-    "we_dig_bio": 2020,
+    "we_dig_bio": 2023,
     "country": "United States"
 }
 
-TestNfNWeDigBioOctober2020 = ExtractorTest(
+TestNfNWeDigBioApril2023 = ExtractorTest(
     extractors.nfn_extractor,
-    classification_we_dig_bio_october_2020,
-    expected_we_dig_bio_october_2020,
-    'Test NfN during October, 2020, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    classification_we_dig_bio_april_2023,
+    expected_we_dig_bio_april_2023,
+    'Test NfN during April, 2023, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioOctober2020'
+    test_name='TestNfNWeDigBioApril2023'
 )
 
-classification_not_we_dig_bio_2020 = {
+classification_we_dig_bio_october_2023 = {
     "annotations": [{
         "task": "T99",
         "value": [
@@ -191,26 +191,27 @@ classification_not_we_dig_bio_2020 = {
             "country": "United States",
         }
     },
-    "created_at": "2020-07-16T05:30:00.000Z",
+    "created_at": "2023-10-14T05:30:00.000Z",
 }
 
-expected_not_we_dig_bio_2020 = {
+expected_we_dig_bio_october_2023 = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
+    "we_dig_bio": 2023,
     "country": "United States"
 }
 
-TestNfNNotWeDigBio2020 = ExtractorTest(
+TestNfNWeDigBioOctober2023 = ExtractorTest(
     extractors.nfn_extractor,
-    classification_not_we_dig_bio_2020,
-    expected_not_we_dig_bio_2020,
-    'Test NfN during 2020, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
+    classification_we_dig_bio_october_2023,
+    expected_we_dig_bio_october_2023,
+    'Test NfN during October, 2023, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNNotWeDigBio2020'
+    test_name='TestNfNWeDigBioOctober2023'
 )
 
-classification_we_dig_bio_april_2021 = {
+classification_not_we_dig_bio_2023 = {
     "annotations": [{
         "task": "T99",
         "value": [
@@ -233,237 +234,23 @@ classification_we_dig_bio_april_2021 = {
             "country": "United States",
         }
     },
-    "created_at": "2021-04-09T05:30:00.000Z",
+    "created_at": "2023-07-16T05:30:00.000Z",
 }
 
-expected_we_dig_bio_april_2021 = {
-    "workflow": "herbarium",
-    "decade": "00s",
-    "time": "lunchbreak",
-    "we_dig_bio": 2021,
-    "country": "United States"
-}
-
-TestNfNWeDigBioApril2021 = ExtractorTest(
-    extractors.nfn_extractor,
-    classification_we_dig_bio_april_2021,
-    expected_we_dig_bio_april_2021,
-    'Test NfN during April, 2021, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioApril2021'
-)
-
-classification_we_dig_bio_october_2021 = {
-    "annotations": [{
-        "task": "T99",
-        "value": [
-            {
-                "task": "T11",
-                "value": [
-                    {
-                        "value": 2001,
-                        "option": True
-                    }
-                ]
-            }
-        ]
-    }],
-    "metadata": {
-        "utc_offset": "18000",
-    },
-    "subject": {
-        "metadata": {
-            "country": "United States",
-        }
-    },
-    "created_at": "2021-10-15T05:30:00.000Z",
-}
-
-expected_we_dig_bio_october_2021 = {
-    "workflow": "herbarium",
-    "decade": "00s",
-    "time": "lunchbreak",
-    "we_dig_bio": 2021,
-    "country": "United States"
-}
-
-TestNfNWeDigBioOctober2021 = ExtractorTest(
-    extractors.nfn_extractor,
-    classification_we_dig_bio_october_2021,
-    expected_we_dig_bio_october_2021,
-    'Test NfN during October, 2021, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioOctober2021'
-)
-
-classification_not_we_dig_bio_2021 = {
-    "annotations": [{
-        "task": "T99",
-        "value": [
-            {
-                "task": "T11",
-                "value": [
-                    {
-                        "value": 2001,
-                        "option": True
-                    }
-                ]
-            }
-        ]
-    }],
-    "metadata": {
-        "utc_offset": "18000",
-    },
-    "subject": {
-        "metadata": {
-            "country": "United States",
-        }
-    },
-    "created_at": "2021-07-16T05:30:00.000Z",
-}
-
-expected_not_we_dig_bio_2021 = {
+expected_not_we_dig_bio_2023 = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
     "country": "United States"
 }
 
-TestNfNNotWeDigBio2021 = ExtractorTest(
+TestNfNNotWeDigBio2023 = ExtractorTest(
     extractors.nfn_extractor,
-    classification_not_we_dig_bio_2021,
-    expected_not_we_dig_bio_2021,
-    'Test NfN during 2021, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
+    classification_not_we_dig_bio_2023,
+    expected_not_we_dig_bio_2023,
+    'Test NfN during 2023, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNNotWeDigBio2021'
-)
-
-classification_we_dig_bio_april_2022 = {
-    "annotations": [{
-        "task": "T99",
-        "value": [
-            {
-                "task": "T11",
-                "value": [
-                    {
-                        "value": 2001,
-                        "option": True
-                    }
-                ]
-            }
-        ]
-    }],
-    "metadata": {
-        "utc_offset": "18000",
-    },
-    "subject": {
-        "metadata": {
-            "country": "United States",
-        }
-    },
-    "created_at": "2022-04-09T05:30:00.000Z",
-}
-
-expected_we_dig_bio_april_2022 = {
-    "workflow": "herbarium",
-    "decade": "00s",
-    "time": "lunchbreak",
-    "we_dig_bio": 2022,
-    "country": "United States"
-}
-
-TestNfNWeDigBioApril2022 = ExtractorTest(
-    extractors.nfn_extractor,
-    classification_we_dig_bio_april_2022,
-    expected_we_dig_bio_april_2022,
-    'Test NfN during April, 2022, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioApril2022'
-)
-
-classification_we_dig_bio_october_2022 = {
-    "annotations": [{
-        "task": "T99",
-        "value": [
-            {
-                "task": "T11",
-                "value": [
-                    {
-                        "value": 2001,
-                        "option": True
-                    }
-                ]
-            }
-        ]
-    }],
-    "metadata": {
-        "utc_offset": "18000",
-    },
-    "subject": {
-        "metadata": {
-            "country": "United States",
-        }
-    },
-    "created_at": "2022-10-14T05:30:00.000Z",
-}
-
-expected_we_dig_bio_october_2022 = {
-    "workflow": "herbarium",
-    "decade": "00s",
-    "time": "lunchbreak",
-    "we_dig_bio": 2022,
-    "country": "United States"
-}
-
-TestNfNWeDigBioOctober2022 = ExtractorTest(
-    extractors.nfn_extractor,
-    classification_we_dig_bio_october_2022,
-    expected_we_dig_bio_october_2022,
-    'Test NfN during October, 2022, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioOctober2022'
-)
-
-classification_not_we_dig_bio_2022 = {
-    "annotations": [{
-        "task": "T99",
-        "value": [
-            {
-                "task": "T11",
-                "value": [
-                    {
-                        "value": 2001,
-                        "option": True
-                    }
-                ]
-            }
-        ]
-    }],
-    "metadata": {
-        "utc_offset": "18000",
-    },
-    "subject": {
-        "metadata": {
-            "country": "United States",
-        }
-    },
-    "created_at": "2022-07-16T05:30:00.000Z",
-}
-
-expected_not_we_dig_bio_2022 = {
-    "workflow": "herbarium",
-    "decade": "00s",
-    "time": "lunchbreak",
-    "country": "United States"
-}
-
-TestNfNNotWeDigBio2022 = ExtractorTest(
-    extractors.nfn_extractor,
-    classification_not_we_dig_bio_2022,
-    expected_not_we_dig_bio_2022,
-    'Test NfN during 2022, not during a WeDigBio event, with year as nested task and country from metadata at lunchtime local time',
-    kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNNotWeDigBio2022'
+    test_name='TestNfNNotWeDigBio2023'
 )
 
 classification_bad_year = {


### PR DESCRIPTION
Related to zooniverse/notes-from-nature-field-book#220.
Similar to #427 and #542.

Background:
The Notes From Nature Field Book (https://field-book.notesfromnature.org/, frontend repo - https://github.com/zooniverse/notes-from-nature-field-book) awards badges to volunteers for classifying based on various criteria, including classification creation time. There will be special WeDigBio events April 13-16 and October 12-15, 2023, that a special badge is earned for participating in.

Purpose:
In nfn_extractor, this PR refactors we_dig_bio to:
- return 2023 if a classification is created between (and including) April 13-16, 2023
- return 2023 if a classification is created between (and including) October 12-15, 2023
