### PR TITLE
Batch aggregation staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,44 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build_and_push_image:
+    name: Build and Push Image
+    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
+    with:
+      repo_name: aggregation-for-caesar
+      commit_id: ${{ github.sha }}
+      latest: true
+      build_args: "REVISION=${{ github.sha }}"
+
+  deploy_staging:
+    name: Deploy to Staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_app.yaml@main
+    needs: build_and_push_image
+    with:
+      app_name: aggregation
+      repo_name: aggregation-for-caesar
+      commit_id: ${{ github.sha }}
+      environment: staging
+      deploy_check: false
+    secrets:
+      creds: ${{ secrets.AZURE_AKS }}
+
+  slack_notification:
+    name: Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy_staging
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Deploy to Staging / deploy_app
+      status: ${{ needs.deploy_staging.result }}
+      title: "Aggregation Staging deploy complete"
+      title_link: "https://aggregation-staging.zooniverse.org"
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       context: ./
       args:
         REVISION: fake-git-sha-id
-    command: celery --app panoptes_aggregation.tasks.celery worker --loglevel=info
+    command: celery --app panoptes_aggregation.batch_aggregation.celery worker --loglevel=info
     volumes:
       - ./:/usr/src/aggregation
     environment:
@@ -45,7 +45,7 @@ services:
 
   dashboard:
     build: .
-    command: celery --app panoptes_aggregation.tasks.celery flower --port=5555 --broker=redis://redis:6379/0
+    command: celery --app panoptes_aggregation.batch_aggregation.celery flower --port=5555 --broker=redis://redis:6379/0
     ports:
       - 5556:5555
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: '2'
+version: '3'
 services:
   aggregation:
     build:
       context: ./
       args:
         REVISION: fake-git-sha-id
+    image: aggregation-for-caesar:local
     volumes:
       - ./:/usr/src/aggregation
       - ~/.aws:/root/.aws
@@ -25,10 +26,7 @@ services:
       - redis:redis
 
   worker:
-    build:
-      context: ./
-      args:
-        REVISION: fake-git-sha-id
+    image: aggregation-for-caesar:local
     command: celery --app panoptes_aggregation.batch_aggregation.celery worker --loglevel=info
     volumes:
       - ./:/usr/src/aggregation
@@ -44,7 +42,7 @@ services:
       - redis
 
   dashboard:
-    build: .
+    image: aggregation-for-caesar:local
     command: celery --app panoptes_aggregation.batch_aggregation.celery flower --port=5555 --broker=redis://redis:6379/0
     ports:
       - 5556:5555

--- a/kubernetes/deployment-staging.yaml
+++ b/kubernetes/deployment-staging.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregation-caesar-staging
+  name: aggregation-staging
   labels:
-    app: aggregation-caesar-staging
+    app: aggregation-staging
 spec:
   selector:
     matchLabels:
-      app: aggregation-caesar-staging
+      app: aggregation-staging
   template:
     metadata:
       labels:
-        app: aggregation-caesar-staging
+        app: aggregation-staging
     spec:
       containers:
-        - name: aggregation-caesar-app-staging
+        - name: aggregation-staging-app
           image: ghcr.io/zooniverse/aggregation-for-caesar:batch-aggregation-staging
           ports:
             - containerPort: 80
@@ -98,10 +98,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregation-caesar-staging
+  name: aggregation-staging
 spec:
   selector:
-    app: aggregation-caesar-staging
+    app: aggregation-staging
   ports:
     - protocol: TCP
       port: 80
@@ -110,20 +110,20 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregation-caesar-staging-celery
+  name: aggregation-staging-celery
   labels:
-    app: aggregation-caesar-staging-celery
+    app: aggregation-staging-celery
 spec:
   selector:
     matchLabels:
-      app: aggregation-caesar-staging-celery
+      app: aggregation-staging-celery
   template:
     metadata:
       labels:
-        app: aggregation-caesar-staging-celery
+        app: aggregation-staging-celery
     spec:
       containers:
-        - name: aggregation-caesar-app-staging-celery
+        - name: aggregation-staging-celery
           image: ghcr.io/zooniverse/aggregation-for-caesar:batch-aggregation-staging
           resources:
             requests:
@@ -203,10 +203,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregation-caesar-staging
+  name: aggregation-staging-celery
 spec:
   selector:
