### PR TITLE
Fix import for GUI

### DIFF
--- a/panoptes_aggregation/scripts/__init__.py
+++ b/panoptes_aggregation/scripts/__init__.py
@@ -1,7 +1,7 @@
 from .config_workflow_panoptes import config_workflow
 from .extract_panoptes_csv import extract_csv
 from .reduce_panoptes_csv import reduce_csv
-from .batch_utils import progressbar as pbe
+from .batch_utils import progressbar as pb
 from .path_type import PathType
 from .gui_overrides import gui_override, pbar_override
 from .aggregation_parser import main as parser_main

--- a/panoptes_aggregation/scripts/gui.py
+++ b/panoptes_aggregation/scripts/gui.py
@@ -22,8 +22,7 @@ try:
 except ImportError:
     raise ImportError('The GUI component is not installed, reinstall with `pip install -U panoptes_aggregation[gui]`')
 
-panoptes_aggregation.scripts.pbar_override(panoptes_aggregation.scripts.pbe)
-panoptes_aggregation.scripts.pbar_override(panoptes_aggregation.scripts.pbr)
+panoptes_aggregation.scripts.pbar_override(panoptes_aggregation.scripts.pb)
 panoptes_aggregation.scripts.gui_override(gooey)
 
 current_folder = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
As part of #743, the import and override of progressbar got mangled during refactoring.  Originally, there were two separate imports of progressbar from `extract_panoptes_csv` and `reduce_panoptes_csv` as pbe and pbr, respectively. The refactor reduced this to one (pbe) but didn't remove references to pbr. This issue causes the GUI not to start due to an error related to these imports: 

```
Traceback (most recent call last):
  File "/Users/johnson/anaconda3/envs/main/bin/panoptes_aggregation_gui", line 5, in <module>
    from panoptes_aggregation.scripts.gui import gui
  File "/Users/johnson/anaconda3/envs/main/lib/python3.11/site-packages/panoptes_aggregation/scripts/gui.py", line 26, in <module>
    panoptes_aggregation.scripts.pbar_override(panoptes_aggregation.scripts.pbr)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'panoptes_aggregation.scripts' has no attribute 'pbr'. Did you mean: 'pbe'?
```

This PR makes the minor edit to change the import of progressbar to `pb` and to remove the duplicate `pbar_override()` call in scripts/gui.py.