### PR TITLE
BatchAgg Edits: output files and destination

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -47,6 +47,8 @@ spec:
             # allow a longer response time than 1s
             timeoutSeconds: 10
           env:
+            - name: AGGREGATION_APP_ENV
+              value: production
             - name: FLASK_ENV
               value: production
             - name: PANOPTES_URL
@@ -182,6 +184,8 @@ spec:
             failureThreshold: 3
           args: ["/usr/src/aggregation/scripts/start-celery.sh"]
           env:
+            - name: AGGREGATION_APP_ENV
+              value: production
             - name: FLASK_ENV
               value: production
             - name: CELERY_BROKER_URL

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -47,6 +47,8 @@ spec:
             # allow a longer response time than 1s
             timeoutSeconds: 10
           env:
+            - name: AGGREGATION_APP_ENV
+              value: staging
             - name: FLASK_ENV
               value: production
             - name: CELERY_BROKER_URL
@@ -159,6 +161,8 @@ spec:
             failureThreshold: 3
           args: ["/usr/src/aggregation/scripts/start-celery.sh"]
           env:
+            - name: AGGREGATION_APP_ENV
+              value: staging
             - name: FLASK_ENV
               value: production
             - name: CELERY_BROKER_URL

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -69,7 +69,11 @@ def run_aggregation(project_id, workflow_id, user_id):
         for reducer in reduced_data.keys()
     ]
     combined_reduction_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_reductions.csv')
-    pd.concat(reduction_dfs).to_csv(combined_reduction_filepath, index=False)
+    if len(reduction_dfs) == 0:
+        with open(combined_reduction_filepath, 'w') as combined_reduction_file:
+            combined_reduction_file.write('No supported reducers were found.')
+    else:
+        pd.concat(reduction_dfs).to_csv(combined_reduction_filepath, index=False)
 
     # Upload zip & reduction files to blob storage
     print(f'[Batch Aggregation] Uploading results for {workflow_id})')

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -122,10 +122,10 @@ class BatchAggregator:
     def connect_blob_storage(self):
         connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
         self.blob_service_client = BlobServiceClient.from_connection_string(connect_str)
-        self.blob_service_client.create_container(name=self.id, public_access='container')
 
-    def upload_file_to_storage(self, container_name, filepath):
-        blob = filepath.split('/')[-1]
+    def upload_file_to_storage(self, subdirectory, filepath):
+        container_name = os.getenv('AGGREGATION_APP_ENV', 'production')
+        blob = os.path.join(subdirectory, filepath.split('/')[-1])
         blob_client = self.blob_service_client.get_blob_client(container=container_name, blob=blob)
         with open(file=filepath, mode="rb") as data:
             blob_client.upload_blob(data, overwrite=True)

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -12,6 +12,7 @@ from azure.storage.blob import BlobServiceClient
 from panoptes_client import Panoptes, Project, Workflow
 from panoptes_aggregation.workflow_config import workflow_extractor_config
 from panoptes_aggregation.scripts import batch_utils
+from panoptes_aggregation.csv_utils import flatten_data
 
 celery = Celery(__name__)
 celery.conf.broker_url = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
@@ -36,7 +37,7 @@ def run_aggregation(project_id, workflow_id, user_id):
     ba.process_wf_export(ba.wf_csv)
     cls_df = ba.process_cls_export(ba.cls_csv)
 
-    print(f'[Batch Aggregation] Extacting workflow {workflow_id})')
+    print(f'[Batch Aggregation] Extracting workflow {workflow_id})')
     extractor_config = workflow_extractor_config(ba.tasks)
     extracted_data = batch_utils.batch_extract(cls_df, extractor_config, hide_progressbar=True)
 
@@ -46,20 +47,29 @@ def run_aggregation(project_id, workflow_id, user_id):
     }
 
     print(f'[Batch Aggregation] Reducing workflow {workflow_id})')