-    app: aggregation-caesar-staging
+    app: aggregation-staging-celery
   ports:
     - protocol: TCP
       port: 80

--- a/kubernetes/deployment-staging.yaml
+++ b/kubernetes/deployment-staging.yaml
@@ -171,7 +171,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
-                  key: PANOPTES_CLIENT_STAGING_SECRET
+                  key: PANOPTES_STAGING_CLIENT_SECRET
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment-staging.yaml
+++ b/kubernetes/deployment-staging.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aggregation-staging
+  name: aggregation-staging-app
   labels:
-    app: aggregation-staging
+    app: aggregation-staging-app
 spec:
   selector:
     matchLabels:
-      app: aggregation-staging
+      app: aggregation-staging-app
   template:
     metadata:
       labels:
-        app: aggregation-staging
+        app: aggregation-staging-app
     spec:
       containers:
         - name: aggregation-staging-app
@@ -53,18 +53,18 @@ spec:
               value: redis://aggregation-staging-redis:6379/0
             - name: CELERY_RESULT_BACKEND
               value: redis://aggregation-staging-redis:6379/0
-            - name: PANOPTES_URL
-              value: https://panoptes.zooniverse.org/
-            - name: PANOPTES_CLIENT_ID
+            - name: PANOPTES_STAGING_URL
+              value: https://panoptes-staging.zooniverse.org/
+            - name: PANOPTES_STAGING_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
-                  key: PANOPTES_CLIENT_ID
-            - name: PANOPTES_CLIENT_SECRET
+                  key: PANOPTES_STAGING_CLIENT_ID
+            - name: PANOPTES_STAGING_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
-                  key: PANOPTES_CLIENT_SECRET
+                  key: PANOPTES_STAGING_CLIENT_SECRET
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -86,7 +86,7 @@ spec:
                   name: aggregation-for-caesar-environment
                   key: NEW_RELIC_LICENSE_KEY
             - name: NEW_RELIC_APP_NAME
-              value: 'Aggregation Caesar Staging'
+              value: 'Aggregation Caesar (Staging)'
           volumeMounts:
             - name: aggregation-staging-volume
               mountPath: /usr/src/aggregation/tmp
@@ -98,10 +98,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: aggregation-staging
+  name: aggregation-staging-app
 spec:
   selector:
-    app: aggregation-staging
+    app: aggregation-staging-app
   ports:
     - protocol: TCP
       port: 80
@@ -139,7 +139,8 @@ spec:
                 - -c
                 - celery inspect ping -d celery@$(hostname) | grep -q OK
             initialDelaySeconds: 30
-            periodSeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             exec:
@@ -148,7 +149,8 @@ spec:
                 - -c
                 - celery inspect ping -d celery@$(hostname) | grep -q OK
             initialDelaySeconds: 60
-            periodSeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
             failureThreshold: 3
           args: ["/usr/src/aggregation/scripts/start-celery.sh"]
           env:
@@ -158,18 +160,18 @@ spec:
               value: redis://aggregation-staging-redis:6379/0
             - name: CELERY_RESULT_BACKEND
               value: redis://aggregation-staging-redis:6379/0
-            - name: PANOPTES_URL
-              value: https://panoptes.zooniverse.org/
-            - name: PANOPTES_CLIENT_ID
+            - name: PANOPTES_STAGING_URL
+              value: https://panoptes-staging.zooniverse.org/
+            - name: PANOPTES_STAGING_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
-                  key: PANOPTES_CLIENT_ID
-            - name: PANOPTES_CLIENT_SECRET
+                  key: PANOPTES_STAGING_CLIENT_ID
+            - name: PANOPTES_STAGING_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
-                  key: PANOPTES_CLIENT_SECRET
+                  key: PANOPTES_CLIENT_STAGING_SECRET
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -304,7 +306,7 @@ kind: Ingress
 metadata:
   name: aggregation-staging-ingress
   annotations:
-    ingressClassName: nginx
+    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 20m

--- a/kubernetes/deployment-staging.yaml
+++ b/kubernetes/deployment-staging.yaml
@@ -53,37 +53,37 @@ spec:
               value: redis://aggregation-staging-redis:6379/0
             - name: CELERY_RESULT_BACKEND
               value: redis://aggregation-staging-redis:6379/0
