### PR TITLE
Add survey_whitelist_extractor

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -6,6 +6,7 @@ from .point_extractor_by_frame import point_extractor_by_frame
 from .rectangle_extractor import rectangle_extractor
 from .question_extractor import question_extractor
 from .survey_extractor import survey_extractor
+from .survey_whitelist_extractor import survey_whitelist_extractor
 from .poly_line_text_extractor import poly_line_text_extractor
 from .line_text_extractor import line_text_extractor
 from .sw_extractor import sw_extractor
@@ -29,6 +30,7 @@ extractors = {
     'question_extractor': question_extractor,
     'shortcut_extractor': shortcut_extractor,
     'survey_extractor': survey_extractor,
+    'survey_whitelist_extractor': survey_whitelist_extractor,
     'poly_line_text_extractor': poly_line_text_extractor,
     'line_text_extractor': line_text_extractor,
     'sw_extractor': sw_extractor,

--- a/panoptes_aggregation/extractors/survey_whitelist_extractor.py
+++ b/panoptes_aggregation/extractors/survey_whitelist_extractor.py
@@ -9,6 +9,7 @@ subject metadata.
 from .survey_extractor import survey_extractor
 from .pluck_and_split_extractor import pluck_and_split_extractor
 from .extractor_wrapper import extractor_wrapper
+from slugify import slugify
 
 
 @extractor_wrapper()
@@ -39,8 +40,14 @@ def survey_whitelist_extractor(classification, **kwargs):
     >>> survey_extractor(classification)
     [{'choice': 'agouti','answers_howmany': {'1': 1}, 'in_whitelist': true}]
     """
-    whitelist = pluck_and_split_extractor(classification, **kwargs).get("data", [])
-    survey = survey_extractor(classification, **kwargs)
+    # We are already inside extractor_wrapper here, so annotations have been
+    # normalized to a plain list. Call the underlying extractor functions
+    # directly to avoid re-wrapping that normalized payload.
+    whitelist = pluck_and_split_extractor._original(classification, **kwargs).get("data", [])
+    if isinstance(whitelist, str):
+        whitelist = [whitelist]
+    whitelist = {slugify(choice.strip(), separator="-") for choice in whitelist}
+    survey = survey_extractor._original(classification, **kwargs)
 
     for extract in survey:
         extract["in_whitelist"] = extract.get("choice") in whitelist

--- a/panoptes_aggregation/extractors/survey_whitelist_extractor.py
+++ b/panoptes_aggregation/extractors/survey_whitelist_extractor.py
@@ -1,0 +1,48 @@
+"""
+Survey Whitelist Extractor
+----------------
+This module provides a function to extract choices and sub-questions from
+panoptes survey tasks, and match those choices against a whitelist in the
+subject metadata.
+"""
+
+from .survey_extractor import survey_extractor
+from .pluck_and_split_extractor import pluck_and_split_extractor
+from .extractor_wrapper import extractor_wrapper
+
+
+@extractor_wrapper()
+def survey_whitelist_extractor(classification, **kwargs):
+    """Extract annotations from a survey task into a list, matching choices
+    against a list plucked from the subject data.
+
+    Parameters
+    ----------
+    classification : dict
+        A dictionary containing an `annotations` key that is a list of
+        panoptes annotations
+
+    Returns
+    -------
+    extraction : list
+        A list of dicts each with `choice`, `answers`, and `in_whitelist`
+        as keys.  Each `choice` made in an annotation is extacted to a
+        different element of the list.
+
+    Examples
+    --------
+    >>> classification = {'annotations': [
+            {'value':
+                [{'choice': 'AGOUTI', 'answers': {'HOWMANY': '1'}}]
+            }
+        ]}
+    >>> survey_extractor(classification)
+    [{'choice': 'agouti','answers_howmany': {'1': 1}, 'in_whitelist': true}]
+    """
+    whitelist = pluck_and_split_extractor(classification, **kwargs).get("data", [])
+    survey = survey_extractor(classification, **kwargs)
+
+    for extract in survey:
+        extract["in_whitelist"] = extract.get("choice") in whitelist
+
+    return survey

--- a/panoptes_aggregation/tests/extractor_tests/test_survey_whitelist_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_survey_whitelist_extractor.py
@@ -39,5 +39,7 @@ TestSurveyWhitelist = ExtractorTest(
     blank_extract=[],
     test_type="assertCountEqual",
     test_name="TestSurveyWhitelist",
-    path="$.metadata.species_whitelist",
+    kwargs={
+        "path": "$.metadata.species_whitelist",
+    },
 )

--- a/panoptes_aggregation/tests/extractor_tests/test_survey_whitelist_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_survey_whitelist_extractor.py
@@ -1,0 +1,43 @@
+from panoptes_aggregation import extractors
+from .base_test_class import ExtractorTest
+
+classification = {
+    "annotations": [
+        {
+            "task": "T0",
+            "value": [
+                {"choice": "AGOUTI", "answers": {"HOWMANY": "1"}, "filters": {}},
+                {
+                    "choice": "PECCARYCOLLARED",
+                    "answers": {"HOWMANY": "3", "WHATDOING": ["standing", "sleeping"]},
+                    "filters": {},
+                },
+                {"choice": "NOTHINGHERE", "answers": {}, "filters": {}},
+            ],
+        }
+    ],
+    "metadata": {"species_whitelist": "AGOUTI, PECCARYCOLLARED"},
+}
+
+expected = [
+    {"choice": "agouti", "answers_howmany": {"1": 1}, "in_whitelist": True},
+    {
+        "choice": "peccarycollared",
+        "answers_howmany": {"3": 1},
+        "answers_whatdoing": {"standing": 1, "sleeping": 1},
+        "in_whitelist": True,
+    },
+    {"choice": "nothinghere", "in_whitelist": False},
+]
+
+
+TestSurveyWhitelist = ExtractorTest(
+    extractors.survey_whitelist_extractor,
+    classification,
+    expected,
+    "Test survey whitelist",
+    blank_extract=[],
+    test_type="assertCountEqual",
+    test_name="TestSurveyWhitelist",
+    path="$.metadata.species_whitelist",
+)


### PR DESCRIPTION
@CKrawczyk This is to handle what I was asking you about the other day. If there is a subject metadata field with a list of strings, I want to be about to count how many survey classifications contain one of those strings. I decided the simplest thing to do is to add a new extractor that does that in one step rather than doing it with two extractors and then trying to reduce the two extracts.

I haven't tested this yet. I've just outlined roughly how I think it should work. Before I test it fully, I wondered if you could have a quick look and let me know if this seems like a sensible way to do it?