### PR TITLE
Fix missing comma in collatex dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ On linux systems you may need to install GTK3:
 sudo apt-get install build-essential libgtk-3-dev
 ```
 
+#### Mac Anaconda build
+If you are installing this code on a Mac using the anaconda build of python and you want to use the GUI instead of the command line you will have to update one line of the of code in the `panoptes_aggregation_gui` script.  Change the first line from:
+```python
+#!/path/to/anaconda/python/bin/python
+```
+to:
+```python
+#!/bin/bash /path/to/anaconda/python/bin/python.app
+```
+
+You can find the location of this file with the command:
+```bash
+which panoptes_aggregation_gui
+```
+
+You will also need to run:
+```bash
+conda install python.app
+```
+
 ### With Docker
 [https://docs.docker.com/get-started/](https://docs.docker.com/get-started/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.8,<3.12"
 dependencies = [
     "beautifulsoup4>=4.8.1,<4.13",
-    "collatex>=2.3<2.4",
+    "collatex>=2.3,<2.4",
     "hdbscan>=0.8.20,<=0.8.33",
     "lxml>=4.4,<4.10",
     "numpy>=1.22.0,<1.26.3",


### PR DESCRIPTION
While reviewing @lcjohnso's latest PR I ran across a typo in the collatex dependency that the latest pip flagged up. 

I also, add the info about using the GUI Anaconda on a Mac, it is still needed.