### PR TITLE
Feature/new default xi

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -21,7 +21,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 ENV LANG=C.UTF-8
 
 WORKDIR /usr/src/aggregation

--- a/Dockerfile.bin_cmds
+++ b/Dockerfile.bin_cmds
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 
 ENV LANG=C.UTF-8

--- a/panoptes_aggregation/reducers/optics_line_text_reducer.py
+++ b/panoptes_aggregation/reducers/optics_line_text_reducer.py
@@ -23,7 +23,7 @@ with warnings.catch_warnings():
 DEFAULTS = {
     'min_samples': {'default': 'auto', 'type': int},
     'max_eps': {'default': None, 'type': float},
-    'xi': {'default': 0.05, 'type': float},
+    'xi': {'default': 0.15, 'type': float},
     'angle_eps': {'default': 30.0, 'type': float},
     'gutter_eps': {'default': 300.0, 'type': float},
     'low_consensus_threshold': {'default': 3.0, 'type': float},

--- a/panoptes_aggregation/reducers/shape_reducer_optics.py
+++ b/panoptes_aggregation/reducers/shape_reducer_optics.py
@@ -23,6 +23,7 @@ DEFAULTS = {
     'min_samples': {'default': 3, 'type': int},
     'eps_t': {'default': 0.5, 'type': float},
     'min_cluster_size': {'default': 2, 'type': int},
+    'xi': {'default': 0.15, 'type': float},
     'algorithm': {'default': 'auto', 'type': str},
     'leaf_size': {'default': 30, 'type': int},
     'p': {'default': 2, 'type': float},

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -493,7 +493,7 @@ reduced_data = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.11,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -514,7 +514,7 @@ TestOpticsLTReducer = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
-        'xi': 0.11
+        'xi': 0.15
     },
     okwargs={
         'min_samples': 'auto'
@@ -539,7 +539,7 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
-        'xi': 0.11
+        'xi': 0.15
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -691,7 +691,7 @@ reduced_data_with_dollar_sign = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.05,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -761,7 +761,7 @@ reduced_data_no_length = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.05,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 300.0,
         'low_consensus_threshold': 3.0,

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -493,7 +493,6 @@ reduced_data = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -514,7 +513,6 @@ TestOpticsLTReducer = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
-        'xi': 0.15
     },
     okwargs={
         'min_samples': 'auto'
@@ -539,7 +537,6 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
-        'xi': 0.15
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -691,7 +688,6 @@ reduced_data_with_dollar_sign = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -761,7 +757,6 @@ reduced_data_no_length = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
-        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 300.0,
         'low_consensus_threshold': 3.0,

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -514,6 +514,7 @@ TestOpticsLTReducer = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
+        'xi': 0.15
     },
     okwargs={
         'min_samples': 'auto'
@@ -538,6 +539,7 @@ TestOpticsLTReducerWithMinSamples = ReducerTest(
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
         'minimum_views': 5,
+        'xi': 0.15
     },
     network_kwargs=kwargs_extra_data,
     output_kwargs=True,
@@ -709,7 +711,8 @@ TestOpticsLTReducerWithDollarSign = ReducerTest(
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
-        'minimum_views': 5
+        'minimum_views': 5,
+        'xi': 0.15
     },
     okwargs={'min_samples': 'auto'},
     network_kwargs=kwargs_extra_data_with_dollar_sign,
@@ -780,7 +783,8 @@ TestOpticsLTReducerNoLengthLine = ReducerTest(
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
-        'minimum_views': 5
+        'minimum_views': 5,
+        'xi': 0.15
     },
     network_kwargs=kwargs_extra_data_no_length,
     output_kwargs=True,

--- a/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
+++ b/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py
@@ -493,6 +493,7 @@ reduced_data = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -688,6 +689,7 @@ reduced_data_with_dollar_sign = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 150.0,
         'low_consensus_threshold': 3.0,
@@ -757,6 +759,7 @@ reduced_data_no_length = {
     'parameters': {
         'min_samples': 'auto',
         'max_eps': None,
+        'xi': 0.15,
         'angle_eps': 30.0,
         'gutter_eps': 300.0,
         'low_consensus_threshold': 3.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dynamic = ["version"]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.10,<3.12"
 dependencies = [
     "beautifulsoup4>=4.8.1,<4.13",
     "collatex>=2.3,<2.4",


### PR DESCRIPTION
Changed the default value of xi used in [sklearn's OPTIC algorithm](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/cluster/_optics.py) from 0.05 to 0.15. The value of xi approximately controls the size of the clusters, with a small xi leading to larger clusters and a larger xi leading to smaller clusters. While 0.05 is the standard value, as recommended in the [original OPTICS paper](https://dl.acm.org/doi/pdf/10.1145/304181.304187), this value can incorrectly include obvious outliers when the size of each cluster is very small, as often occurs in Zooniverse projects.

The value of 0.15 was chosen after tests with the real data from PRINT project found that obvious outliers (by visual inspection) where identified, while minimising the differences with the previous value of 0.05.

Note that this branch uses the updated OPTICS algorithm, where the `_predecessor_correction` function had a [bug fixed](https://github.com/scikit-learn/scikit-learn/commit/da220e4066f5df9da35447c2dba0409f7b59ce91#diff-608d5bfd333acf1f13bcb85dd6df2f3afd24b154e3d39acd9d2596b2ef79f343R819). This bug in fact inadvertently helped remove outliers, including in the [unit tests](https://github.com/zooniverse/aggregation-for-caesar/blob/master/panoptes_aggregation/tests/reducer_tests/test_optics_line_text_reducer.py) used here. This is how the problem with a too low xi value for the use case here was first identified.