### PR TITLE
Add pluck_and_split_extractor

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -1,4 +1,5 @@
 from .bezier_extractor import bezier_extractor
+from .pluck_and_split_extractor import pluck_and_split_extractor
 from .point_extractor import point_extractor
 from .polygon_extractor import polygon_extractor
 from .point_extractor_by_frame import point_extractor_by_frame
@@ -41,5 +42,6 @@ extractors = {
     'text_extractor': text_extractor,
     'all_tasks_empty_extractor': all_tasks_empty_extractor,
     'polygon_extractor': polygon_extractor,
-    'bezier_extractor': bezier_extractor
+    'bezier_extractor': bezier_extractor,
+    'pluck_and_split_extractor': pluck_and_split_extractor,
 }

--- a/panoptes_aggregation/extractors/pluck_and_split_extractor.py
+++ b/panoptes_aggregation/extractors/pluck_and_split_extractor.py
@@ -1,0 +1,39 @@
+"""
+Pluck and Split Extractor
+----------------
+This module provides a function to pluck a metadata field and also
+split it by a given character.
+"""
+
+import jsonpath
+
+from .extractor_wrapper import extractor_wrapper
+
+
+@extractor_wrapper()
+def pluck_and_split_extractor(classification, **kwargs):
+    """Pluck fields and split their values by a string.
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing an `annotations` key that is a list of
+        panoptes annotations, plus classification and subject metadata.
+
+    Returns
+    -------
+    extraction : dict
+        A dictionary containing a list of extracted values.
+    """
+
+    matching_values = set()
+
+    for f in jsonpath.findall(kwargs["path"], classification):
+        matching_values.update(f.split(kwargs.get("split_str", ",")))
+
+    matching_values = sorted(list(matching_values))
+    if len(matching_values) == 0:
+        return {}
+    if len(matching_values) == 1:
+        matching_values = matching_values[0]
+    return {"data": matching_values}

--- a/panoptes_aggregation/tests/extractor_tests/test_pluck_and_split_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_pluck_and_split_extractor.py
@@ -1,0 +1,46 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    "annotations": [],
+    "subject": {"metadata": {"one": "alpha,beta,gamma", "two": "red,green,blue"}},
+    "metadata": {"three": "a_b_c", "four": "1_2_3"},
+}
+
+expected_single = {"data": ["alpha", "beta", "gamma"]}
+expected_split_str = {"data": ["a", "b", "c"]}
+expected_multi = {"data": ["alpha", "beta", "blue", "gamma", "green", "red"]}
+
+TestPluckAndSplitSingle = ExtractorTest(
+    extractors.pluck_and_split_extractor,
+    classification,
+    expected_single,
+    "Test pluck_and_split extractor with single matching field",
+    kwargs={
+        "path": "$.subject.metadata.one",
+    },
+    test_name="TestPluckAndSplitSingle",
+)
+
+TestPluckAndSplitStr = ExtractorTest(
+    extractors.pluck_and_split_extractor,
+    classification,
+    expected_split_str,
+    "Test pluck_and_split extractor with different split str",
+    kwargs={
+        "path": "$.metadata.three",
+        "split_str": "_",
+    },
+    test_name="TestPluckAndSplitStr",
+)
+
+TestPluckAndSplitMulti = ExtractorTest(
+    extractors.pluck_and_split_extractor,
+    classification,
+    expected_multi,
+    "Test pluck_and_split extractor with multiple matches",
+    kwargs={
+        "path": "$.subject.metadata[*]",
+    },
+    test_name="TestPluckAndSplitMulti",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "shapely>=2.0,<2.1",
     "contourpy>=1.3.0,<1.4.0",
     "shapelysmooth>=0.2.0,<1.0",
+    "python-jsonpath (>=2.0.0,<3.0.0)",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This adds an equivalent of the built-in pluck field extractor which also splits the extracted string into a list. This functionality is required for the Chimp & See project, which wants to set up rules based on comma-separated values stored in the subject metadata.

I'm not 100% sure the returned dict is correct. It will currently just put all the results in a "data" key (`{"data": ["a", "b", "c"]}`) -- is that what Caesar will be expecting? 