### PR TITLE
Get rid of some Pandas warngins

### DIFF
--- a/panoptes_aggregation/scripts/config_workflow_panoptes.py
+++ b/panoptes_aggregation/scripts/config_workflow_panoptes.py
@@ -33,10 +33,10 @@ def config_workflow(
     with workflow_csv as workflow_csv_in:
         workflows = pandas.read_csv(workflow_csv_in, encoding='utf-8')
 
-    workflows['version_parse'] = np.array([
+    workflows = workflows.assign(version_parse=np.array([
         packaging.version.parse('{0}.{1}'.format(v, m))
         for v, m in zip(workflows.version, workflows.minor_version)
-    ])
+    ]))
 
     wdx = (workflows.workflow_id == workflow_id)
     if (version is None) and (min_version is None) and (max_version is None):


### PR DESCRIPTION
When running the compiled binary versions of the GUI there are some things that trigger Pandas 3.0 deprecation warnings.  I have no idea how to make these trigger in the base Python code, but the only one of these are triggered by our code.  This makes the message go away in the binary versions.

Note: the extractor and reducer can also trigger this warning in the binary versions, but in both cases it is the Pandas code itself that is triggering the warning message.  These messages will be cleaned up once Pandas 2.3.0 is released.