### PR TITLE
Update collatex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.8,<3.12"
 dependencies = [
     "beautifulsoup4>=4.8.1,<4.13",
-    "collatex@git+https://github.com/interedition/collatex.git@174035dda549ac3f967919a8475fdeb8dbb48f40#subdirectory=collatex-pythonport",
+    "collatex>=2.3<2.4",
     "hdbscan>=0.8.20,<=0.8.33",
     "lxml>=4.4,<4.10",
     "numpy>=1.22.0,<1.26.3",


### PR DESCRIPTION
The new version just laded on Pypi so we don't need to install from git anymore.  This will make it so we can release to Pypi ourselves once merged.