### PR TITLE
Add NfN extractor condition and tests for October, 2025 WeDigBio event

### DIFF
--- a/panoptes_aggregation/extractors/nfn_extractor.py
+++ b/panoptes_aggregation/extractors/nfn_extractor.py
@@ -109,6 +109,8 @@ def we_dig_bio(parser):
         return 2024
     elif (date.year == 2025) and (date.month == 4) and (10 <= date.day <= 13):
         return 2025
+    elif (date.year == 2025) and (date.month == 10) and (9 <= date.day <= 12):
+        return 2025
     else:
         return None
 

--- a/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_nfn_extractor.py
@@ -168,7 +168,7 @@ TestNfNWeDigBioApril2025 = ExtractorTest(
     test_name='TestNfNWeDigBioApril2025'
 )
 
-classification_we_dig_bio_october_2024 = {
+classification_we_dig_bio_october_2025 = {
     "annotations": [{
         "task": "T99",
         "value": [
@@ -191,24 +191,24 @@ classification_we_dig_bio_october_2024 = {
             "country": "United States",
         }
     },
-    "created_at": "2024-10-12T05:30:00.000Z",
+    "created_at": "2025-10-10T05:30:00.000Z",
 }
 
-expected_we_dig_bio_october_2024 = {
+expected_we_dig_bio_october_2025 = {
     "workflow": "herbarium",
     "decade": "00s",
     "time": "lunchbreak",
-    "we_dig_bio": 2024,
+    "we_dig_bio": 2025,
     "country": "United States"
 }
 
-TestNfNWeDigBioOctober2024 = ExtractorTest(
+TestNfNWeDigBioOctober2025 = ExtractorTest(
     extractors.nfn_extractor,
-    classification_we_dig_bio_october_2024,
-    expected_we_dig_bio_october_2024,
-    'Test NfN during October, 2024, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
+    classification_we_dig_bio_october_2025,
+    expected_we_dig_bio_october_2025,
+    'Test NfN during October, 2025, WeDigBio event with year as nested task and country from metadata at lunchtime local time',
     kwargs={'year': 'T11', 'workflow': 'herbarium', 'country': 'metadata'},
-    test_name='TestNfNWeDigBioOctober2024'
+    test_name='TestNfNWeDigBioOctober2025'
 )
 
 classification_not_we_dig_bio_2025 = {


### PR DESCRIPTION
Related to https://github.com/zooniverse/notes-from-nature-field-book/pull/321.
Similar to https://github.com/zooniverse/aggregation-for-caesar/pull/816.

Background:
The Notes From Nature Field Book (https://field-book.notesfromnature.org/, frontend repo - https://github.com/zooniverse/notes-from-nature-field-book) awards badges to volunteers for classifying based on various criteria, including classification creation time. There will be special [WeDigBio events October 9-12, 2025](https://blog.notesfromnature.org/) that a special badge is earned for participating in.

Purpose:
In nfn_extractor, this PR refactors we_dig_bio to:
- return `2025` if a classification is created between (and including) October 9-12, 2025