-            - name: PANOPTES_STAGING_URL
+            - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
-            - name: PANOPTES_STAGING_CLIENT_ID
+            - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
-                  key: PANOPTES_STAGING_CLIENT_ID
-            - name: PANOPTES_STAGING_CLIENT_SECRET
+                  name: aggregation-staging-env
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
-                  key: PANOPTES_STAGING_CLIENT_SECRET
+                  name: aggregation-staging-env
+                  key: PANOPTES_CLIENT_SECRET
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: MAST_AUTH_TOKEN
             - name: MAST_PROD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: MAST_PROD_TOKEN
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: SENTRY_DSN
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: NEW_RELIC_LICENSE_KEY
             - name: NEW_RELIC_APP_NAME
               value: 'Aggregation Caesar (Staging)'
@@ -160,37 +160,37 @@ spec:
               value: redis://aggregation-staging-redis:6379/0
             - name: CELERY_RESULT_BACKEND
               value: redis://aggregation-staging-redis:6379/0
-            - name: PANOPTES_STAGING_URL
+            - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
-            - name: PANOPTES_STAGING_CLIENT_ID
+            - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
-                  key: PANOPTES_STAGING_CLIENT_ID
-            - name: PANOPTES_STAGING_CLIENT_SECRET
+                  name: aggregation-staging-env
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
-                  key: PANOPTES_STAGING_CLIENT_SECRET
+                  name: aggregation-staging-env
+                  key: PANOPTES_CLIENT_SECRET
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: MAST_AUTH_TOKEN
             - name: MAST_PROD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: MAST_PROD_TOKEN
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: SENTRY_DSN
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aggregation-for-caesar-environment
+                  name: aggregation-staging-env
                   key: NEW_RELIC_LICENSE_KEY
             - name: NEW_RELIC_APP_NAME
               value: 'Aggregation Caesar (Staging)'

