### PR TITLE
Replace survey_whitelist_extractor with whitelist_count_extractor

### DIFF
--- a/panoptes_aggregation/extractors/__init__.py
+++ b/panoptes_aggregation/extractors/__init__.py
@@ -6,7 +6,7 @@ from .point_extractor_by_frame import point_extractor_by_frame
 from .rectangle_extractor import rectangle_extractor
 from .question_extractor import question_extractor
 from .survey_extractor import survey_extractor
-from .survey_whitelist_extractor import survey_whitelist_extractor
+from .whitelist_count_extractor import whitelist_count_extractor
 from .poly_line_text_extractor import poly_line_text_extractor
 from .line_text_extractor import line_text_extractor
 from .sw_extractor import sw_extractor
@@ -30,7 +30,7 @@ extractors = {
     'question_extractor': question_extractor,
     'shortcut_extractor': shortcut_extractor,
     'survey_extractor': survey_extractor,
-    'survey_whitelist_extractor': survey_whitelist_extractor,
+    'whitelist_count_extractor': whitelist_count_extractor,
     'poly_line_text_extractor': poly_line_text_extractor,
     'line_text_extractor': line_text_extractor,
     'sw_extractor': sw_extractor,

--- a/panoptes_aggregation/extractors/whitelist_count_extractor.py
+++ b/panoptes_aggregation/extractors/whitelist_count_extractor.py
@@ -6,16 +6,14 @@ panoptes survey tasks, and match those choices against a whitelist in the
 subject metadata.
 """
 
-from .survey_extractor import survey_extractor
 from .pluck_and_split_extractor import pluck_and_split_extractor
 from .extractor_wrapper import extractor_wrapper
 from slugify import slugify
 
 
 @extractor_wrapper()
-def survey_whitelist_extractor(classification, **kwargs):
-    """Extract annotations from a survey task into a list, matching choices
-    against a list plucked from the subject data.
+def whitelist_count_extractor(classification, **kwargs):
+    """Extract whether survey choices match a subject metadata whitelist.
 
     Parameters
     ----------
@@ -25,10 +23,11 @@ def survey_whitelist_extractor(classification, **kwargs):
 
     Returns
     -------
-    extraction : list
-        A list of dicts each with `choice`, `answers`, and `in_whitelist`
-        as keys.  Each `choice` made in an annotation is extacted to a
-        different element of the list.
+    extraction : dict
+        A dict shaped like a question extraction, suitable for reduction with
+        the question reducer. If any selected survey choice is in the
+        whitelist, the dict contains ``in_whitelist``. If any selected survey
+        choice is not in the whitelist, the dict contains ``not_in_whitelist``.
 
     Examples
     --------
@@ -37,8 +36,8 @@ def survey_whitelist_extractor(classification, **kwargs):
                 [{'choice': 'AGOUTI', 'answers': {'HOWMANY': '1'}}]
             }
         ]}
-    >>> survey_extractor(classification)
-    [{'choice': 'agouti','answers_howmany': {'1': 1}, 'in_whitelist': true}]
+    >>> whitelist_count_extractor(classification)
+    {'in_whitelist': 1}
     """
     # We are already inside extractor_wrapper here, so annotations have been
     # normalized to a plain list. Call the underlying extractor functions
@@ -47,9 +46,15 @@ def survey_whitelist_extractor(classification, **kwargs):
     if isinstance(whitelist, str):
         whitelist = [whitelist]
     whitelist = {slugify(choice.strip(), separator="-") for choice in whitelist}
-    survey = survey_extractor._original(classification, **kwargs)
 
-    for extract in survey:
-        extract["in_whitelist"] = extract.get("choice") in whitelist
+    extraction = {}
+    if len(classification["annotations"]) > 0:
+        annotation = classification["annotations"][0]
+        for value in annotation["value"]:
+            choice = slugify(value["choice"], separator="-")
+            if choice in whitelist:
+                extraction["in_whitelist"] = 1
+            else:
+                extraction["not_in_whitelist"] = 1
 
-    return survey
+    return extraction

--- a/panoptes_aggregation/tests/extractor_tests/test_whitelist_count_extractor.py
+++ b/panoptes_aggregation/tests/extractor_tests/test_whitelist_count_extractor.py
@@ -19,26 +19,16 @@ classification = {
     "metadata": {"species_whitelist": "AGOUTI, PECCARYCOLLARED"},
 }
 
-expected = [
-    {"choice": "agouti", "answers_howmany": {"1": 1}, "in_whitelist": True},
-    {
-        "choice": "peccarycollared",
-        "answers_howmany": {"3": 1},
-        "answers_whatdoing": {"standing": 1, "sleeping": 1},
-        "in_whitelist": True,
-    },
-    {"choice": "nothinghere", "in_whitelist": False},
-]
+expected = {"in_whitelist": 1, "not_in_whitelist": 1}
 
 
-TestSurveyWhitelist = ExtractorTest(
-    extractors.survey_whitelist_extractor,
+TestWhitelistCount = ExtractorTest(
+    extractors.whitelist_count_extractor,
     classification,
     expected,
-    "Test survey whitelist",
-    blank_extract=[],
-    test_type="assertCountEqual",
-    test_name="TestSurveyWhitelist",
+    "Test whitelist count",
+    blank_extract={},
+    test_name="TestWhitelistCount",
     kwargs={
         "path": "$.metadata.species_whitelist",
     },


### PR DESCRIPTION
This simplifies the new extractor to just count how many annotations match the whitelist or not. This should be a simpler way to do what I need that should hopefully also work with Caesar. To be tested in staging.