### PR TITLE
adding eps_t parameter to temporal tools for full 3D IoU calculation

### DIFF
--- a/panoptes_aggregation/reducers/shape_metric_IoU.py
+++ b/panoptes_aggregation/reducers/shape_metric_IoU.py
@@ -9,7 +9,6 @@ import shapely.affinity
 import scipy.optimize
 import numpy
 from functools import lru_cache
-import sys
 
 
 def tupleize(func):
@@ -113,9 +112,9 @@ def IoU_metric(params1, params2, shape, eps_t=None):
     if 'temporal' in shape:
         # combine the shape IoU with the time difference and normalize
         # build two boxes in the time domain with width eps_t and height 1
-        # centered at (t - eps_t/2, 0.5) and calculate the intersection in time
-        time_params1 = (params1[5] - eps_t / 2, 0, eps_t, 1)
-        time_params2 = (params2[5] - eps_t / 2, 0, eps_t, 1)
+        # centered at (t - eps_t / 2, 0.5) and calculate the intersection in time
+        time_params1 = (params1[-1] - eps_t, 0, eps_t, 1)
+        time_params2 = (params2[-1] - eps_t, 0, eps_t, 1)
         time_geo1 = panoptes_to_geometry(time_params1, 'rectangle')
         time_geo2 = panoptes_to_geometry(time_params2, 'rectangle')
         time_intersection = 0
@@ -292,9 +291,9 @@ def average_shape_IoU(params_list, shape, eps_t=None):
     def sum_distance(x):
         return sum([IoU_metric(x, p, shape, eps_t)**2 for p in params_list])
     # find shape that minimizes the variance in the IoU metric using bounds