-    for task_type, extract_df in extracted_data.items():
-        csv_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_{task_type}.csv')
-        extract_df.to_csv(csv_filepath)
-        reducer_list = batch_standard_reducers[task_type]
-        reduced_data = {}
+    reduced_data = {}
+    for extractor_type, extract_df in extracted_data.items():
+        extract_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_{extractor_type}.csv')
+        extract_df.to_csv(extract_filepath, index=False)
+        reducer_list = batch_standard_reducers[extractor_type]
 
         for reducer in reducer_list:
             # This is an override. The workflow_reducer_config method returns a config object
             # that is incompatible with the batch_utils batch_reduce method
             reducer_config = {'reducer_config': {reducer: {}}}
             reduced_data[reducer] = batch_utils.batch_reduce(extract_df, reducer_config, hide_progressbar=True)
-            # filename = f'{ba.output_path}/{ba.workflow_id}_reductions.csv'
-            filename = os.path.join(ba.output_path, f'{ba.workflow_id}_reductions.csv')
-            reduced_data[reducer].to_csv(filename, mode='a')
+            # Output full pre-reducer output files
+            reduction_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_{reducer}_reductions.csv')
+            reduced_data[reducer].to_csv(reduction_filepath, index=False)
+
+    # Merge and save combined reductions file
+    reduction_dfs = [
+        flatten_data(reduced_data[reducer]) if reducer != 'survey_reducer'
+        else reduced_data[reducer]
+        for reducer in reduced_data.keys()
+    ]
+    combined_reduction_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_reductions.csv')
+    pd.concat(reduction_dfs).to_csv(combined_reduction_filepath, index=False)
 
     # Upload zip & reduction files to blob storage
     print(f'[Batch Aggregation] Uploading results for {workflow_id})')

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -30,14 +30,14 @@ def run_aggregation(project_id, workflow_id, user_id):
 
     print(f'[Batch Aggregation] Run beginning for workflow {workflow_id} by user {user_id}')
 
-    print(f'[Batch Aggregation] Saving exports for workflow {workflow_id})')
+    print(f'[Batch Aggregation] Saving exports for workflow {workflow_id}')
     ba.save_exports()
 
-    print(f'[Batch Aggregation] Processing exports for workflow {workflow_id})')
+    print(f'[Batch Aggregation] Processing exports for workflow {workflow_id}')
     ba.process_wf_export(ba.wf_csv)
     cls_df = ba.process_cls_export(ba.cls_csv)
 
-    print(f'[Batch Aggregation] Extracting workflow {workflow_id})')
+    print(f'[Batch Aggregation] Extracting workflow {workflow_id}')
     extractor_config = workflow_extractor_config(ba.tasks)
     extracted_data = batch_utils.batch_extract(cls_df, extractor_config, hide_progressbar=True)
 
@@ -46,7 +46,7 @@ def run_aggregation(project_id, workflow_id, user_id):
         'survey_extractor': ['survey_reducer']
     }
 
-    print(f'[Batch Aggregation] Reducing workflow {workflow_id})')
+    print(f'[Batch Aggregation] Reducing workflow {workflow_id}')
     reduced_data = {}
     for extractor_type, extract_df in extracted_data.items():
         extract_filepath = os.path.join(ba.output_path, f'{ba.workflow_id}_{extractor_type}.csv')

--- a/panoptes_aggregation/batch_aggregation.py
+++ b/panoptes_aggregation/batch_aggregation.py
@@ -134,7 +134,7 @@ class BatchAggregator:
         self.connect_blob_storage()
         reductions_file = os.path.join(self.output_path, f'{self.workflow_id}_reductions.csv')
         self.upload_file_to_storage(self.id, reductions_file)
-        zippath = os.path.join('tmp', self.id)
+        zippath = os.path.join('tmp', f'{self.workflow_id}_aggregation')
         zipfile = make_archive(zippath, 'zip', self.output_path)
         self.upload_file_to_storage(self.id, zipfile)
 

