### PR TITLE
Remove broken imports from sphinx config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,9 +19,6 @@
 #
 import os
 import sys
-from docutils.parsers.rst.directives.admonitions import BaseAdmonition
-from sphinx.util import compat
-compat.make_admonition = BaseAdmonition
 sys.path.insert(0, os.path.abspath('../../panoptes_aggregation'))
 sys.path.insert(0, os.path.abspath('../..'))
 from panoptes_aggregation import __version__


### PR DESCRIPTION
The latest sphinx update moved around some imports, breaking one of the old workarounds in the conf.py script.  Removing that workaround has fixed the issue (I honestly don't remember what these lines of code did in the first place).