### PR TITLE
Add Azure connection secret to celery pod

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -200,6 +200,11 @@ spec:
                 secretKeyRef:
                   name: aggregation-for-caesar-environment
                   key: PANOPTES_CLIENT_SECRET
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: AZURE_STORAGE_CONNECTION_STRING
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -65,6 +65,11 @@ spec:
                 secretKeyRef:
                   name: aggregation-staging-env
                   key: PANOPTES_CLIENT_SECRET
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: AZURE_STORAGE_CONNECTION_STRING
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -172,6 +177,11 @@ spec:
                 secretKeyRef:
                   name: aggregation-staging-env
                   key: PANOPTES_CLIENT_SECRET
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: aggregation-for-caesar-environment
+                  key: AZURE_STORAGE_CONNECTION_STRING
             - name: MAST_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Celery pod needs access to the Azure blob storage connection string. Staging needs it, too.