--- a/kubernetes/deployment-staging.yaml
+++ b/kubernetes/deployment-staging.yaml
@@ -1,0 +1,327 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aggregation-caesar-staging
+  labels:
+    app: aggregation-caesar-staging
+spec:
+  selector:
+    matchLabels:
+      app: aggregation-caesar-staging
+  template:
+    metadata:
+      labels:
+        app: aggregation-caesar-staging
+    spec:
+      containers:
+        - name: aggregation-caesar-app-staging
+          image: ghcr.io/zooniverse/aggregation-for-caesar:batch-aggregation-staging
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "500m"
+            limits:
+              memory: "1000Mi"
+              cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            # wait 6 * 10 seconds(default periodSeconds) for the container to start
+            # after this succeeds once the liveness probe takes over
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            # start checking for readiness after 20s (to serve traffic)
+            initialDelaySeconds: 20
+            # allow a longer response time than 1s
+            timeoutSeconds: 10
+          env:
+            - name: FLASK_ENV
+              value: production
+            - name: CELERY_BROKER_URL
+              value: redis://aggregation-staging-redis:6379/0
+            - name: CELERY_RESULT_BACKEND
+              value: redis://aggregation-staging-redis:6379/0
+            - name: PANOPTES_URL
+              value: https://panoptes.zooniverse.org/
+            - name: PANOPTES_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: PANOPTES_CLIENT_SECRET
+            - name: MAST_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: MAST_AUTH_TOKEN
+            - name: MAST_PROD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: MAST_PROD_TOKEN
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: SENTRY_DSN
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: NEW_RELIC_LICENSE_KEY
+            - name: NEW_RELIC_APP_NAME
+              value: 'Aggregation Caesar Staging'
+          volumeMounts:
+            - name: aggregation-staging-volume
+              mountPath: /usr/src/aggregation/tmp
+      volumes:
+        - name: aggregation-staging-volume
+          persistentVolumeClaim:
+            claimName: aggregation-staging-data-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aggregation-caesar-staging
+spec:
+  selector:
+    app: aggregation-caesar-staging
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aggregation-caesar-staging-celery
+  labels:
+    app: aggregation-caesar-staging-celery
+spec:
+  selector:
+    matchLabels:
+      app: aggregation-caesar-staging-celery
+  template:
+    metadata:
+      labels:
+        app: aggregation-caesar-staging-celery
+    spec:
+      containers:
+        - name: aggregation-caesar-app-staging-celery
+          image: ghcr.io/zooniverse/aggregation-for-caesar:batch-aggregation-staging
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "500m"
+            limits:
+              memory: "1000Mi"
+              cpu: "1000m"
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - celery inspect ping -d celery@$(hostname) | grep -q OK
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - celery inspect ping -d celery@$(hostname) | grep -q OK
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          args: ["/usr/src/aggregation/scripts/start-celery.sh"]
+          env:
+            - name: FLASK_ENV
+              value: production
+            - name: CELERY_BROKER_URL
+              value: redis://aggregation-staging-redis:6379/0
+            - name: CELERY_RESULT_BACKEND
+              value: redis://aggregation-staging-redis:6379/0
+            - name: PANOPTES_URL
+              value: https://panoptes.zooniverse.org/
+            - name: PANOPTES_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: PANOPTES_CLIENT_SECRET
+            - name: MAST_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: MAST_AUTH_TOKEN
+            - name: MAST_PROD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: MAST_PROD_TOKEN
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: SENTRY_DSN
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: NEW_RELIC_LICENSE_KEY
+            - name: NEW_RELIC_APP_NAME
+              value: 'Aggregation Caesar (Staging)'
+          volumeMounts:
+            - name: aggregation-staging-volume
+              mountPath: /usr/src/aggregation/tmp
+      volumes:
+        - name: aggregation-staging-volume
+          persistentVolumeClaim:
+            claimName: aggregation-staging-data-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aggregation-caesar-staging
+spec:
+  selector:
+    app: aggregation-caesar-staging
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: aggregation-staging-redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: azurefile
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: aggregation-staging-data-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: azurefile
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aggregation-staging-redis
+  labels:
+    app: aggregation-staging-redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: aggregation-staging-redis
+  template:
+    metadata:
+      labels:
+        app: aggregation-staging-redis
+    spec:
+      tolerations:
+      - key: "servicelife"
+        operator: "Equal"
+        value: "longlife"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: servicelife
+                operator: In
+                values:
+                - longlife
+      containers:
+        - name: aggregation-staging-redis
+          image: redis
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+          volumeMounts:
+          - name: aggregation-staging-redis-data
+            mountPath: "/data"
+      volumes:
+        - name: aggregation-staging-redis-data
+          persistentVolumeClaim:
+            claimName: aggregation-staging-redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aggregation-staging-redis
+spec:
+  selector:
+    app: aggregation-staging-redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  type: NodePort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aggregation-staging-ingress
+  annotations:
+    ingressClassName: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 20m
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - aggregation-staging.zooniverse.org
+    secretName: aggregation-staging-tls-secret
+  rules:
+  - host: aggregation-staging.zooniverse.org
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: aggregation-staging-app
+            port:
+              number: 80

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -47,7 +47,8 @@ def run_aggregation(project_id, workflow_id, user_id):
 
     print(f'[Batch Aggregation] Reducing workflow {workflow_id})')
     for task_type, extract_df in extracted_data.items():
-        extract_df.to_csv(f'{ba.output_path}/{ba.workflow_id}_{task_type}.csv')
+        csv_filepath =  os.path.join(ba.output_path, f'{ba.workflow_id}_{task_type}.csv')
+        extract_df.to_csv(csv_filepath)
         reducer_list = batch_standard_reducers[task_type]
         reduced_data = {}
 
@@ -57,7 +58,7 @@ def run_aggregation(project_id, workflow_id, user_id):
             reducer_config = {'reducer_config': {reducer: {}}}
             reduced_data[reducer] = batch_utils.batch_reduce(extract_df, reducer_config)
             # filename = f'{ba.output_path}/{ba.workflow_id}_reductions.csv'
-            filename = os.path.join(ba.output_path, ba.workflow_id, '_reductions.csv')
+            filename = os.path.join(ba.output_path, f'{ba.workflow_id}_reductions.csv')
             reduced_data[reducer].to_csv(filename, mode='a')
 
     # Upload zip & reduction files to blob storage
@@ -87,7 +88,7 @@ class BatchAggregator:
 
     def save_exports(self):
         self.output_path = os.path.join('tmp', str(self.workflow_id))
