### PR TITLE
Shape Extractor: add param to adopt v1 key format

### DIFF
--- a/panoptes_aggregation/extractors/shape_extractor.py
+++ b/panoptes_aggregation/extractors/shape_extractor.py
@@ -13,7 +13,7 @@ from ..shape_tools import SHAPE_LUT
 @extractor_wrapper()
 @tool_wrapper
 @subtask_wrapper
-def shape_extractor(classification, **kwargs):
+def shape_extractor(classification, use_v1_keys=False, **kwargs):
     '''Extract shape data from annotations
 
     Parameters
@@ -24,6 +24,10 @@ def shape_extractor(classification, **kwargs):
     shape: str, keyword, required
         A string indicating what shape the annotation contains. This
         should be the name of one of the pre-defined shape tools.
+    use_v1_keys: boolean, keyword, optional
+        A boolean that, when true, adopts classifier v1 `toolN` keys
+        instead of the default classifier v2 `toolIndexN` keys for 
+        classifier v2 annotations.
 
     Returns
     -------
@@ -50,7 +54,10 @@ def shape_extractor(classification, **kwargs):
             elif 'toolIndex' in value:
                 # classifier v2.0
                 tool_index = value['toolIndex']
-                key = '{0}_toolIndex{1}'.format(task_key, tool_index)
+                if use_v1_keys:
+                    key = '{0}_tool{1}'.format(task_key, tool_index)
+                else:
+                    key = '{0}_toolIndex{1}'.format(task_key, tool_index)
             else:
                 raise KeyError('Neither `tool` or `toolIndex` are in the annotation')
 

--- a/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_point.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_shape_extractor_point.py
@@ -102,3 +102,50 @@ TestShapePointOneTool = ExtractorTest(
     },
     test_name='TestShapePointOneTool'
 )
+
+classification_v2 = {
+    'annotations': [{
+        'task': 'T0',
+        'taskType': 'drawing',
+        'value': [{
+            'frame': 0,
+            'toolIndex': 0,
+            'toolType': 'point',
+            'x': 452.1,
+            'y': 202.8,
+            'details': []
+        }]
+    }]
+}
+
+expected_v2 = {
+    'frame0': {
+        'T0_toolIndex0_x': [452.1],
+        'T0_toolIndex0_y': [202.8]
+    }
+}
+
+TestShapePointV2 = ExtractorTest(
+    extractors.shape_extractor,
+    classification_v2,
+    expected_v2,
+    'Test shape point, v2 annotation',
+    kwargs={'shape': 'point'},
+    test_name='TestShapePointV2'
+)
+
+expected_v2_v1keys = {
+    'frame0': {
+        'T0_tool0_x': [452.1],
+        'T0_tool0_y': [202.8]
+    }
+}
+
+TestShapePointV2V1Keys = ExtractorTest(
+    extractors.shape_extractor,
+    classification_v2,
+    expected_v2_v1keys,
+    'Test shape point, v2 annotation, output v1 keys',
+    kwargs={'shape': 'point', 'use_v1_keys': True},
+    test_name='TestShapePointV2V1Keys'
+)


### PR DESCRIPTION
**Existing Challenge:** Since #301, the shape extractor will produce outputs with different keys for classifier v2.0 annotations (from FEM workflows) compared to classifier v1.0 annotations (from PFE workflows). E.g., `T0_toolIndex0_x` for v2 annotations compared to `T0_tool0_x` for v1 annotations. This v1-to-v2 change can be challenging or unwanted if workflows are trying to reduce v1 and v2 annotations together, or if a downstream use case requires the v1 key names (i.e., for Zoo Notes).

**Proposed Solution:** Add a keyword parameter, `use_v1_keys`, to the shape extractor that overrides default behavior for v2 annotations and adopts the v1 key names.

**Specific Outcome:** Zoo Notes will display extracted and reduced point results for the 
[Science Scribbler: Virus Factory - In Schools!](https://www.zooniverse.org/projects/helenacotterill/science-scribbler-virus-factory-in-schools) project.

Example Workflow: [31226](https://www.zooniverse.org/projects/helenacotterill/science-scribbler-virus-factory-in-schools/classify/workflow/31226)
Example Subject: https://zoo-notes.zooniverse.org/view/workflow/31226/subject/50156079