-    m = scipy.optimize.shgo(
+    m = scipy.optimize.direct(
         sum_distance,
-        sampling_method='sobol',
+        locally_biased=False,
         bounds=average_bounds(params_list, shape)
     )
     # find the 1-sigma value

--- a/panoptes_aggregation/reducers/shape_reducer_dbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_dbscan.py
@@ -13,7 +13,6 @@ from ..shape_tools import SHAPE_LUT
 from .shape_process_data import process_data, DEFAULTS_PROCESS
 from .shape_metric import get_shape_metric_and_avg
 from .shape_metric_IoU import IoU_metric, average_shape_IoU
-import sys
 
 DEFAULTS = {
     'eps': {'default': 5.0, 'type': float},

--- a/panoptes_aggregation/reducers/shape_reducer_dbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_dbscan.py
@@ -13,10 +13,11 @@ from ..shape_tools import SHAPE_LUT
 from .shape_process_data import process_data, DEFAULTS_PROCESS
 from .shape_metric import get_shape_metric_and_avg
 from .shape_metric_IoU import IoU_metric, average_shape_IoU
-
+import sys
 
 DEFAULTS = {
     'eps': {'default': 5.0, 'type': float},
+    'eps_t': {'default': 0.5, 'type': float},
     'min_samples': {'default': 3, 'type': int},
     'algorithm': {'default': 'auto', 'type': str},
     'leaf_size': {'default': 30, 'type': int},
@@ -67,6 +68,7 @@ def shape_reducer_dbscan(data_by_tool, **kwargs):
         * `tool*_clusters_sigma` : The standard deviation of the average shape under the IoU metric
     '''
     shape = data_by_tool.pop('shape')
+    eps_t = kwargs.pop('eps_t', None)
     shape_params = SHAPE_LUT[shape]
     metric_type = kwargs.pop('metric_type', 'euclidean').lower()
     symmetric = data_by_tool.pop('symmetric')
@@ -75,7 +77,7 @@ def shape_reducer_dbscan(data_by_tool, **kwargs):
         kwargs['metric'] = metric
     elif metric_type == 'iou':
         kwargs['metric'] = IoU_metric
-        kwargs['metric_params'] = {'shape': shape}
+        kwargs['metric_params'] = {'shape': shape, 'eps_t': eps_t}
         avg = average_shape_IoU
     else:
         raise ValueError('metric_type must be either "euclidean" or "IoU".')
@@ -104,7 +106,7 @@ def shape_reducer_dbscan(data_by_tool, **kwargs):
                         if metric_type == 'euclidean':
                             k_loc = avg(loc[idx])
                         elif metric_type == 'iou':
-                            k_loc, sigma = avg(loc[idx], shape)
+                            k_loc, sigma = avg(loc[idx], shape, eps_t)
                             clusters[frame].setdefault('{0}_clusters_sigma'.format(tool), []).append(float(sigma))
                         for pdx, param in enumerate(shape_params):
                             clusters[frame].setdefault('{0}_clusters_{1}'.format(tool, param), []).append(float(k_loc[pdx]))

--- a/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
@@ -19,6 +19,7 @@ from .shape_metric_IoU import IoU_metric, average_shape_IoU
 DEFAULTS = {
     'min_cluster_size': {'default': 5, 'type': int},
     'min_samples': {'default': 3, 'type': int},
+    'eps_t': {'default': 0.5, 'type': float},
     'algorithm': {'default': 'best', 'type': str},
     'leaf_size': {'default': 40, 'type': int},
     'p': {'default': None, 'type': float},
@@ -72,6 +73,7 @@ def shape_reducer_hdbscan(data_by_tool, **kwargs):
         * `tool*_clusters_sigma` : The standard deviation of the average shape under the IoU metric
     '''
     shape = data_by_tool.pop('shape')
+    eps_t = kwargs.pop('eps_t', None)
     shape_params = SHAPE_LUT[shape]
     metric_type = kwargs.pop('metric_type', 'euclidean').lower()
     symmetric = data_by_tool.pop('symmetric')
@@ -80,6 +82,7 @@ def shape_reducer_hdbscan(data_by_tool, **kwargs):
         kwargs['metric'] = metric
     elif metric_type == 'iou':
         kwargs['metric'] = IoU_metric
+        kwargs['metric_params'] = {'shape': shape, 'eps_t': eps_t}
         kwargs['shape'] = shape
         avg = average_shape_IoU
     else:

--- a/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
+++ b/panoptes_aggregation/reducers/shape_reducer_hdbscan.py
@@ -82,8 +82,8 @@ def shape_reducer_hdbscan(data_by_tool, **kwargs):
         kwargs['metric'] = metric
     elif metric_type == 'iou':
         kwargs['metric'] = IoU_metric
-        kwargs['metric_params'] = {'shape': shape, 'eps_t': eps_t}
         kwargs['shape'] = shape
+        kwargs['eps_t'] = eps_t
         avg = average_shape_IoU
     else:
         raise ValueError('metric_type must be either "euclidean" or "IoU".')
@@ -115,7 +115,7 @@ def shape_reducer_hdbscan(data_by_tool, **kwargs):
                         if metric_type == 'euclidean':
                             k_loc = avg(loc[idx])
                         elif metric_type == 'iou':
-                            k_loc, sigma = avg(loc[idx], shape)
+                            k_loc, sigma = avg(loc[idx], shape, eps_t)
                             clusters[frame].setdefault('{0}_clusters_sigma'.format(tool), []).append(float(sigma))
                         for pdx, param in enumerate(shape_params):
                             clusters[frame].setdefault('{0}_clusters_{1}'.format(tool, param), []).append(float(k_loc[pdx]))

--- a/panoptes_aggregation/reducers/shape_reducer_optics.py
+++ b/panoptes_aggregation/reducers/shape_reducer_optics.py
@@ -112,7 +112,7 @@ def shape_reducer_optics(data_by_tool, **kwargs):
                         if metric_type == 'euclidean':
                             k_loc = avg(loc[idx])
                         elif metric_type == 'iou':
-                            k_loc, sigma = avg(loc[idx], shape)
+                            k_loc, sigma = avg(loc[idx], shape, eps_t)
                             clusters[frame].setdefault('{0}_clusters_sigma'.format(tool), []).append(float(sigma))
                         for pdx, param in enumerate(shape_params):
                             clusters[frame].setdefault('{0}_clusters_{1}'.format(tool, param), []).append(float(k_loc[pdx]))

--- a/panoptes_aggregation/reducers/shape_reducer_optics.py
+++ b/panoptes_aggregation/reducers/shape_reducer_optics.py
@@ -21,6 +21,7 @@ warnings.filterwarnings("ignore", category=RuntimeWarning, module='sklearn.clust
 
 DEFAULTS = {
     'min_samples': {'default': 3, 'type': int},
+    'eps_t': {'default': 0.5, 'type': float},
     'min_cluster_size': {'default': 2, 'type': int},
     'algorithm': {'default': 'auto', 'type': str},
     'leaf_size': {'default': 30, 'type': int},
@@ -71,6 +72,7 @@ def shape_reducer_optics(data_by_tool, **kwargs):
         * `tool*_clusters_sigma` : The standard deviation of the average shape under the IoU metric
     '''
     shape = data_by_tool.pop('shape')
+    eps_t = kwargs.pop('eps_t', None)
     shape_params = SHAPE_LUT[shape]
     metric_type = kwargs.pop('metric_type', 'euclidean').lower()
     symmetric = data_by_tool.pop('symmetric')
@@ -79,7 +81,7 @@ def shape_reducer_optics(data_by_tool, **kwargs):
         kwargs['metric'] = metric
     elif metric_type == 'iou':
         kwargs['metric'] = IoU_metric
-        kwargs['metric_params'] = {'shape': shape}
+        kwargs['metric_params'] = {'shape': shape, 'eps_t': eps_t}
         avg = average_shape_IoU
     else:
         raise ValueError('metric_type must be either "euclidean" or "IoU".')

--- a/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_temporal_rotate_rectangle.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_shape_reducer_temporal_rotate_rectangle.py
@@ -95,6 +95,16 @@ extracted_data = [
             "T0_toolIndex0_y_center": [580.0],
         }
     },
+    {
+        'frame0': {
+            'T0_toolIndex0_angle': [50],
+            'T0_toolIndex0_displayTime': [0.5],
+            'T0_toolIndex0_height': [100],
+            'T0_toolIndex0_width': [80],
+            'T0_toolIndex0_x_center': [500],
+            'T0_toolIndex0_y_center': [580]
+        },
+    }
 ]
 
 kwargs_extra_data = {
@@ -107,7 +117,8 @@ kwargs_extra_data = {
         6,
         7,
         8,
-        9
+        9,
+        10
     ]
 }
 
@@ -122,7 +133,8 @@ processed_data = {
             (520.0, 510.0, 120.0, 50.0, 10.0, 1.0),
             (530.0, 500.0, 150.0, 50.0, 12.0, 0.9),
             (350.0, 620.0, 100.0, 80.0, 25.0, 0.6),
-            (350.0, 580.0, 80.0, 140.0, 20.0, 0.9)
+            (350.0, 580.0, 80.0, 140.0, 20.0, 0.9),
+            (500.0, 580.0, 80.0, 100.0, 50.0, 0.5)
         ]
     },
     'shape': 'temporalRotateRectangle',
@@ -130,22 +142,22 @@ processed_data = {
 }
 
 reduced_data_dbscan = {
-    "frame0": {
-        "T0_toolIndex0_cluster_labels": [0, 0, 0, 1, 1, 1, 1, 1, 1],
-        "T0_toolIndex0_clusters_count": [3, 6],
-        "T0_toolIndex0_clusters_angle": [9.4, 21.5],
-        "T0_toolIndex0_clusters_displayTime": [0.1, 0.9],
-        "T0_toolIndex0_clusters_height": [60.7, 104.5],
-        "T0_toolIndex0_clusters_sigma": [0.2, 0.5],
-        "T0_toolIndex0_clusters_width": [138.0, 102.8],
-        "T0_toolIndex0_clusters_x_center": [502.2, 352.3],
-        "T0_toolIndex0_clusters_y_center": [503.9, 604.9],
-        "T0_toolIndex0_temporalRotateRectangle_angle": [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0],
-        "T0_toolIndex0_temporalRotateRectangle_displayTime": [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9],
-        "T0_toolIndex0_temporalRotateRectangle_height": [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0],
-        "T0_toolIndex0_temporalRotateRectangle_width": [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0],
-        "T0_toolIndex0_temporalRotateRectangle_x_center": [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0],
-        "T0_toolIndex0_temporalRotateRectangle_y_center": [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0]
+    'frame0': {
+        'T0_toolIndex0_cluster_labels': [0, 0, 0, 1, 2, 2, 2, 1, 1, -1],
+        'T0_toolIndex0_clusters_angle': [10.0, 110.0, 10.0],
+        'T0_toolIndex0_clusters_count': [3, 3, 3],
+        'T0_toolIndex0_clusters_displayTime': [0.1, 0.7, 0.9],
+        'T0_toolIndex0_clusters_height': [61.0, 98.5, 54.5],
+        'T0_toolIndex0_clusters_sigma': [0.4, 0.7, 0.4],
+        'T0_toolIndex0_clusters_width': [137.5, 143.3, 136.1],
+        'T0_toolIndex0_clusters_x_center': [502.9, 358.1, 522.3],
+        'T0_toolIndex0_clusters_y_center': [504.3, 584.7, 508.1],
+        'T0_toolIndex0_temporalRotateRectangle_angle': [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0, 50.0],
+        'T0_toolIndex0_temporalRotateRectangle_displayTime': [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9, 0.5],
+        'T0_toolIndex0_temporalRotateRectangle_height': [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0, 100.0],
+        'T0_toolIndex0_temporalRotateRectangle_width': [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0, 80.0],
+        'T0_toolIndex0_temporalRotateRectangle_x_center': [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0, 500.0],
+        'T0_toolIndex0_temporalRotateRectangle_y_center': [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0, 580.0]
     }
 }
 
@@ -159,8 +171,9 @@ TestShapeReducerTemporalRotateRectangleDbscan = ReducerTest(
     network_kwargs=kwargs_extra_data,
     pkwargs={'shape': 'temporalRotateRectangle'},
     kwargs={
-        'eps': 0.5,
+        'eps': 0.8,
         'min_samples': 2,
+        'eps_t': 0.5,
         'metric_type': 'IoU',
     },
     test_name='TestShapeReducerTemporalRotateRectangleDbscan',
@@ -168,22 +181,22 @@ TestShapeReducerTemporalRotateRectangleDbscan = ReducerTest(
 )
 
 reduced_data_optics = {
-    "frame0": {
-        "T0_toolIndex0_cluster_labels": [0, 0, 0, 2, 1, 1, 1, 2, 2],
-        "T0_toolIndex0_clusters_angle": [9.4, 9.4, 20.0],
-        "T0_toolIndex0_clusters_count": [3, 3, 3],
-        "T0_toolIndex0_clusters_displayTime": [0.1, 0.9, 0.7],
-        "T0_toolIndex0_clusters_height": [60.7, 51.4, 143.7],
-        "T0_toolIndex0_clusters_sigma": [0.2, 0.2, 0.3],
-        "T0_toolIndex0_clusters_width": [138.0, 137.4, 92.1],
-        "T0_toolIndex0_clusters_x_center": [502.2, 522.5, 355.0],
-        "T0_toolIndex0_clusters_y_center": [503.9, 509.1, 583.8],
-        "T0_toolIndex0_temporalRotateRectangle_angle": [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0],
-        "T0_toolIndex0_temporalRotateRectangle_displayTime": [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9],
-        "T0_toolIndex0_temporalRotateRectangle_height": [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0],
-        "T0_toolIndex0_temporalRotateRectangle_width": [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0],
-        "T0_toolIndex0_temporalRotateRectangle_x_center": [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0],
-        "T0_toolIndex0_temporalRotateRectangle_y_center": [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0]
+    'frame0': {
+        'T0_toolIndex0_cluster_labels': [0, 0, 0, 2, 1, 1, 1, 2, 2, -1],
+        'T0_toolIndex0_clusters_angle': [10.0, 10.0, 110.0],
+        'T0_toolIndex0_clusters_count': [3, 3, 3],
+        'T0_toolIndex0_clusters_displayTime': [0.1, 0.9, 0.7],
+        'T0_toolIndex0_clusters_height': [61.0, 54.5, 98.5],
+        'T0_toolIndex0_clusters_sigma': [0.4, 0.4, 0.7],
+        'T0_toolIndex0_clusters_width': [137.5, 136.1, 143.3],
+        'T0_toolIndex0_clusters_x_center': [502.9, 522.3, 358.1],
+        'T0_toolIndex0_clusters_y_center': [504.3, 508.1, 584.7],
+        'T0_toolIndex0_temporalRotateRectangle_angle': [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0, 50.0],
+        'T0_toolIndex0_temporalRotateRectangle_displayTime': [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9, 0.5],
+        'T0_toolIndex0_temporalRotateRectangle_height': [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0, 100.0],
+        'T0_toolIndex0_temporalRotateRectangle_width': [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0, 80.0],
+        'T0_toolIndex0_temporalRotateRectangle_x_center': [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0, 500.0],
+        'T0_toolIndex0_temporalRotateRectangle_y_center': [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0, 580.0]
     }
 }
 
@@ -200,6 +213,7 @@ TestShapeReducerTemporalRotateRectangleOptics = ReducerTest(
     kwargs={
         'min_samples': 2,
         'metric_type': 'IoU',
+        'eps_t': 0.5
     },
     test_name='TestShapeReducerTemporalRotateRectangleOptics',
     round=1
@@ -207,23 +221,23 @@ TestShapeReducerTemporalRotateRectangleOptics = ReducerTest(
 
 reduced_data_hdbscan = {
     "frame0": {
-        "T0_toolIndex0_cluster_labels": [0, 0, 0, 2, 1, 1, 1, 2, 2],
-        "T0_toolIndex0_clusters_count": [3, 3, 3],
-        "T0_toolIndex0_cluster_probabilities": [1.0, 0.5, 1.0, 1.0, 1.0, 1.0, 0.6, 0.7, 1.0],
-        "T0_toolIndex0_clusters_angle": [9.4, 9.4, 20.0],
-        "T0_toolIndex0_clusters_displayTime": [0.1, 0.9, 0.7],
-        "T0_toolIndex0_clusters_height": [60.7, 51.4, 143.7],
-        "T0_toolIndex0_clusters_persistance": [0.5, 0.6, 0.1],
-        "T0_toolIndex0_clusters_sigma": [0.2, 0.2, 0.3],
-        "T0_toolIndex0_clusters_width": [138.0, 137.4, 92.1],
-        "T0_toolIndex0_clusters_x_center": [502.2, 522.5, 355.0],
-        "T0_toolIndex0_clusters_y_center": [503.9, 509.1, 583.8],
-        "T0_toolIndex0_temporalRotateRectangle_angle": [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0],
-        "T0_toolIndex0_temporalRotateRectangle_displayTime": [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9],
-        "T0_toolIndex0_temporalRotateRectangle_height": [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0],
-        "T0_toolIndex0_temporalRotateRectangle_width": [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0],
-        "T0_toolIndex0_temporalRotateRectangle_x_center": [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0],
-        "T0_toolIndex0_temporalRotateRectangle_y_center": [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0]
+        'T0_toolIndex0_cluster_labels': [1, 1, 1, 0, 2, 2, 2, 0, 0, 1],
+        'T0_toolIndex0_cluster_probabilities': [1.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.9, 1.0, 0.3],
+        'T0_toolIndex0_clusters_angle': [110.0, 100.1, 10.0],
+        'T0_toolIndex0_clusters_count': [3, 4, 3],
+        'T0_toolIndex0_clusters_displayTime': [0.7, 0.1, 0.9],
+        'T0_toolIndex0_clusters_height': [98.5, 137.8, 54.5],
+        'T0_toolIndex0_clusters_persistance': [0.1, 0.4, 0.4],
+        'T0_toolIndex0_clusters_sigma': [0.7, 0.7, 0.4],
+        'T0_toolIndex0_clusters_width': [143.3, 62.7, 136.1],
+        'T0_toolIndex0_clusters_x_center': [358.1, 502.9, 522.3],
+        'T0_toolIndex0_clusters_y_center': [584.7, 505.2, 508.1],
+        'T0_toolIndex0_temporalRotateRectangle_angle': [10.0, 12.0, 15.0, 30.0, 10.0, 10.0, 12.0, 25.0, 20.0, 50.0],
+        'T0_toolIndex0_temporalRotateRectangle_displayTime': [0.1, 0.1, 0.1, 0.7, 0.9, 1.0, 0.9, 0.6, 0.9, 0.5],
+        'T0_toolIndex0_temporalRotateRectangle_height': [50.0, 60.0, 60.0, 120.0, 50.0, 50.0, 50.0, 80.0, 140.0, 100.0],
+        'T0_toolIndex0_temporalRotateRectangle_width': [150.0, 160.0, 120.0, 110.0, 140.0, 120.0, 150.0, 100.0, 80.0, 80.0],
+        'T0_toolIndex0_temporalRotateRectangle_x_center': [510.0, 490.0, 510.0, 360.0, 520.0, 520.0, 530.0, 350.0, 350.0, 500.0],
+        'T0_toolIndex0_temporalRotateRectangle_y_center': [500.0, 515.0, 500.0, 570.0, 510.0, 510.0, 500.0, 620.0, 580.0, 580.0]
     }
 }
 
@@ -242,6 +256,7 @@ TestShapeReducerTemporalRotateRectangleHdbscan = ReducerTest(
         'allow_single_cluster': True,
         'metric_type': 'IoU',
         'min_samples': 1,
+        'eps_t': 0.5
     },
     test_name='TestShapeReducerTemporalRotateRectangleHdbscan',
     round=1,


### PR DESCRIPTION
Adding an `eps_t` which defines the temporal width of temporal shape tools, thereby constructing a fully 3D IoU. This metric uses the `displayTime` attribute which is a normalized time value for the video, so `eps_t` is essentially the fraction of the video that two shapes must overlap to be part of the same cluster.

Also updating the solver from `scipy.optimize.shgo` to `scipy.optimize.direct`. One main issue was that keeping `locally_biased` to True was causing poor convergence (particularly on the rectangle tool), but `locally_biased=False` is definitely much slower.