### PR TITLE
Adding the ability to specify classes to filter user-skill calculation

### DIFF
--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -58,7 +58,10 @@ def reducer_wrapper(
             if 'strategy' in kwargs:
                 kwargs_details['strategy'] = kwargs['strategy'].strip("\'")
             if 'focus_classes' in kwargs:
-                kwargs_details['focus_classes'] = ast.literal_eval(kwargs['focus_classes'])
+                focus_classes = kwargs['focus_classes']
+                if isinstance(focus_classes, str):
+                    focus_classes = ast.literal_eval(focus_classes)
+                kwargs_details['focus_classes'] = focus_classes
 
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:

--- a/panoptes_aggregation/reducers/reducer_wrapper.py
+++ b/panoptes_aggregation/reducers/reducer_wrapper.py
@@ -57,6 +57,8 @@ def reducer_wrapper(
                 kwargs_details['mode'] = kwargs['mode'].strip("\'")
             if 'strategy' in kwargs:
                 kwargs_details['strategy'] = kwargs['strategy'].strip("\'")
+            if 'focus_classes' in kwargs:
+                kwargs_details['focus_classes'] = ast.literal_eval(kwargs['focus_classes'])
 
             no_version = kwargs.pop('no_version', False)
             if defaults_process is not None:

--- a/panoptes_aggregation/reducers/user_skill_reducer.py
+++ b/panoptes_aggregation/reducers/user_skill_reducer.py
@@ -12,7 +12,6 @@ import numpy as np
 from ..feedback_strategies import FEEDBACK_STRATEGIES
 from sklearn.metrics import confusion_matrix
 
-
 # smallest possible value for difficulty so that
 # subjects have a non-negligible effect on user skill
 # in extreme cases
@@ -21,7 +20,7 @@ DIFFICULTY_FLOOR = 0.05
 
 @reducer_wrapper(relevant_reduction=True)
 def user_skill_reducer(extracts, relevant_reduction=[], mode='binary', null_class='NONE',
-                       skill_threshold=0.7, count_threshold=10, strategy='mean'):
+                       skill_threshold=0.7, count_threshold=10, strategy='mean', focus_classes=None):
     '''
         Parameters
         ----------
@@ -84,12 +83,18 @@ def user_skill_reducer(extracts, relevant_reduction=[], mode='binary', null_clas
 
     # remove the null class from the skill array to calculate the mean skill
     if mode == 'binary':
-        null_removed_classes = [classi for classi in classes if classi != 'False']
-        null_removed_counts = [ci for classi, ci in per_class_count.items() if classi != 'False']
-        mean_skill = np.sum([weighted_per_class_skill_dict[key] for key in null_removed_classes]) / (len(null_removed_classes) + 1.e-16)
+        null_class = 'False'
     else:
+        null_class = null_class
+
+    # compute either on user-specified classes or perform mean skill calculation on all detected classes
+    if focus_classes is None:
         null_removed_classes = [classi for classi in classes if classi != null_class]
         null_removed_counts = [ci for classi, ci in per_class_count.items() if classi != null_class]
+        mean_skill = np.sum([weighted_per_class_skill_dict[key] for key in null_removed_classes]) / (len(null_removed_classes) + 1.e-16)
+    else:
+        null_removed_classes = [classi for classi in focus_classes if classi != null_class]
+        null_removed_counts = [ci for classi, ci in per_class_count.items() if classi in null_removed_classes]
         mean_skill = np.sum([weighted_per_class_skill_dict[key] for key in null_removed_classes]) / (len(null_removed_classes) + 1.e-16)
 
     # check the leveling up value

--- a/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_user_skill_reducer.py
@@ -505,3 +505,133 @@ TestOneToOneUserSkillReducer = ReducerTest(
     processed_type='list',
     test_name='TestOneToOneUserSkillReducer'
 )
+
+
+extracted_data = [
+    {
+        "1": 1,
+        "feedback": {
+            "strategy": "singleAnswerQuestion",
+            "true_answer": [
+                "1"
+            ],
+            "agreement_score": 1
+        },
+        "aggregation_version": "4.1.0"
+    },
+    {
+        "7": 1,
+        "aggregation_version": "4.1.0"
+    },
+    {
+        "1": 1,
+        "feedback": {
+            "strategy": "singleAnswerQuestion",
+            "true_answer": [
+                "2"
+            ],
+            "agreement_score": 0
+        },
+        "aggregation_version": "4.1.0"
+    },
+    {
+        "1": 1,
+        "aggregation_version": "4.1.0"
+    },
+    {
+        "1": 1,
+        "feedback": {
+            "strategy": "singleAnswerQuestion",
+            "true_answer": [
+                "1"
+            ],
+            "agreement_score": 1
+        },
+        "aggregation_version": "4.1.0"
+    }
+]
+
+kwargs_extra_data = {
+    "relevant_reduction": [
+        {
+            "data": {
+                "difficulty": [
+                    1
+                ],
+                "aggregation_version": "4.1.0"
+            }
+        },
+        {
+            "data": {
+                "aggregation_version": "4.1.0"
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    0
+                ],
+                "aggregation_version": "4.1.0"
+            }
+        },
+        {
+            "data": {
+                "aggregation_version": "4.1.0"
+            }
+        },
+        {
+            "data": {
+                "difficulty": [
+                    1
+                ],
+                "aggregation_version": "4.1.0"
+            }
+        }
+    ]
+}
+
+
+reduced_data = {
+    "classes": [
+        "1",
+        "2"
+    ],
+    "confusion_simple": [
+        [
+            2,
+            0
+        ],
+        [
+            1,
+            0
+        ]
+    ],
+    "weighted_skill": {
+        "1": 0.999999999999999,
+        "2": 0.0
+    },
+    "skill": {
+        "1": 1.0,
+        "2": 0.0
+    },
+    "count": {
+        "1": 2,
+        "2": 1
+    },
+    "mean_skill": 0.999999999999999,
+    "level_up": True
+}
+
+TestSubclassUserSkillReducer = ReducerTest(
+    user_skill_reducer,
+    process,
+    extracted_data,
+    extracted_data,
+    reduced_data,
+    'Test user skill reducer with class subsetting',
+    network_kwargs=kwargs_extra_data,
+    kwargs={'mode': 'one-to-one', 'strategy': 'all', 'skill_threshold': 0.2, 'count_threshold': 1, 'focus_classes': ["1"]},
+    add_version=False,
+    processed_type='list',
+    test_name='TestUserSkillReducer_SubsetClass'
+)


### PR DESCRIPTION
**Context:** The current version of the user-skill calculation is done on ALL detected classes present within a task (either the mean skill or that skill for all classes be above a certain `skill_threshold`). This creates a situation where, for a task with large number of classes OR imbalanced datasets, the user has to see at least N images per class before they get a chance to even be considered for leveling up. 

**Motivation:** Research teams should be given the opportunity to provide specific classes using which they can judge the leveling up decision.

**This PR:** 

- The `user_skill_reducer` function now takes in `focus_classes` argument (`default: None`).
- The solution involved a conditional statement saying if `focus_classes` are provided (e.g., ['square', 'triangle']), then compute the `mean_skill`, `null_removed_classes`, and `null_removed_class_counts` on these subset classes (instead of everything).
- As such, the output still contains the entire confusion matrix (for all classes), but, the mean skill is computed on user-specified classes only.
- A refactoring on `lines 87-89` were done as this block of code is just repeated between `if binary... else: ...` statement, with the only difference being the `null_class='False'` in the binary case.

An example caeasar config looks as such: `.../reducers/user_skill_reducer?mode='one-to-one'&count_threshold=5&focus_classes=['1', '2']&strategy='all'&skill_threshold=0.2`