--- a/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
+++ b/panoptes_aggregation/tests/batch_aggregation/test_batch_aggregation.py
@@ -2,6 +2,7 @@ try:
     from panoptes_aggregation.scripts import batch_utils
     from panoptes_aggregation.batch_aggregation import run_aggregation
     from panoptes_aggregation import batch_aggregation as batch_agg
+    import pandas as pd
 
     batch_agg.celery.conf.update(CELERY_BROKER_URL='memory://')
     batch_agg.celery.conf.update(CELERY_RESULT_BACKEND='cache+memory://')
@@ -40,6 +41,8 @@ class TestBatchAggregation(unittest.TestCase):
         batch_utils.batch_extract = MagicMock(return_value=test_extracts)
         mock_reducer = MagicMock()
         batch_utils.batch_reduce = mock_reducer
+        mock_combo_df = MagicMock()
+        pd.concat = mock_combo_df
 
         run_aggregation(1, 10, 100)
         mock_aggregator_instance.check_permission.assert_called_once()
@@ -107,7 +110,7 @@ class TestBatchAggregation(unittest.TestCase):
         ba = batch_agg.BatchAggregator(1, 10, 100)
         mock_client = MagicMock()
         ba.blob_service_client = MagicMock(return_value=mock_client)
-        ba.upload_file_to_storage('container', cls_export)
+        ba.upload_file_to_storage('asdf123asdf', cls_export)
         mock_client.upload_blob.assert_called_once
 
     @patch("panoptes_aggregation.batch_aggregation.Project")
@@ -168,9 +171,3 @@ class TestBatchAggregation(unittest.TestCase):
         ba.update_panoptes(body)
         mock_get.assert_called_with('/aggregations', params={'workflow_id': 10})
         mock_put.assert_not_called()
-
-    @patch("panoptes_aggregation.batch_aggregation.BlobServiceClient")
-    def test_connect_blob_storage(self, mock_client):
-        ba = batch_agg.BatchAggregator(1, 10, 100)
-        ba.connect_blob_storage()
-        ba.blob_service_client.create_container.assert_called_once_with(name=ba.id, public_access='container')


### PR DESCRIPTION
Revision of the Batch Aggregation feature with regard to output files and upload destinations

Changes:
1. Output files are created for individual extractors (e.g., 12862_question_extractor.csv) and reducers (`<workflow_ID>_<reducer_name>_reductions.csv`; e.g., 12862_question_reducer_reductions.csv), all of which are distributed in the full-directory ZIP file.
    - New: individual reduction files, drops index files from extract and reduction CSVs.
3. Two files available for download on blob storage
    1. `<workflow_ID>_reductions.csv` = a combined, mostly-flattened reductions output file
        - Output file now support workflows with multiple supported task types, uses pandas.concat() instead of file-based concatenation (which included a second header), and drops index from output CSV
        - `data` columns are flattened for ease of access, except for survey_reducer output (which includes many `data` fields due to follow-on questions).
    2. `<workflow_ID>_aggregation.zip` = ZIP of the full processing directory (classification and workflows exports, extracts CSVs, individual per-reducer reduction CSVs (unflattened), and the combined reductions CSV described above.
        - Changed file name to include workflow_id for better human readability and usefulness after download.
4. Shift from many-containers to two-container blob storage setup: use two ENV-based containers (`production` and `staging`) and store each aggregation output in a subdirectory/path using its UUID hash.
    - This change matches access patterns used elsewhere, and prevents too many containers from being created on storage account. There is no limit to the number of blobs or containers, but access via some apps (i.e., MS Azure Storage Explorer) are easier to navigate when using a small number of containers.
    - Example: new ZIP file location = `https://aggregationdata.blob.core.windows.net/production/<UUID_hash>/<workflow_id>_reductions.csv`
    - Fix Tests: remove `test_connect_blob_storage` now that new containers are no longer created.

Linked to: https://github.com/zooniverse/panoptes/pull/4475, https://github.com/zooniverse/panoptes-python-client/pull/328