### PR TITLE
Remove ingress from deploy template

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -314,30 +314,3 @@ spec:
       port: 6379
       targetPort: 6379
   type: NodePort
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: aggregation-staging-ingress
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-    nginx.ingress.kubernetes.io/proxy-body-size: 20m
-    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
-spec:
-  tls:
-  - hosts:
-    - aggregation-staging.zooniverse.org
-    secretName: aggregation-staging-tls-secret
-  rules:
-  - host: aggregation-staging.zooniverse.org
-    http:
-      paths:
-      - pathType: Prefix
-        path: /
-        backend:
-          service:
-            name: aggregation-staging-app
-            port:
-              number: 80


### PR DESCRIPTION
Ingresses for this app, both staging and production, have been folded into the updated *.zooniverse.org IngressRoute over on the static repo. 