-        os.mkdir(self.output_path)
+        os.makedirs(self.output_path, exist_ok=True)
 
         cls_export = Workflow(self.workflow_id).describe_export('classifications')
         full_cls_url = cls_export['media'][0]['src']

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -80,9 +80,9 @@ class BatchAggregator:
     """
 
     def __init__(self, project_id, workflow_id, user_id):
-        self.project_id = project_id
-        self.workflow_id = workflow_id
-        self.user_id = user_id
+        self.project_id = int(project_id)
+        self.workflow_id = int(workflow_id)
+        self.user_id = int(user_id)
         self._generate_uuid()
         self._connect_api_client()
 

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -154,7 +154,7 @@ class BatchAggregator:
         project = Project.find(self.project_id)
         permission = False
         for user in project.collaborators():
-            if user.id == self.user_id:
+            if user.id == str(self.user_id):
                 permission = True
         return permission
 

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -122,7 +122,7 @@ class BatchAggregator:
     def connect_blob_storage(self):
         connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
         self.blob_service_client = BlobServiceClient.from_connection_string(connect_str)
-        self.blob_service_client.create_container(name=self.id)
+        self.blob_service_client.create_container(name=self.id, public_access='container')
 
     def upload_file_to_storage(self, container_name, filepath):
         blob = filepath.split('/')[-1]

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -142,6 +142,9 @@ class BatchAggregator:
         # An Aggregation class can be added to the python client to avoid doing this manually
         params = {'workflow_id': self.workflow_id}
         response = Panoptes.client().get('/aggregations', params=params)
+        if response[0] is None:
+            print(f'[Batch Aggregation] Panoptes Aggregation resource not found. Unable to update.')
+            return False
         agg_id = response[0]['aggregations'][0]['id']
         fresh_etag = response[1]
 

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -142,7 +142,7 @@ class BatchAggregator:
         # An Aggregation class can be added to the python client to avoid doing this manually
         params = {'workflow_id': self.workflow_id}
         response = Panoptes.client().get('/aggregations', params=params)
-        if response[0] is None:
+        if not response[0]['aggregations']:
             print(f'[Batch Aggregation] Panoptes Aggregation resource not found. Unable to update.')
             return False
         agg_id = response[0]['aggregations'][0]['id']

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -47,7 +47,7 @@ def run_aggregation(project_id, workflow_id, user_id):
 
     print(f'[Batch Aggregation] Reducing workflow {workflow_id})')
     for task_type, extract_df in extracted_data.items():
-        csv_filepath =  os.path.join(ba.output_path, f'{ba.workflow_id}_{task_type}.csv')
+        csv_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_{task_type}.csv')
         extract_df.to_csv(csv_filepath)
         reducer_list = batch_standard_reducers[task_type]
         reduced_data = {}

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -177,5 +177,6 @@ class BatchAggregator:
         Panoptes.connect(
             endpoint=os.getenv('PANOPTES_URL', 'https://panoptes.zooniverse.org/'),
             client_id=os.getenv('PANOPTES_CLIENT_ID'),
-            client_secret=os.getenv('PANOPTES_CLIENT_SECRET')
+            client_secret=os.getenv('PANOPTES_CLIENT_SECRET'),
+            admin='true'
         )

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -87,8 +87,8 @@ class BatchAggregator:
         self._connect_api_client()
 
     def save_exports(self):
-        self.output_path = os.path.join('tmp', str(self.workflow_id))
-        os.makedirs(self.output_path, exist_ok=True)
+        self.output_path = os.path.join('tmp', str(self.id))
+        os.makedirs(self.output_path)
 
         cls_export = Workflow(self.workflow_id).describe_export('classifications')
         full_cls_url = cls_export['media'][0]['src']

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -143,7 +143,7 @@ class BatchAggregator:
         params = {'workflow_id': self.workflow_id}
         response = Panoptes.client().get('/aggregations', params=params)
         if not response[0]['aggregations']:
-            print(f'[Batch Aggregation] Panoptes Aggregation resource not found. Unable to update.')
+            print('[Batch Aggregation] Panoptes Aggregation resource not found. Unable to update.')
             return False
         agg_id = response[0]['aggregations'][0]['id']
         fresh_etag = response[1]

--- a/panoptes_aggregation/routes.py
+++ b/panoptes_aggregation/routes.py
@@ -124,7 +124,7 @@ def make_application():
         workflow_id = content['workflow_id']
         user_id = content['user_id']
         task = batch_aggregation.run_aggregation.delay(project_id, workflow_id, user_id)
-        return json.dumps({"task_id": task.id}), 202
+        return jsonify({"task_id": task.id}), 202
 
     @application.route('/tasks/<task_id>', methods=['GET'])
     def get_status(task_id):

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -132,7 +132,7 @@ class TestBatchAggregation(unittest.TestCase):
 
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.put")
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.get")
-    def test_update_panoptes_success(self, mock_get, mock_put):
+    def test_update_panoptes_run_success(self, mock_get, mock_put):
         ba = batch_agg.BatchAggregator(1, 10, 100)
         mock_get.return_value = ({'aggregations': [{'id': 5555}]}, 'thisisanetag')
         body = {'uuid': ba.id, 'status': 'completed'}
@@ -142,7 +142,7 @@ class TestBatchAggregation(unittest.TestCase):
 
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.put")
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.get")
-    def test_update_panoptes_put_failure(self, mock_get, mock_put):
+    def test_update_panoptes_run_failure(self, mock_get, mock_put):
         ba = batch_agg.BatchAggregator(1, 10, 100)
         mock_get.return_value = ({'aggregations': [{'id': 5555}]}, 'thisisanetag')
         body = {'status': 'failure'}
@@ -154,7 +154,7 @@ class TestBatchAggregation(unittest.TestCase):
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.get")
     def test_update_panoptes_get_failure(self, mock_get, mock_put):
         ba = batch_agg.BatchAggregator(1, 10, 100)
-        mock_get.return_value = (None, None)
+        mock_get.return_value = ({'aggregations': []}, 'etag')
         body = {'status': 'failure'}
         ba.update_panoptes(body)
         mock_get.assert_called_with('/aggregations', params={'workflow_id': 10})

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -103,7 +103,8 @@ class TestBatchAggregation(unittest.TestCase):
     @patch("panoptes_aggregation.batch_aggregation.Project")
     def test_check_permission_success(self, mock_project):
         mock_user = MagicMock()
-        mock_user.id = 100
+        # Panoptes responses return strings
+        mock_user.id = '100'
         mock_project.find().collaborators.return_value = [mock_user]
 
         ba = batch_agg.BatchAggregator(1, 10, 100)

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -52,8 +52,9 @@ class TestBatchAggregation(unittest.TestCase):
         mock_project.return_value.describe_export.return_value = csv_dict
         mock_workflow.return_value.describe_export.return_value = csv_dict
         ba = batch_agg.BatchAggregator(1, 10, 100)
+        ba.id = 'asdf123asdf'
         batch_agg.BatchAggregator._download_export = MagicMock(side_effect=['./cls_export.csv', './wf_export.csv'])
-        expected_response = {'classifications': 'tmp/10/10_cls_export.csv', 'workflows': 'tmp/10/10_workflow_export.csv'}
+        expected_response = {'classifications': 'tmp/asdf123asdf/10_cls_export.csv', 'workflows': 'tmp/asdf123asdf/10_workflow_export.csv'}
 
         response = ba.save_exports()
 

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -118,7 +118,7 @@ class TestBatchAggregation(unittest.TestCase):
         mock_user = MagicMock()
 
         # List of collaborators does not include initiating user
-        mock_user.id = 999
+        mock_user.id = '999'
         mock_project.find().collaborators.return_value = [mock_user]
 
         ba = batch_agg.BatchAggregator(1, 10, 100)

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -142,13 +142,23 @@ class TestBatchAggregation(unittest.TestCase):
 
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.put")
     @patch("panoptes_aggregation.batch_aggregation.Panoptes.get")
-    def test_update_panoptes_failure(self, mock_get, mock_put):
+    def test_update_panoptes_put_failure(self, mock_get, mock_put):
         ba = batch_agg.BatchAggregator(1, 10, 100)
         mock_get.return_value = ({'aggregations': [{'id': 5555}]}, 'thisisanetag')
         body = {'status': 'failure'}
         ba.update_panoptes(body)
         mock_get.assert_called_with('/aggregations', params={'workflow_id': 10})
         mock_put.assert_called_with('/aggregations/5555', etag='thisisanetag', json={'aggregations': body})
+
+    @patch("panoptes_aggregation.batch_aggregation.Panoptes.put")
+    @patch("panoptes_aggregation.batch_aggregation.Panoptes.get")
+    def test_update_panoptes_get_failure(self, mock_get, mock_put):
+        ba = batch_agg.BatchAggregator(1, 10, 100)
+        mock_get.return_value = (None, None)
+        body = {'status': 'failure'}
+        ba.update_panoptes(body)
+        mock_get.assert_called_with('/aggregations', params={'workflow_id': 10})
+        mock_put.assert_not_called()
 
     @patch("panoptes_aggregation.batch_aggregation.BlobServiceClient")
     def test_connect_blob_storage(self, mock_client):

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -43,10 +43,10 @@ class TestBatchAggregation(unittest.TestCase):
         mock_aggregator_instance.upload_files.assert_called_once()
         mock_aggregator_instance.update_panoptes.assert_called_once()
 
-    @patch("panoptes_aggregation.batch_aggregation.os.mkdir")
+    @patch("panoptes_aggregation.batch_aggregation.os.makedirs")
     @patch("panoptes_aggregation.batch_aggregation.Workflow")
     @patch("panoptes_aggregation.batch_aggregation.Project")
-    def test_save_exports(self, mock_project, mock_workflow, mock_mkdir):
+    def test_save_exports(self, mock_project, mock_workflow, mock_makedirs):
         # Test that Panoptes calls are made and files are saved
         csv_dict = {'media': [{'src': 'http://zooniverse.org/123.csv'}]}
         mock_project.return_value.describe_export.return_value = csv_dict
@@ -60,7 +60,7 @@ class TestBatchAggregation(unittest.TestCase):
 
         assert ba.id is not None
         self.assertEqual(response, expected_response)
-        mock_mkdir.assert_called_once()
+        mock_makedirs.assert_called_once()
         mock_project.assert_called_once_with(1)
         mock_workflow.assert_called_once_with(10)
         mock_project.return_value.describe_export.assert_called_once_with('workflows')
@@ -164,4 +164,4 @@ class TestBatchAggregation(unittest.TestCase):
     def test_connect_blob_storage(self, mock_client):
         ba = batch_agg.BatchAggregator(1, 10, 100)
         ba.connect_blob_storage()
-        ba.blob_service_client.create_container.assert_called_once_with(name=ba.id)
+        ba.blob_service_client.create_container.assert_called_once_with(name=ba.id, public_access='container')

--- a/scripts/start-celery.sh
+++ b/scripts/start-celery.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-exec celery --app panoptes_aggregation.tasks.celery worker --loglevel=info
+exec celery --app panoptes_aggregation.batch_aggregation.celery worker --loglevel=info

--- a/scripts/start-flower.sh
+++ b/scripts/start-flower.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 BROKER=${CELERY_BROKER_URL:='redis://redis:6379/0'}
-exec celery --app panoptes_aggregation.tasks.celery flower --port=5555 --broker=$BROKER
+exec celery --app panoptes_aggregation.batch_aggregation.celery flower --port=5555 --broker=$BROKER


### PR DESCRIPTION
Includes a new staging deployment template, some additional logging, and a couple small fixes. 

This new staging template currently deploys directly from the `batch-aggregation-staging` branch, not the head of master. I'll be testing locally with this after approval, then I'll add a workflow to automate the staging deploy. A dry run against the server with this template creates the following:

```bash
$ kubectl apply --dry-run=server -f ./kubernetes/deployment-staging.yaml
deployment.apps/aggregation-staging created (server dry run)
service/aggregation-staging created (server dry run)
deployment.apps/aggregation-staging-celery created (server dry run)
service/aggregation-staging-celery created (server dry run)
persistentvolumeclaim/aggregation-staging-redis created (server dry run)
persistentvolumeclaim/aggregation-staging-data-storage created (server dry run)
deployment.apps/aggregation-staging-redis created (server dry run)
service/aggregation-staging-redis created (server dry run)
ingress.networking.k8s.io/aggregation-staging-ingress created (server dry run)
```
I'm pretty sure that's everything this needs. I've created a new DNS record to point to the new staging app, `aggregation-staging.zooniverse.org`. I didn't include a deploy for Flower yet, let's see how this goes.